### PR TITLE
添加窗口内全屏功能选项

### DIFF
--- a/lib/pages/setting/models/play_settings.dart
+++ b/lib/pages/setting/models/play_settings.dart
@@ -200,6 +200,14 @@ List<SettingsModel> get playSettings => [
   ),
   const SettingsModel(
     settingsType: SettingsType.sw1tch,
+    title: '窗口内全屏',
+    subtitle: '开启后全屏功能将铺满窗口而不是铺满屏幕',
+    leading: Icon(Icons.fit_screen_outlined),
+    setKey: SettingBoxKey.useInAppFullscreen,
+    defaultVal: false,
+  ),
+  const SettingsModel(
+    settingsType: SettingsType.sw1tch,
     title: '后台播放',
     subtitle: '进入后台时继续播放',
     leading: Icon(Icons.motion_photos_pause_outlined),

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -1514,6 +1514,7 @@ class PlPlayerController {
 
   late final FullScreenMode mode = FullScreenMode.values[Pref.fullScreenMode];
   late final horizontalScreen = Pref.horizontalScreen;
+  late final useInAppFullscreen = Pref.useInAppFullscreen;
 
   // 全屏
   bool fsProcessing = false;
@@ -1552,7 +1553,8 @@ class PlPlayerController {
           await landscape();
         }
       } else {
-        await enterDesktopFullscreen(inAppFullScreen: inAppFullScreen);
+        // 根据设置决定使用窗口内全屏还是铺满屏幕全屏
+        await enterDesktopFullscreen(inAppFullScreen: inAppFullScreen || useInAppFullscreen);
       }
     } else {
       if (Utils.isMobile) {

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -33,6 +33,7 @@ abstract class SettingBoxKey {
       enableLongShowControl = 'enableLongShowControl',
       allowRotateScreen = 'allowRotateScreen',
       horizontalScreen = 'horizontalScreen',
+      useInAppFullscreen = 'useInAppFullscreen',
       CDNService = 'CDNService',
       disableAudioCDN = 'disableAudioCDN',
       autoPiP = 'autoPiP',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -181,6 +181,11 @@ abstract class Pref {
     SettingBoxKey.fullScreenMode,
     defaultValue: FullScreenMode.auto.index,
   );
+  
+  static bool get useInAppFullscreen => _setting.get(
+    SettingBoxKey.useInAppFullscreen,
+    defaultValue: false,
+  );
 
   static int get btmProgressBehavior => _setting.get(
     SettingBoxKey.btmProgressBehavior,


### PR DESCRIPTION
在设置中添加窗口内全屏开关选项，允许用户选择全屏时铺满窗口而非整个屏幕