### PR TITLE
feat: support custom video CDN hosts

### DIFF
--- a/lib/pages/setting/models/video_settings.dart
+++ b/lib/pages/setting/models/video_settings.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:PiliPlus/models/common/video/audio_quality.dart';
-import 'package:PiliPlus/models/common/video/cdn_type.dart';
 import 'package:PiliPlus/models/common/video/live_quality.dart';
 import 'package:PiliPlus/models/common/video/video_decode_type.dart';
 import 'package:PiliPlus/models/common/video/video_quality.dart';
@@ -58,7 +57,7 @@ List<SettingsModel> get videoSettings => [
     title: 'CDN 设置',
     leading: const Icon(MdiIcons.cloudPlusOutline),
     getSubtitle: () =>
-        '当前使用：${VideoUtils.cdnService.desc}，部分 CDN 可能失效，如无法播放请尝试切换',
+        '当前使用：${VideoUtils.effectiveCdnDesc()}，部分 CDN 可能失效，如无法播放请尝试切换',
     onTap: _showCDNDialog,
   ),
   NormalModel(
@@ -172,14 +171,33 @@ List<SettingsModel> get videoSettings => [
 ];
 
 Future<void> _showCDNDialog(BuildContext context, VoidCallback setState) async {
-  final res = await showDialog<CDNService>(
+  final res = await showDialog<CdnSelectResult>(
     context: context,
     builder: (context) => const CdnSelectDialog(),
   );
   if (res != null) {
-    VideoUtils.cdnService = res;
-    await GStorage.setting.put(SettingBoxKey.CDNService, res.name);
+    await _saveCdnSelectResult(res);
     setState();
+  }
+}
+
+Future<void> _saveCdnSelectResult(CdnSelectResult result) async {
+  switch (result.type) {
+    case CdnSelectResultType.builtIn:
+      final service = result.service!;
+      VideoUtils.cdnService = service;
+      VideoUtils.customCDNUrl = null;
+      await GStorage.setting.put(SettingBoxKey.CDNService, service.name);
+      await GStorage.setting.delete(SettingBoxKey.customCDNUrl);
+    case CdnSelectResultType.custom:
+      final host = result.customCDNUrl!;
+      VideoUtils.customCDNUrl = host;
+      await GStorage.setting.put(SettingBoxKey.customCDNUrl, host);
+      SmartDialog.showToast('已设置自定义 CDN：$host');
+    case CdnSelectResultType.clearCustom:
+      VideoUtils.customCDNUrl = null;
+      await GStorage.setting.delete(SettingBoxKey.customCDNUrl);
+      SmartDialog.showToast('已清除自定义 CDN');
   }
 }
 

--- a/lib/pages/setting/widgets/select_dialog.dart
+++ b/lib/pages/setting/widgets/select_dialog.dart
@@ -70,6 +70,35 @@ class SelectDialog<T> extends StatelessWidget {
   }
 }
 
+enum CdnSelectResultType { builtIn, custom, clearCustom }
+
+final class CdnSelectResult {
+  final CdnSelectResultType type;
+  final CDNService? service;
+  final String? customCDNUrl;
+
+  const CdnSelectResult._({
+    required this.type,
+    this.service,
+    this.customCDNUrl,
+  });
+
+  const CdnSelectResult.builtIn(CDNService service)
+    : this._(
+        type: CdnSelectResultType.builtIn,
+        service: service,
+      );
+
+  const CdnSelectResult.custom(String customCDNUrl)
+    : this._(
+        type: CdnSelectResultType.custom,
+        customCDNUrl: customCDNUrl,
+      );
+
+  const CdnSelectResult.clearCustom()
+    : this._(type: CdnSelectResultType.clearCustom);
+}
+
 class CdnSelectDialog extends StatefulWidget {
   final BaseItem? sample;
 
@@ -243,26 +272,154 @@ class _CdnSelectDialogState extends State<CdnSelectDialog> {
 
   @override
   Widget build(BuildContext context) {
-    return SelectDialog<CDNService>(
-      title: 'CDN 设置',
-      values: CDNService.values.map((i) => (i, i.desc)).toList(),
-      value: VideoUtils.cdnService,
-      subtitleBuilder: _cdnSpeedTest
-          ? (context, index) {
-              final item = _cdnResList[index];
-              return ValueListenableBuilder(
-                valueListenable: item,
-                builder: (context, value, _) {
-                  return Text(
-                    value ?? '---',
-                    style: const TextStyle(fontSize: 13),
+    final titleMedium = TextTheme.of(context).titleMedium!;
+    final customHost = VideoUtils.normalizeCustomCDNHost(
+      VideoUtils.customCDNUrl,
+    );
+    return AlertDialog(
+      clipBehavior: Clip.hardEdge,
+      title: const Text('CDN 设置'),
+      constraints: _cdnSpeedTest
+          ? const BoxConstraints(maxWidth: 320, minWidth: 320)
+          : null,
+      contentPadding: const EdgeInsets.symmetric(vertical: 12),
+      content: Material(
+        type: .transparency,
+        child: SingleChildScrollView(
+          child: RadioGroup<CDNService>(
+            onChanged: (v) {
+              if (v == null) return;
+              Navigator.of(context).pop(CdnSelectResult.builtIn(v));
+            },
+            groupValue: VideoUtils.cdnService,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ...List.generate(
+                  CDNService.values.length,
+                  (index) {
+                    final item = CDNService.values[index];
+                    return RadioListTile<CDNService>(
+                      dense: true,
+                      value: item,
+                      title: Text(
+                        item.desc,
+                        style: titleMedium,
+                      ),
+                      subtitle: _cdnSpeedTest
+                          ? _CdnSpeedResultText(notifier: _cdnResList[index])
+                          : null,
+                    );
+                  },
+                ),
+                const Divider(height: 1),
+                ListTile(
+                  dense: true,
+                  leading: const Icon(Icons.edit_outlined),
+                  title: Text('自定义 CDN 节点', style: titleMedium),
+                  subtitle: Text(
+                    customHost ?? '未设置，点击输入 host 或 URL',
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
+                  ),
+                  trailing: customHost == null
+                      ? null
+                      : IconButton(
+                          tooltip: '清除自定义 CDN',
+                          icon: const Icon(Icons.close),
+                          onPressed: () => Navigator.of(
+                            context,
+                          ).pop(const CdnSelectResult.clearCustom()),
+                        ),
+                  onTap: () async {
+                    final host = await _showCustomCdnDialog(
+                      context,
+                      customHost,
+                    );
+                    if (!context.mounted || host == null) return;
+                    Navigator.of(context).pop(CdnSelectResult.custom(host));
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<String?> _showCustomCdnDialog(
+    BuildContext context,
+    String? initialValue,
+  ) async {
+    final controller = TextEditingController(text: initialValue ?? '');
+    String? errorText;
+    try {
+      return await showDialog<String>(
+        context: context,
+        builder: (context) => StatefulBuilder(
+          builder: (context, setDialogState) => AlertDialog(
+            title: const Text('自定义 CDN 节点'),
+            content: TextField(
+              controller: controller,
+              autofocus: true,
+              decoration: InputDecoration(
+                hintText: 'upos-sz-mirrorali.bilivideo.com',
+                errorText: errorText,
+              ),
+              onChanged: (_) {
+                if (errorText == null) return;
+                setDialogState(() => errorText = null);
+              },
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: Text(
+                  '取消',
+                  style: TextStyle(color: ColorScheme.of(context).outline),
+                ),
+              ),
+              TextButton(
+                onPressed: () {
+                  final host = VideoUtils.normalizeCustomCDNHost(
+                    controller.text,
                   );
+                  if (host == null) {
+                    setDialogState(() => errorText = '请输入有效的 host 或完整 URL');
+                    return;
+                  }
+                  Navigator.of(context).pop(host);
                 },
-              );
-            }
-          : null,
+                child: const Text('确定'),
+              ),
+            ],
+          ),
+        ),
+      );
+    } finally {
+      controller.dispose();
+    }
+  }
+}
+
+class _CdnSpeedResultText extends StatelessWidget {
+  final ValueNotifier<String?> notifier;
+
+  const _CdnSpeedResultText({required this.notifier});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder(
+      valueListenable: notifier,
+      builder: (context, value, _) {
+        return Text(
+          value ?? '---',
+          style: const TextStyle(fontSize: 13),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        );
+      },
     );
   }
 }

--- a/lib/pages/video/widgets/header_control.dart
+++ b/lib/pages/video/widgets/header_control.dart
@@ -16,7 +16,6 @@ import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/http/video.dart';
 import 'package:PiliPlus/models/common/super_resolution_type.dart';
 import 'package:PiliPlus/models/common/video/audio_quality.dart';
-import 'package:PiliPlus/models/common/video/cdn_type.dart';
 import 'package:PiliPlus/models/common/video/video_decode_type.dart';
 import 'package:PiliPlus/models/common/video/video_quality.dart';
 import 'package:PiliPlus/models/video/play/url.dart';
@@ -483,21 +482,19 @@ class HeaderControlState extends State<HeaderControl>
                     title: const Text('CDN 设置', style: titleStyle),
                     leading: const Icon(MdiIcons.cloudPlusOutline, size: 20),
                     subtitle: Text(
-                      '当前：${VideoUtils.cdnService.desc}，无法播放请切换',
+                      '当前：${VideoUtils.effectiveCdnDesc()}，无法播放请切换',
                       style: subTitleStyle,
                     ),
                     onTap: () async {
                       Get.back();
-                      final result = await showDialog<CDNService>(
+                      final result = await showDialog<CdnSelectResult>(
                         context: context,
                         builder: (context) => CdnSelectDialog(
                           sample: videoInfo.dash?.video?.firstOrNull,
                         ),
                       );
                       if (result != null) {
-                        VideoUtils.cdnService = result;
-                        setting.put(SettingBoxKey.CDNService, result.name);
-                        SmartDialog.showToast('已设置为 ${result.desc}，正在重载视频');
+                        await _saveCdnSelectResult(result);
                         videoDetailCtr.queryVideoUrl(
                           defaultST: videoDetailCtr.playedTime,
                           fromReset: true,
@@ -760,6 +757,27 @@ class HeaderControlState extends State<HeaderControl>
         );
       },
     );
+  }
+
+  Future<void> _saveCdnSelectResult(CdnSelectResult result) async {
+    switch (result.type) {
+      case CdnSelectResultType.builtIn:
+        final service = result.service!;
+        VideoUtils.cdnService = service;
+        VideoUtils.customCDNUrl = null;
+        await setting.put(SettingBoxKey.CDNService, service.name);
+        await setting.delete(SettingBoxKey.customCDNUrl);
+        SmartDialog.showToast('已设置为 ${service.desc}，正在重载视频');
+      case CdnSelectResultType.custom:
+        final host = result.customCDNUrl!;
+        VideoUtils.customCDNUrl = host;
+        await setting.put(SettingBoxKey.customCDNUrl, host);
+        SmartDialog.showToast('已设置自定义 CDN：$host，正在重载视频');
+      case CdnSelectResultType.clearCustom:
+        VideoUtils.customCDNUrl = null;
+        await setting.delete(SettingBoxKey.customCDNUrl);
+        SmartDialog.showToast('已清除自定义 CDN，正在重载视频');
+    }
   }
 
   static void showPlayerInfo(

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -35,6 +35,7 @@ abstract final class SettingBoxKey {
       enableLongShowControl = 'enableLongShowControl',
       horizontalScreen = 'horizontalScreen',
       CDNService = 'CDNService',
+      customCDNUrl = 'customCDNUrl',
       disableAudioCDN = 'disableAudioCDN',
       autoPiP = 'autoPiP',
       enableAutoLongPressSpeed = 'enableAutoLongPressSpeed',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -274,6 +274,11 @@ abstract final class Pref {
     return CDNService.backupUrl;
   }
 
+  static String? get customCDNUrl {
+    final value = _setting.get(SettingBoxKey.customCDNUrl);
+    return value is String && value.isNotEmpty ? value : null;
+  }
+
   static String get banWordForRecommend =>
       _setting.get(SettingBoxKey.banWordForRecommend, defaultValue: '');
 

--- a/lib/utils/video_utils.dart
+++ b/lib/utils/video_utils.dart
@@ -5,10 +5,25 @@ import 'package:flutter/foundation.dart' show kDebugMode, debugPrint;
 
 abstract final class VideoUtils {
   static CDNService cdnService = Pref.defaultCDNService;
+  static String? customCDNUrl = _readCustomCDNUrl();
   static String? liveCdnUrl = Pref.liveCdnUrl;
   static bool disableAudioCDN = Pref.disableAudioCDN;
 
   static const _proxyTf = 'proxy-tf-all-ws.bilivideo.com';
+
+  static const _replaceableCdnHostParts = [
+    'bilivideo',
+    'acgvideo',
+    'edge.mountaintoys.cn',
+    'akamaized.net',
+  ];
+
+  static const _apiHostParts = [
+    'api',
+    'bvc',
+    'data',
+    'pbp',
+  ];
 
   static final _mirrorRegex = RegExp(
     r'^https?://(?:upos-\w+-(?!302)\w+|(?:upos|proxy)-tf-[^/]+)\.(?:bilivideo|akamaized)\.(?:com|net)/upgcxcode',
@@ -21,9 +36,22 @@ abstract final class VideoUtils {
   static String getCdnUrl(
     Iterable<String> urls, {
     CDNService? defaultCDNService,
+    String? customCDNUrl,
     bool isAudio = false,
   }) {
     defaultCDNService ??= cdnService;
+    customCDNUrl = normalizeCustomCDNHost(
+      customCDNUrl ?? VideoUtils.customCDNUrl,
+    );
+
+    if (customCDNUrl != null && !(isAudio && disableAudioCDN)) {
+      for (final url in urls) {
+        final replaced = _replaceWithCustomCdn(url, customCDNUrl);
+        if (replaced != null) {
+          return replaced;
+        }
+      }
+    }
 
     if (defaultCDNService == CDNService.baseUrl) {
       return urls.first;
@@ -86,6 +114,66 @@ abstract final class VideoUtils {
         : Uri.parse(mcdnUpgcxcode)
               .replace(host: defaultCDNService.host ?? CDNService.ali.host)
               .toString();
+  }
+
+  static String? normalizeCustomCDNHost(String? value) {
+    final trimmed = value?.trim();
+    if (trimmed == null || trimmed.isEmpty) {
+      return null;
+    }
+
+    final uri = Uri.tryParse(trimmed);
+    if (uri == null) {
+      return null;
+    }
+
+    if (uri.hasScheme) {
+      return uri.host.isEmpty ? null : uri.host;
+    }
+
+    if (trimmed.contains('/') ||
+        trimmed.contains('?') ||
+        trimmed.contains('#')) {
+      return null;
+    }
+    return trimmed;
+  }
+
+  static String effectiveCdnDesc({
+    CDNService? service,
+    String? customCDNUrl,
+  }) {
+    final host = normalizeCustomCDNHost(
+      customCDNUrl ?? VideoUtils.customCDNUrl,
+    );
+    return host == null ? (service ?? cdnService).desc : '自定义：$host';
+  }
+
+  static String? _replaceWithCustomCdn(String url, String customHost) {
+    final uri = Uri.tryParse(url);
+    if (uri == null || uri.host.isEmpty) {
+      return null;
+    }
+    if (!_isReplaceableMediaHost(uri.host)) {
+      return null;
+    }
+    return uri.replace(host: customHost).toString();
+  }
+
+  static bool _isReplaceableMediaHost(String host) {
+    final lowerHost = host.toLowerCase();
+    if (_apiHostParts.any(lowerHost.contains)) {
+      return false;
+    }
+    return _replaceableCdnHostParts.any(lowerHost.contains);
+  }
+
+  static String? _readCustomCDNUrl() {
+    try {
+      return Pref.customCDNUrl;
+    } catch (_) {
+      return null;
+    }
   }
 
   static String getLiveCdnUrl(CodecItem e) {

--- a/test/utils/video_utils_test.dart
+++ b/test/utils/video_utils_test.dart
@@ -1,0 +1,47 @@
+import 'package:PiliPlus/models/common/video/cdn_type.dart';
+import 'package:PiliPlus/utils/video_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('VideoUtils custom CDN', () {
+    test('normalizes a custom CDN URL to its host', () {
+      expect(
+        VideoUtils.normalizeCustomCDNHost('https://example.cdn.test/path?a=1'),
+        'example.cdn.test',
+      );
+      expect(VideoUtils.normalizeCustomCDNHost(' example.cdn.test/ '), null);
+      expect(VideoUtils.normalizeCustomCDNHost(''), null);
+    });
+
+    test('replaces known video CDN hosts with custom host', () {
+      final result = VideoUtils.getCdnUrl(
+        [
+          'https://upos-sz-mirrorali.bilivideo.com/upgcxcode/12/34/video.m4s?e=1',
+        ],
+        defaultCDNService: CDNService.ali,
+        customCDNUrl: 'custom.cdn.test',
+      );
+
+      expect(
+        result,
+        'https://custom.cdn.test/upgcxcode/12/34/video.m4s?e=1',
+      );
+    });
+
+    test('does not replace API-like hosts', () {
+      final result = VideoUtils.getCdnUrl(
+        [
+          'https://api.bilibili.com/x/player/playurl?cid=1',
+          'https://upos-sz-mirrorali.bilivideo.com/upgcxcode/12/34/video.m4s',
+        ],
+        defaultCDNService: CDNService.ali,
+        customCDNUrl: 'custom.cdn.test',
+      );
+
+      expect(
+        result,
+        'https://custom.cdn.test/upgcxcode/12/34/video.m4s',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add support for custom video CDN hosts, inspired by the host override behavior in https://github.com/Kanda-Akihito-Kun/ccb.
- Replace known media CDN hosts while avoiding API-like hosts, and persist the custom host in settings.
- Integrate the custom CDN entry at the bottom of the existing CDN selector so no extra settings row is added.

## Details

- Supports entering either a host or a full URL, normalizing it to a host before saving.
- Custom CDN takes priority for video media URLs; choosing any built-in CDN clears the custom override.
- The player-side CDN menu and the video settings page share the same selector/result flow.
- Adds focused tests for host normalization, media CDN replacement, and API-host avoidance.
