### PR TITLE
修复了README中对纯文本异常使用bash代码高亮

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ## 开发环境
 
-```bash
+```text
 [✓] Flutter (Channel stable, 3.24.0, on Microsoft Windows [版本 10.0.19045.4046], locale zh-CN)
 [✓] Android toolchain - develop for Android devices (Android SDK version 34.0.0)
 [✓] Xcode - develop for iOS and macOS (Xcode 15.1)


### PR DESCRIPTION
将bash改成了text来取消代码高亮