### PR TITLE
Move a setting from “Other settings” to “Player settings”

### DIFF
--- a/lib/pages/setting/models/extra_settings.dart
+++ b/lib/pages/setting/models/extra_settings.dart
@@ -705,13 +705,6 @@ List<SettingsModel> get extraSettings => [
   ),
   SettingsModel(
     settingsType: SettingsType.sw1tch,
-    title: '全屏展示点赞/投币/收藏等操作按钮',
-    leading: const Icon(MdiIcons.dotsHorizontalCircleOutline),
-    setKey: SettingBoxKey.showFSActionItem,
-    defaultVal: true,
-  ),
-  SettingsModel(
-    settingsType: SettingsType.sw1tch,
     title: '启用双指缩小视频',
     leading: const Icon(Icons.pinch),
     setKey: SettingBoxKey.enableShrinkVideoSize,

--- a/lib/pages/setting/models/play_settings.dart
+++ b/lib/pages/setting/models/play_settings.dart
@@ -197,6 +197,13 @@ List<SettingsModel> get playSettings => [
   ),
   SettingsModel(
     settingsType: SettingsType.sw1tch,
+    title: '全屏展示点赞/投币/收藏等操作按钮',
+    leading: const Icon(MdiIcons.dotsHorizontalCircleOutline),
+    setKey: SettingBoxKey.showFSActionItem,
+    defaultVal: true,
+  ),
+  SettingsModel(
+    settingsType: SettingsType.sw1tch,
     title: '观看人数',
     subtitle: '展示同时在看人数',
     leading: const Icon(Icons.people_outlined),


### PR DESCRIPTION
The “Full-screen display of like/coin/favorite buttons” setting has been moved from “Settings - Other Settings” to “Settings - Player Settings.” This setting should be considered a player setting.
将"全屏展示点赞/投币/收藏等操作按钮"设置项从"设置-其他设置"移动到了"设置-播放器设置"中，这个设置项应该算一个播放器设置