### PR TITLE
Adapt to 16:10 tablet

### DIFF
--- a/lib/pages/live_room/view.dart
+++ b/lib/pages/live_room/view.dart
@@ -463,7 +463,7 @@ class _LiveRoomPageState extends State<LiveRoomPage>
 
   Widget get _buildBodyH {
     double videoWidth =
-        clampDouble(context.height / context.width * 1.04, 0.58, 0.75) *
+        clampDouble(context.height / context.width * 1.08, 0.58, 0.75) *
             context.width;
     return Expanded(
       child: Row(

--- a/lib/pages/video/detail/view_v.dart
+++ b/lib/pages/video/detail/view_v.dart
@@ -1221,7 +1221,7 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
             );
           }
           double videoWidth =
-              clampDouble(context.height / context.width * 1.04, 0.5, 0.7) *
+              clampDouble(context.height / context.width * 1.08, 0.5, 0.7) *
                   context.width;
           if (context.width >= 560) {
             videoWidth = min(videoWidth, context.width - 280);


### PR DESCRIPTION
在16:10平板设备上，如Galaxy Tab A7(10.4)，左侧的视频太小了，尤其是遇到4:3等不规则视频，通过微调使其接近正常大小。
3:2和4:3比例平板一般取最大值0.7，与原来几乎没区别，不受影响。调整后更接近官方HD。

调整前：
![Screenshot_20250410-235526](https://github.com/user-attachments/assets/ef28b1f0-ede5-415d-a466-11ee18748614)

调整后：
![Screenshot_20250410-235951](https://github.com/user-attachments/assets/db0e958a-86a4-4ce2-bb18-2b6010e085af)

与HD对比：
![Screenshot_20250410-120104_HD](https://github.com/user-attachments/assets/001bb583-7e7c-49c3-860c-d0c233ac481a)

