### PR TITLE
Some tweaks for macOS target

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -78,14 +78,12 @@ void main() async {
     );
   } else if (Utils.isDesktop) {
     await windowManager.ensureInitialized();
-    WindowOptions windowOptions = WindowOptions(
-      minimumSize: const Size(400, 720),
-      size: const Size(1180, 720),
+    WindowOptions windowOptions = const WindowOptions(
+      minimumSize: Size(400, 720),
+      size: Size(1180, 720),
       center: true,
       skipTaskbar: false,
-      titleBarStyle: Platform.isMacOS
-          ? TitleBarStyle.hidden
-          : TitleBarStyle.normal,
+      titleBarStyle: TitleBarStyle.normal,
       title: Constants.appName,
     );
     windowManager.waitUntilReadyToShow(windowOptions, () async {

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -10,5 +10,7 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -6,5 +6,7 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
macOS上隐藏titlebar效果并不好，会导致视频画面与系统窗口操作按钮重叠，左上角的返回等按钮也会与系统窗口操作按钮响应有冲突。
<img width="2062" height="1304" alt="piliplus 2025-09-14 下午4 19 05" src="https://github.com/user-attachments/assets/ab3df197-222c-41ed-b4fc-fdd48c01ff4e" />
