### PR TITLE
fix #624

### DIFF
--- a/lib/utils/accounts/account_manager/account_mgr.dart
+++ b/lib/utils/accounts/account_manager/account_mgr.dart
@@ -123,11 +123,6 @@ class AccountManager extends Interceptor {
       }
       return handler.next(options);
     } else {
-      if (account is AnonymousAccount) {
-        options.headers[HttpHeaders.cookieHeader] = '';
-        handler.next(options);
-        return;
-      }
       account.cookieJar.loadForRequest(options.uri).then((cookies) {
         final previousCookies =
             options.headers[HttpHeaders.cookieHeader] as String?;


### PR DESCRIPTION
`AnonymousAccount`在app退出后会丢失cookie信息, 相当于浏览器的隐身模式, 如果需要清空cookie应使用`AnonymousAccount().delete()`