### PR TITLE
Feat: 增加账号模式：视频观看进度

### DIFF
--- a/lib/http/video.dart
+++ b/lib/http/video.dart
@@ -251,7 +251,7 @@ class VideoHttp {
                   resultProgress?['play_view_business_info']?['user_status']?['watch_progress']?['current_watch_progress'];
           case VideoType.pgc:
             var result = res.data['result'];
-            var resultProgress = resProgress.data['data'];
+            var resultProgress = resProgress.data['result'];
             data = PlayUrlModel.fromJson(result['video_info'])
               ..lastPlayTime =
                   resultProgress?['play_view_business_info']?['user_status']?['watch_progress']?['current_watch_progress'];

--- a/lib/http/video.dart
+++ b/lib/http/video.dart
@@ -216,17 +216,25 @@ class VideoHttp {
     });
 
     try {
-      var res = await Request().get(
-        videoType.api,
-        queryParameters: params,
-      );
-      var resProgress = res;
+      late Response res;
+      late Response resProgress;
+
       if (Accounts.get(AccountType.video).mid !=
           Accounts.get(AccountType.progress).mid) {
-        resProgress = await Request().get(
-          '${videoType.api}#progress#',
+        // 并行获取视频数据和进度数据
+        final results = await Future.wait([
+          Request().get(videoType.api, queryParameters: params),
+          Request().get('${videoType.api}#progress#', queryParameters: params),
+        ]);
+        res = results[0];
+        resProgress = results[1];
+      } else {
+        // 只需要获取视频数据，进度数据使用相同的结果
+        res = await Request().get(
+          videoType.api,
           queryParameters: params,
         );
+        resProgress = res;
       }
 
       if (res.data['code'] == 0) {

--- a/lib/http/video.dart
+++ b/lib/http/video.dart
@@ -220,22 +220,33 @@ class VideoHttp {
         videoType.api,
         queryParameters: params,
       );
+      var resProgress = res;
+      if (Accounts.get(AccountType.video).mid !=
+          Accounts.get(AccountType.progress).mid) {
+        resProgress = await Request().get(
+          '${videoType.api}#progress#',
+          queryParameters: params,
+        );
+      }
 
       if (res.data['code'] == 0) {
         late PlayUrlModel data;
         switch (videoType) {
           case VideoType.ugc:
             data = PlayUrlModel.fromJson(res.data['data']);
+            data.lastPlayTime = resProgress.data['data']['last_play_time'];
           case VideoType.pugv:
             var result = res.data['data'];
+            var resultProgress = resProgress.data['data'];
             data = PlayUrlModel.fromJson(result)
               ..lastPlayTime =
-                  result?['play_view_business_info']?['user_status']?['watch_progress']?['current_watch_progress'];
+                  resultProgress?['play_view_business_info']?['user_status']?['watch_progress']?['current_watch_progress'];
           case VideoType.pgc:
             var result = res.data['result'];
+            var resultProgress = resProgress.data['data'];
             data = PlayUrlModel.fromJson(result['video_info'])
               ..lastPlayTime =
-                  result?['play_view_business_info']?['user_status']?['watch_progress']?['current_watch_progress'];
+                  resultProgress?['play_view_business_info']?['user_status']?['watch_progress']?['current_watch_progress'];
         }
         return Success(data);
       } else if (epid != null && videoType == VideoType.ugc) {

--- a/lib/models/common/account_type.dart
+++ b/lib/models/common/account_type.dart
@@ -2,7 +2,8 @@ enum AccountType {
   main('主账号'),
   heartbeat('记录观看'),
   recommend('推荐'),
-  video('视频取流');
+  video('视频取流'),
+  progress('视频播放进度');
 
   final String title;
   const AccountType(this.title);

--- a/lib/utils/accounts/account_manager/account_mgr.dart
+++ b/lib/utils/accounts/account_manager/account_mgr.dart
@@ -74,6 +74,11 @@ class AccountManager extends Interceptor {
       Api.pgcUrl,
       Api.pugvUrl,
     },
+    AccountType.progress: {
+      '${Api.ugcUrl}#progress#',
+      '${Api.pgcUrl}#progress#',
+      '${Api.pugvUrl}#progress#',
+    },
   };
 
   static const loginApi = {
@@ -116,6 +121,9 @@ class AccountManager extends Interceptor {
     final path = options.path;
 
     late final Account account = options.extra['account'] ?? _findAccount(path);
+    if (path.endsWith('#progress#')) {
+      options.path = path.replaceAll('#progress#', '');
+    }
 
     if (_skipCookie(path) || account is NoAccount) return handler.next(options);
 


### PR DESCRIPTION
目前无法实现这样的功能：播放视频时读取主账号的视频播放进度，但是使用此账号的视频取流。

Q: 为什么要这样的功能？
A: 因为大号没有大会员，但是小号有，如果有这个功能可以实现大号正常获取视频播放进度

目前的实现方式不太优雅，但是是我想到的最小变动实现这个功能的方法，还请见谅。