### PR TITLE
feat: 优化账号切换交互，默认一键切换并保留原功能入口

### DIFF
--- a/lib/common/widgets/radio_widget.dart
+++ b/lib/common/widgets/radio_widget.dart
@@ -1,3 +1,4 @@
+import 'package:PiliPlus/utils/platform_utils.dart';
 import 'package:flutter/material.dart';
 
 class RadioWidget<T> extends StatefulWidget {
@@ -61,17 +62,13 @@ class RadioWidgetState<T> extends State<RadioWidget<T>> with RadioClient<T> {
     final child = Row(
       mainAxisSize: widget.mainAxisSize,
       children: [
-        Focus(
-          parentNode: focusNode,
-          canRequestFocus: false,
-          skipTraversal: true,
-          includeSemantics: true,
-          descendantsAreFocusable: false,
-          descendantsAreTraversable: false,
+        ExcludeFocus(
           child: Radio<T>(
             value: radioValue,
             groupRegistry: _radioRegistry,
-            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            materialTapTargetSize: PlatformUtils.isDesktop
+                ? .padded
+                : .shrinkWrap,
           ),
         ),
         Text(widget.title),
@@ -91,22 +88,13 @@ class WrapRadioOptionsGroup<T> extends StatelessWidget {
   final String groupTitle;
   final Map<T, String> options;
   final EdgeInsetsGeometry? itemPadding;
-  final bool vertical;
 
   const WrapRadioOptionsGroup({
     super.key,
     required this.groupTitle,
     required this.options,
     this.itemPadding,
-    this.vertical = false,
   });
-
-  const WrapRadioOptionsGroup.vertical({
-    super.key,
-    required this.groupTitle,
-    required this.options,
-    this.itemPadding,
-  }) : vertical = true;
 
   @override
   Widget build(BuildContext context) {
@@ -123,28 +111,15 @@ class WrapRadioOptionsGroup<T> extends StatelessWidget {
           ),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 12),
-          child: vertical
-              ? Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: options.entries.map((entry) {
-                    return RadioWidget<T>(
-                      value: entry.key,
-                      title: entry.value,
-                      padding:
-                          itemPadding ??
-                          const EdgeInsets.symmetric(vertical: 4),
-                    );
-                  }).toList(),
-                )
-              : Wrap(
-                  children: options.entries.map((entry) {
-                    return RadioWidget<T>(
-                      value: entry.key,
-                      title: entry.value,
-                      padding: itemPadding ?? const EdgeInsets.only(right: 10),
-                    );
-                  }).toList(),
-                ),
+          child: Wrap(
+            children: options.entries.map((entry) {
+              return RadioWidget<T>(
+                value: entry.key,
+                title: entry.value,
+                padding: itemPadding ?? const EdgeInsets.only(right: 10),
+              );
+            }).toList(),
+          ),
         ),
       ],
     );

--- a/lib/common/widgets/radio_widget.dart
+++ b/lib/common/widgets/radio_widget.dart
@@ -91,13 +91,22 @@ class WrapRadioOptionsGroup<T> extends StatelessWidget {
   final String groupTitle;
   final Map<T, String> options;
   final EdgeInsetsGeometry? itemPadding;
+  final bool vertical;
 
   const WrapRadioOptionsGroup({
     super.key,
     required this.groupTitle,
     required this.options,
     this.itemPadding,
+    this.vertical = false,
   });
+
+  const WrapRadioOptionsGroup.vertical({
+    super.key,
+    required this.groupTitle,
+    required this.options,
+    this.itemPadding,
+  }) : vertical = true;
 
   @override
   Widget build(BuildContext context) {
@@ -114,15 +123,28 @@ class WrapRadioOptionsGroup<T> extends StatelessWidget {
           ),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 12),
-          child: Wrap(
-            children: options.entries.map((entry) {
-              return RadioWidget<T>(
-                value: entry.key,
-                title: entry.value,
-                padding: itemPadding ?? const EdgeInsets.only(right: 10),
-              );
-            }).toList(),
-          ),
+          child: vertical
+              ? Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: options.entries.map((entry) {
+                    return RadioWidget<T>(
+                      value: entry.key,
+                      title: entry.value,
+                      padding:
+                          itemPadding ??
+                          const EdgeInsets.symmetric(vertical: 4),
+                    );
+                  }).toList(),
+                )
+              : Wrap(
+                  children: options.entries.map((entry) {
+                    return RadioWidget<T>(
+                      value: entry.key,
+                      title: entry.value,
+                      padding: itemPadding ?? const EdgeInsets.only(right: 10),
+                    );
+                  }).toList(),
+                ),
         ),
       ],
     );

--- a/lib/pages/login/controller.dart
+++ b/lib/pages/login/controller.dart
@@ -737,137 +737,119 @@ class LoginPageController extends GetxController
         (k, v) => MapEntry(v, k as String),
       ),
     };
