### PR TITLE
fix regex & use set in uid

### DIFF
--- a/lib/pages/danmaku/controller.dart
+++ b/lib/pages/danmaku/controller.dart
@@ -69,7 +69,7 @@ class PlDanmakuController {
       queryDanmaku(segmentIndex);
     }
     if (plPlayerController.danmakuWeight == 0 &&
-        plPlayerController.danmakuFilterRule.isEmpty) {
+        plPlayerController.filterCount == 0) {
       return dmSegMap[progress ~/ 100];
     } else {
       return dmSegMap[progress ~/ 100]
@@ -81,29 +81,8 @@ class PlDanmakuController {
   }
 
   bool filterDanmaku(DanmakuElem elem) {
-    if (plPlayerController.dmRegExp?.hasMatch(elem.content) == true) {
-      return false;
-    }
-    for (var filter in plPlayerController.danmakuFilterRule) {
-      switch (filter['type']) {
-        case 0:
-          if (elem.content.contains(filter['filter'])) {
-            return false;
-          }
-          break;
-        // case 1:
-        //   if (RegExp(filter['filter'], caseSensitive: false)
-        //       .hasMatch(elem.content)) {
-        //     return false;
-        //   }
-        //   break;
-        case 2:
-          if (elem.idStr == filter['filter']) {
-            return false;
-          }
-          break;
-      }
-    }
-    return true;
+    return !(plPlayerController.dmUid.contains(elem.content) ||
+             plPlayerController.dmFilterString.any((i) => elem.content.contains(i)) ||
+             plPlayerController.dmRegExp?.hasMatch(elem.content) == true);
   }
 }

--- a/lib/pages/danmaku/controller.dart
+++ b/lib/pages/danmaku/controller.dart
@@ -83,6 +83,6 @@ class PlDanmakuController {
   bool filterDanmaku(DanmakuElem elem) {
     return !(plPlayerController.dmUid.contains(elem.content) ||
              plPlayerController.dmFilterString.any((i) => elem.content.contains(i)) ||
-             plPlayerController.dmRegExp?.hasMatch(elem.content) == true);
+             plPlayerController.dmRegExp.any((i) => i.hasMatch(elem.content)));
   }
 }

--- a/lib/pages/danmaku_block/index.dart
+++ b/lib/pages/danmaku_block/index.dart
@@ -53,16 +53,23 @@ class _DanmakuBlockPageState extends State<DanmakuBlockPage> {
     }).toList();
     // debugPrint("simpleRuleList:$simpleRuleList");
     List regex = [];
-    plPlayerController.danmakuFilterRule = simpleRuleList.where((item) {
-      if (item['type'] != 1) {
-        return true;
-      } else {
-        regex.add(item['filter']);
-        return false;
+    plPlayerController.filterCount = simpleRuleList.length;
+    simpleRuleList.forEach((item) {
+      switch (item['type']) {
+        case 0:
+          plPlayerController.dmFilterString.add(item['filter']);
+          break;
+        case 1:
+          regex.add(item['filter']);
+          break;
+        case 2:
+          plPlayerController.dmUid.add(item['filter']);
+          break;
       }
-    }).toList();
+    });
     plPlayerController.dmRegExp =
         regex.isNotEmpty ? RegExp(regex.join('|'), caseSensitive: false) : null;
+    debugPrint(plPlayerController.dmRegExp?.pattern);
     scrollController.dispose();
     GStorage.localCache.put(LocalCacheKey.danmakuFilterRule, simpleRuleList);
     super.dispose();

--- a/lib/pages/danmaku_block/index.dart
+++ b/lib/pages/danmaku_block/index.dart
@@ -52,7 +52,6 @@ class _DanmakuBlockPageState extends State<DanmakuBlockPage> {
       return e.toMap();
     }).toList();
     // debugPrint("simpleRuleList:$simpleRuleList");
