### PR TITLE
fix: resolve fullscreen UI offset issue on some Android tablets

### DIFF
--- a/lib/pages/video/view.dart
+++ b/lib/pages/video/view.dart
@@ -498,7 +498,7 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
       child: Scaffold(
         resizeToAvoidBottomInset: false,
         key: videoDetailController.scaffoldKey,
-        appBar: removeSafeArea
+        appBar: (removeSafeArea || isFullScreen)
             ? null
             : PreferredSize(
                 preferredSize: const Size.fromHeight(0),
@@ -1122,7 +1122,7 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
           Scaffold(
             resizeToAvoidBottomInset: false,
             key: videoDetailController.scaffoldKey,
-            appBar: removeSafeArea
+            appBar: (removeSafeArea || isFullScreen)
                 ? null
                 : AppBar(
                     backgroundColor: Colors.black,
@@ -1131,7 +1131,7 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
             body: SafeArea(
               left: !removeSafeArea && !isFullScreen,
               right: !removeSafeArea && !isFullScreen,
-              top: !removeSafeArea,
+              top: !removeSafeArea && !isFullScreen,
               bottom: false,
               child: childWhenDisabledLandscapeInner,
             ),
@@ -1142,7 +1142,7 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
   Widget get childWhenDisabledAlmostSquare => Scaffold(
         resizeToAvoidBottomInset: false,
         key: videoDetailController.scaffoldKey,
-        appBar: removeSafeArea
+        appBar: (removeSafeArea || isFullScreen)
             ? null
             : AppBar(
                 backgroundColor: Colors.black,
@@ -1151,7 +1151,7 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
         body: SafeArea(
           left: !removeSafeArea && !isFullScreen,
           right: !removeSafeArea && !isFullScreen,
-          top: !removeSafeArea,
+          top: !removeSafeArea && !isFullScreen,
           bottom: false,
           child: childWhenDisabledAlmostSquareInner,
         ),


### PR DESCRIPTION
Fixed the issue where the video player interface would shift downward when entering fullscreen mode.

This bug occurs on two Lenovo tablets with resolutions of 2560x1600 and 3040x1904 respectively (I don't have other test devices). During fullscreen playback, a blank area appears at the top of the screen where neither danmaku nor video content is displayed (causing the video area to be off-center). When the playback menu is invoked, some buttons below the bottom progress bar overflow off the screen and become unclickable.

This commit fixes the above issues. Danmaku and video content can now enter the previously blank area, and the bottom progress bar and its buttons are positioned correctly. However, when the playback menu is invoked, the top bar position is still slightly lower than expected. Since it's transparent and doesn't affect operation, this can be left unaddressed for now.

The following figure shows the comparison before and after the bug fix.

![Fix preview](https://github.com/user-attachments/assets/1834c538-da66-4277-a635-ed5cc0cf891b)