+    bool quickSelect = selectAccount.every((e) => e == selectAccount.first);
     return showDialog(
       context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('账号切换'),
-        titlePadding: const .only(left: 22, top: 16, right: 22),
-        contentPadding: const .symmetric(vertical: 5),
-        actionsPadding: const .only(left: 16, right: 16, bottom: 10),
-        content: SingleChildScrollView(
-          child: Builder(
-            builder: (context) => RadioGroup(
-              groupValue: selectAccount[0],
-              onChanged: (v) {
-                selectAccount[0] = v!;
-                (context as Element).markNeedsBuild();
-              },
-              child: WrapRadioOptionsGroup<Account>.vertical(
-                groupTitle: '选择账号mid, 为0时使用匿名', // subtitle
-                options: options,
-              ),
-            ),
-          ),
-        ),
-        actions: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      builder: (context) => Builder(
+        builder: (context) => AlertDialog(
+          title: Row(
+            crossAxisAlignment: .start,
+            mainAxisAlignment: .spaceBetween,
             children: [
-              TextButton(
-                onPressed: () {
-                  switchAccountDialogDetailed(context); // 打开详细弹窗
-                },
-                child: const Text('更多'),
-              ),
-              Row(
-                children: [
-                  TextButton(
-                    onPressed: Get.back,
-                    child: Text(
-                      '取消',
+              Text.rich(
+                style: const TextStyle(height: 1.5),
+                TextSpan(
+                  children: [
+                    const TextSpan(text: '账号切换'),
+                    TextSpan(
+                      text: '\nmid 为0时使用匿名',
                       style: TextStyle(
-                        color: Theme.of(context).colorScheme.outline,
+                        fontSize: 14,
+                        color: ColorScheme.of(context).outline,
                       ),
                     ),
-                  ),
-                  TextButton(
-                    onPressed: () {
-                      for (var (i, v) in selectAccount.indexed) {
-                        if (selectAccount[0] != Accounts.accountMode[i]) {
-                          Accounts.set(AccountType.values[i], selectAccount[0]);
-                        }
-                      }
-                      Get.back();
-                    },
-                    child: const Text('确定'),
-                  ),
-                ],
+                  ],
+                ),
+              ),
+              TextButton(
+                onPressed: () {
+                  quickSelect = !quickSelect;
+                  (context as Element).markNeedsBuild();
+                },
+                child: const Text('切换'),
               ),
             ],
           ),
-        ],
-      ),
-    );
-  }
-
-  static Future<void>? switchAccountDialogDetailed(BuildContext context) {
-    if (Accounts.account.isEmpty) {
-      SmartDialog.showToast('请先登录');
-      return Get.toNamed('/loginPage');
-    }
-    final selectAccount = List.of(Accounts.accountMode);
-    final options = {
-      AnonymousAccount(): '0',
-      ...Accounts.account.toMap().map(
-        (k, v) => MapEntry(v, k as String),
-      ),
-    };
-    return showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('选择账号mid, 为0时使用匿名'),
-        titlePadding: const EdgeInsets.only(left: 22, top: 16, right: 22),
-        contentPadding: const EdgeInsets.symmetric(vertical: 5),
-        actionsPadding: const EdgeInsets.only(
-          left: 16,
-          right: 16,
-          bottom: 10,
-        ),
-        content: SingleChildScrollView(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: AccountType.values
-                .map(
-                  (e) => Builder(
-                    builder: (context) => RadioGroup(
-                      groupValue: selectAccount[e.index],
-                      onChanged: (v) {
-                        selectAccount[e.index] = v!;
-                        (context as Element).markNeedsBuild();
-                      },
-                      child: WrapRadioOptionsGroup<Account>(
-                        groupTitle: e.title,
-                        options: options,
+          titlePadding: const .only(left: 22, top: 16, right: 22, bottom: 3),
+          contentPadding: const .symmetric(vertical: 5),
+          actionsPadding: const .only(left: 16, right: 16, bottom: 10),
+          content: SingleChildScrollView(
+            child: AnimatedSize(
+              curve: Curves.easeIn,
+              alignment: .topCenter,
+              duration: const Duration(milliseconds: 200),
+              child: quickSelect
+                  ? Builder(
+                      builder: (context) => RadioGroup<Account>(
+                        groupValue: selectAccount[0],
+                        onChanged: (v) {
+                          for (int i = 0; i < selectAccount.length; i++) {
+                            selectAccount[i] = v!;
+                          }
+                          (context as Element).markNeedsBuild();
+                        },
+                        child: Column(
+                          crossAxisAlignment: .start,
+                          children: options.entries
+                              .map(
+                                (entry) => RadioWidget<Account>(
+                                  value: entry.key,
+                                  title: entry.value,
+                                  mainAxisSize: .max,
+                                  padding: const .only(left: 12),
+                                ),
+                              )
+                              .toList(),
+                        ),
                       ),
+                    )
+                  : Column(
+                      crossAxisAlignment: .start,
+                      children: AccountType.values
+                          .map(
+                            (e) => Builder(
+                              builder: (context) => RadioGroup<Account>(
+                                groupValue: selectAccount[e.index],
+                                onChanged: (v) {
+                                  selectAccount[e.index] = v!;
+                                  (context as Element).markNeedsBuild();
+                                },
+                                child: WrapRadioOptionsGroup<Account>(
+                                  groupTitle: e.title,
+                                  options: options,
+                                ),
+                              ),
+                            ),
+                          )
+                          .toList(),
                     ),
-                  ),
-                )
-                .toList(),
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: Get.back,
-            child: Text(
-              '取消',
-              style: TextStyle(
-                color: Theme.of(context).colorScheme.outline,
-              ),
             ),
           ),
-          TextButton(
-            onPressed: () {
-              for (final (i, v) in selectAccount.indexed) {
-                if (v != Accounts.accountMode[i]) {
-                  Accounts.set(AccountType.values[i], v);
+          actions: [
+            TextButton(
+              onPressed: Get.back,
+              child: Text(
+                '取消',
+                style: TextStyle(color: ColorScheme.of(context).outline),
+              ),
+            ),
+            TextButton(
+              onPressed: () {
+                Get.back();
+                for (final type in AccountType.values) {
+                  final index = type.index;
+                  final account = quickSelect
+                      ? selectAccount.first
+                      : selectAccount[index];
+                  if (account != Accounts.accountMode[index]) {
+                    Accounts.set(type, account);
+                  }
                 }
-              }
-              // 关闭当前对话框和之前的 switchAccountDialog 对话框
-              Navigator.of(context).popUntil((route) => route.isFirst);
-            },
-            child: const Text('确定'),
-          ),
-        ],
+              },
+              child: const Text('确定'),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/pages/login/controller.dart
+++ b/lib/pages/login/controller.dart
@@ -740,10 +740,89 @@ class LoginPageController extends GetxController
     return showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        title: const Text('选择账号mid, 为0时使用匿名'),
+        title: const Text('账号切换'),
         titlePadding: const .only(left: 22, top: 16, right: 22),
         contentPadding: const .symmetric(vertical: 5),
         actionsPadding: const .only(left: 16, right: 16, bottom: 10),
+        content: SingleChildScrollView(
+          child: Builder(
+            builder: (context) => RadioGroup(
+              groupValue: selectAccount[0],
+              onChanged: (v) {
+                selectAccount[0] = v!;
+                (context as Element).markNeedsBuild();
+              },
+              child: WrapRadioOptionsGroup<Account>.vertical(
+                groupTitle: '选择账号mid, 为0时使用匿名', // subtitle
+                options: options,
+              ),
+            ),
+          ),
+        ),
+        actions: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              TextButton(
+                onPressed: () {
+                  switchAccountDialogDetailed(context); // 打开详细弹窗
+                },
+                child: const Text('更多'),
+              ),
+              Row(
+                children: [
+                  TextButton(
+                    onPressed: Get.back,
+                    child: Text(
+                      '取消',
+                      style: TextStyle(
+                        color: Theme.of(context).colorScheme.outline,
+                      ),
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: () {
+                      for (var (i, v) in selectAccount.indexed) {
+                        if (selectAccount[0] != Accounts.accountMode[i]) {
+                          Accounts.set(AccountType.values[i], selectAccount[0]);
+                        }
+                      }
+                      Get.back();
+                    },
+                    child: const Text('确定'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  static Future<void>? switchAccountDialogDetailed(BuildContext context) {
+    if (Accounts.account.isEmpty) {
+      SmartDialog.showToast('请先登录');
+      return Get.toNamed('/loginPage');
+    }
+    final selectAccount = List.of(Accounts.accountMode);
+    final options = {
+      AnonymousAccount(): '0',
+      ...Accounts.account.toMap().map(
+        (k, v) => MapEntry(v, k as String),
+      ),
+    };
+    return showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('选择账号mid, 为0时使用匿名'),
+        titlePadding: const EdgeInsets.only(left: 22, top: 16, right: 22),
+        contentPadding: const EdgeInsets.symmetric(vertical: 5),
+        actionsPadding: const EdgeInsets.only(
+          left: 16,
+          right: 16,
+          bottom: 10,
+        ),
         content: SingleChildScrollView(
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -783,7 +862,8 @@ class LoginPageController extends GetxController
                   Accounts.set(AccountType.values[i], v);
                 }
               }
-              Get.back();
+              // 关闭当前对话框和之前的 switchAccountDialog 对话框
+              Navigator.of(context).popUntil((route) => route.isFirst);
             },
             child: const Text('确定'),
           ),


### PR DESCRIPTION
默认一键切换账号，便于用户理解（取主账号状态显示，'确定'更改全局）  
保留之前切换账号界面（切换账号-更多）

<img width="712" height="570" alt="4e1c126dc70d819665241304b0c67147" src="https://github.com/user-attachments/assets/ba61990c-f73c-4316-b509-49548488cee8" />

点击'更多'后  

<img width="882" height="678" alt="ce27669ac3e5e3fdaf82e4db4cb25e54" src="https://github.com/user-attachments/assets/d49de7d8-95f6-4b70-9a1f-d5294c12b18d" />

已经成功运行验证，更改的文件经过 dart format