-    List regex = [];
     plPlayerController.filterCount = simpleRuleList.length;
     simpleRuleList.forEach((item) {
       switch (item['type']) {
@@ -60,16 +59,13 @@ class _DanmakuBlockPageState extends State<DanmakuBlockPage> {
           plPlayerController.dmFilterString.add(item['filter']);
           break;
         case 1:
-          regex.add(item['filter']);
+          plPlayerController.dmRegExp.add(RegExp(item['filter'], caseSensitive: false));
           break;
         case 2:
           plPlayerController.dmUid.add(item['filter']);
           break;
       }
     });
-    plPlayerController.dmRegExp =
-        regex.isNotEmpty ? RegExp(regex.join('|'), caseSensitive: false) : null;
-    debugPrint(plPlayerController.dmRegExp?.pattern);
     scrollController.dispose();
     GStorage.localCache.put(LocalCacheKey.danmakuFilterRule, simpleRuleList);
     super.dispose();

--- a/lib/pages/video/detail/widgets/header_control.dart
+++ b/lib/pages/video/detail/widgets/header_control.dart
@@ -1150,7 +1150,7 @@ class _HeaderControlState extends State<HeaderControl> {
                                   arguments: widget.controller)
                             },
                         child: Text(
-                            "屏蔽管理(${widget.controller.danmakuFilterRule.length + (widget.controller.dmRegExp?.pattern.split('|').length ?? 0)})")),
+                            "屏蔽管理(${widget.controller.filterCount})")),
                   ],
                 ),
                 Padding(

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -256,8 +256,10 @@ class PlPlayerController {
 
   /// 弹幕权重
   int danmakuWeight = 0;
-  List danmakuFilterRule = [];
+  int filterCount = 0;
+  List dmFilterString = [];
   RegExp? dmRegExp;
+  Set dmUid = {};
   // 关联弹幕控制器
   DanmakuController? danmakuController;
   bool showDanmaku = true;
@@ -396,16 +398,23 @@ class PlPlayerController {
     List regex = [];
     List rules = GStorage.localCache
         .get(LocalCacheKey.danmakuFilterRule, defaultValue: []);
-    danmakuFilterRule = rules.where((item) {
-      if (item['type'] != 1) {
-        return true;
-      } else {
-        regex.add(item['filter']);
-        return false;
+    filterCount = rules.length;
+    rules.forEach((item) {
+      switch (item['type']) {
+        case 0:
+          dmFilterString.add(item['filter']);
+          break;
+        case 1:
+          regex.add(item['filter']);
+          break;
+        case 2:
+          dmUid.add(item['filter']);
+          break;
       }
-    }).toList();
+    });
     dmRegExp =
         regex.isNotEmpty ? RegExp(regex.join('|'), caseSensitive: false) : null;
+    debugPrint(dmRegExp?.pattern);
     blockTypes = setting.get(SettingBoxKey.danmakuBlockType, defaultValue: []);
     showArea = setting.get(SettingBoxKey.danmakuShowArea, defaultValue: 0.5);
     // 不透明度

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -258,7 +258,7 @@ class PlPlayerController {
   int danmakuWeight = 0;
   int filterCount = 0;
   List dmFilterString = [];
-  RegExp? dmRegExp;
+  List<RegExp> dmRegExp = [];
   Set dmUid = {};
   // 关联弹幕控制器
   DanmakuController? danmakuController;
@@ -405,16 +405,13 @@ class PlPlayerController {
           dmFilterString.add(item['filter']);
           break;
         case 1:
-          regex.add(item['filter']);
+          dmRegExp.add(RegExp(item['filter'], caseSensitive: false));
           break;
         case 2:
           dmUid.add(item['filter']);
           break;
       }
     });
-    dmRegExp =
-        regex.isNotEmpty ? RegExp(regex.join('|'), caseSensitive: false) : null;
-    debugPrint(dmRegExp?.pattern);
     blockTypes = setting.get(SettingBoxKey.danmakuBlockType, defaultValue: []);
     showArea = setting.get(SettingBoxKey.danmakuShowArea, defaultValue: 0.5);
     // 不透明度


### PR DESCRIPTION
- 直接统计`|`的个数会错误的把正则本身里的`|`统计
- 对于正则表达式`(test|example)`与`(.)\1{10,}`, 直接用`|`连接会使表达式匹配 __所有的__ 弹幕(本来是想改成使用命名组的, 结果发现b站的正则库不知道是多早以前的, 命名组不支持, 甚至连非捕获组都不支持)