### PR TITLE
feat: Modified the high-energy progress bar to a gradient effect that follows the playback progress.

### DIFF
--- a/lib/pages/setting/models/extra_settings.dart
+++ b/lib/pages/setting/models/extra_settings.dart
@@ -609,14 +609,6 @@ List<SettingsModel> get extraSettings => [
   ),
   SettingsModel(
     settingsType: SettingsType.sw1tch,
-    title: '显示高能进度条',
-    subtitle: '高能进度条反应了在时域上，单位时间内弹幕发送量的变化趋势',
-    leading: const Icon(Icons.show_chart),
-    setKey: SettingBoxKey.showDmChart,
-    defaultVal: false,
-  ),
-  SettingsModel(
-    settingsType: SettingsType.sw1tch,
     title: '发评反诈',
     subtitle: '发送评论后检查评论是否可见',
     leading: const Stack(

--- a/lib/pages/setting/models/play_settings.dart
+++ b/lib/pages/setting/models/play_settings.dart
@@ -271,4 +271,20 @@ List<SettingsModel> get playSettings => [
       videoPlayerServiceHandler.enableBackgroundPlay = value;
     },
   ),
+  SettingsModel(
+    settingsType: SettingsType.sw1tch,
+    title: '显示高能进度条',
+    subtitle: '高能进度条反应了在时域上，单位时间内弹幕发送量的变化趋势',
+    leading: const Icon(Icons.show_chart),
+    setKey: SettingBoxKey.showDmChart,
+    defaultVal: false,
+  ),
+  SettingsModel(
+    settingsType: SettingsType.sw1tch,
+    title: '高能进度条始终显示',
+    subtitle: '开启后播放器控件收起时也显示高能进度条，关闭则仅在显示控件时显示',
+    leading: const Icon(Icons.visibility_outlined),
+    setKey: SettingBoxKey.dmChartAlwaysShow,
+    defaultVal: true,
+  ),
 ];

--- a/lib/plugin/pl_player/view.dart
+++ b/lib/plugin/pl_player/view.dart
@@ -1870,11 +1870,11 @@ Widget buildDmChart(
                 ),
                 isCurved: true,
                 barWidth: 1,
-                color: grayColor,
+                color: grayColor.withValues(alpha: 0.2),
                 dotData: const FlDotData(show: false),
                 belowBarData: BarAreaData(
                   show: true,
-                  color: lightGrayColor,
+                  color: lightGrayColor.withValues(alpha: 0.2),
                 ),
               ),
               // 已播放部分（主题色曲线）
@@ -1887,9 +1887,10 @@ Widget buildDmChart(
                       plPlayerController.dmTrend[index],
                     ),
                   ),
+
                   isCurved: true,
                   barWidth: 1,
-                  color: primaryColor,
+                  color: primaryColor.withValues(alpha: 0.2),
                   dotData: const FlDotData(show: false),
                   belowBarData: BarAreaData(
                     show: true,

--- a/lib/plugin/pl_player/view.dart
+++ b/lib/plugin/pl_player/view.dart
@@ -29,6 +29,7 @@ import 'package:PiliPlus/plugin/pl_player/widgets/play_pause_btn.dart';
 import 'package:PiliPlus/utils/duration_util.dart';
 import 'package:PiliPlus/utils/extension.dart';
 import 'package:PiliPlus/utils/id_utils.dart';
+import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:easy_debounce/easy_throttle.dart';
 import 'package:fl_chart/fl_chart.dart';
@@ -1447,7 +1448,9 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
                       alignment: Alignment.bottomCenter,
                       children: [
                         if (plPlayerController.dmTrend.isNotEmpty &&
-                            plPlayerController.showDmTreandChart.value)
+                            plPlayerController.showDmTreandChart.value &&
+                            (Pref.dmChartAlwaysShow ||
+                                plPlayerController.showControls.value))
                           buildDmChart(theme, plPlayerController),
                         if (plPlayerController.viewPointList.isNotEmpty &&
                             plPlayerController.showVP.value)

--- a/lib/plugin/pl_player/view.dart
+++ b/lib/plugin/pl_player/view.dart
@@ -1821,52 +1821,87 @@ Widget buildDmChart(
   PlPlayerController plPlayerController, [
   double offset = 0,
 ]) {
-  final color = theme.colorScheme.primary;
-  return IgnorePointer(
-    child: Container(
-      height: 12,
-      margin: EdgeInsets.only(
-        bottom:
-            plPlayerController.viewPointList.isNotEmpty &&
-                plPlayerController.showVP.value
-            ? 20.25 + offset
-            : 4.25 + offset,
-      ),
-      child: LineChart(
-        LineChartData(
-          titlesData: const FlTitlesData(show: false),
-          lineTouchData: const LineTouchData(enabled: false),
-          gridData: const FlGridData(show: false),
-          borderData: FlBorderData(show: false),
-          minX: 0,
-          maxX: (plPlayerController.dmTrend.length - 1).toDouble(),
-          minY: 0,
-          maxY: plPlayerController.dmTrend
-              .reduce((a, b) => a > b ? a : b)
-              .toDouble(),
-          lineBarsData: [
-            LineChartBarData(
-              spots: List.generate(
-                plPlayerController.dmTrend.length,
-                (index) => FlSpot(
-                  index.toDouble(),
-                  plPlayerController.dmTrend[index],
+  return Obx(() {
+    final primaryColor = theme.colorScheme.primary;
+    final grayColor = Colors.grey[600]!;
+    final lightGrayColor = Colors.grey[400]!.withValues(alpha: 0.3);
+
+    // 计算当前播放进度对应的数据点索引
+    final currentPositionSeconds =
+        plPlayerController.sliderPositionSeconds.value;
+    final totalSeconds = plPlayerController.durationSeconds.value.inSeconds;
+    final progressRatio = totalSeconds > 0
+        ? currentPositionSeconds / totalSeconds
+        : 0.0;
+    final progressIndex = (plPlayerController.dmTrend.length * progressRatio)
+        .round();
+
+    return IgnorePointer(
+      child: Container(
+        height: 12,
+        margin: EdgeInsets.only(
+          bottom:
+              plPlayerController.viewPointList.isNotEmpty &&
+                  plPlayerController.showVP.value
+              ? 20.25 + offset
+              : 4.25 + offset,
+        ),
+        child: LineChart(
+          LineChartData(
+            titlesData: const FlTitlesData(show: false),
+            lineTouchData: const LineTouchData(enabled: false),
+            gridData: const FlGridData(show: false),
+            borderData: FlBorderData(show: false),
+            minX: 0,
+            maxX: (plPlayerController.dmTrend.length - 1).toDouble(),
+            minY: 0,
+            maxY: plPlayerController.dmTrend
+                .reduce((a, b) => a > b ? a : b)
+                .toDouble(),
+            lineBarsData: [
+              // 未播放部分（灰色背景曲线）
+              LineChartBarData(
+                spots: List.generate(
+                  plPlayerController.dmTrend.length,
+                  (index) => FlSpot(
+                    index.toDouble(),
+                    plPlayerController.dmTrend[index],
+                  ),
+                ),
+                isCurved: true,
+                barWidth: 1,
+                color: grayColor,
+                dotData: const FlDotData(show: false),
+                belowBarData: BarAreaData(
+                  show: true,
+                  color: lightGrayColor,
                 ),
               ),
-              isCurved: true,
-              barWidth: 1,
-              color: color,
-              dotData: const FlDotData(show: false),
-              belowBarData: BarAreaData(
-                show: true,
-                color: color.withValues(alpha: 0.4),
-              ),
-            ),
-          ],
+              // 已播放部分（主题色曲线）
+              if (progressIndex > 0)
+                LineChartBarData(
+                  spots: List.generate(
+                    progressIndex + 1,
+                    (index) => FlSpot(
+                      index.toDouble(),
+                      plPlayerController.dmTrend[index],
+                    ),
+                  ),
+                  isCurved: true,
+                  barWidth: 1,
+                  color: primaryColor,
+                  dotData: const FlDotData(show: false),
+                  belowBarData: BarAreaData(
+                    show: true,
+                    color: primaryColor.withValues(alpha: 0.4),
+                  ),
+                ),
+            ],
+          ),
         ),
       ),
-    ),
-  );
+    );
+  });
 }
 
 Widget buildSeekPreviewWidget(PlPlayerController plPlayerController) {

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -99,6 +99,7 @@ class SettingBoxKey {
       enableLivePhoto = 'enableLivePhoto',
       showSeekPreview = 'showSeekPreview',
       showDmChart = 'showDmChart',
+      dmChartAlwaysShow = 'dmChartAlwaysShow',
       enableCommAntifraud = 'enableCommAntifraud',
       biliSendCommAntifraud = 'biliSendCommAntifraud',
       enableCreateDynAntifraud = 'enableCreateDynAntifraud',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -425,6 +425,9 @@ class Pref {
   static bool get showDmChart =>
       _setting.get(SettingBoxKey.showDmChart, defaultValue: false);
 
+  static bool get dmChartAlwaysShow =>
+      _setting.get(SettingBoxKey.dmChartAlwaysShow, defaultValue: true);
+
   static bool get enableCommAntifraud =>
       _setting.get(SettingBoxKey.enableCommAntifraud, defaultValue: false);
 


### PR DESCRIPTION
- Modified the high-energy progress bar to default to gray display
- Displayed the theme color (green) for the played portion
- Unplayed sections retain a dark gray curve and transparent light gray background
---
- Adjusted the opacity of the high-energy progress bar to minimize visual impact
---
- Added an option to always display the high-energy progress bar, enabled by default. When disabled, the high-energy progress bar only appears when the player controls are displayed by tapping the screen.
- Moved the high-energy progress bar toggle setting to “Player Settings”
------------------------
feat: 修改高能进度条为跟随播放进度的渐变效果
- 修改高能进度条默认为灰色显示
- 已播放部分显示主题色（绿色）
- 未播放部分保持深灰色曲线和透明浅灰色背景
---
- 修改高能进度条不透明度，减少观感影响
---
- 添加了始终显示高能进度条的设置选项，默认开启，关闭则仅在点击屏幕显示播放器控件时显示高能进度条。
- 移动高能进度条开关设置到“播放器设置”