### PR TITLE
fix: 修复楼中楼回复操作栏溢出

### DIFF
--- a/lib/pages/video/reply/widgets/reply_item_grpc.dart
+++ b/lib/pages/video/reply/widgets/reply_item_grpc.dart
@@ -456,71 +456,83 @@ class ReplyItemGrpc extends StatelessWidget {
       padding: WidgetStatePropertyAll(.zero),
     );
     return Row(
+      crossAxisAlignment: CrossAxisAlignment.end,
       children: [
         const SizedBox(width: 36),
-        SizedBox(
-          height: 32,
-          child: TextButton(
-            style: buttonStyle,
-            onPressed: () {
-              feedBack();
-              onReply?.call(replyItem);
-            },
-            child: Row(
-              spacing: 3,
-              mainAxisSize: .min,
-              children: [
-                Icon(
-                  Icons.reply,
-                  size: 18,
-                  color: theme.colorScheme.outline.withValues(alpha: 0.8),
+        Expanded(
+          child: Wrap(
+            spacing: 2,
+            runSpacing: 0,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              SizedBox(
+                height: 32,
+                child: TextButton(
+                  style: buttonStyle,
+                  onPressed: () {
+                    feedBack();
+                    onReply?.call(replyItem);
+                  },
+                  child: Row(
+                    spacing: 3,
+                    mainAxisSize: .min,
+                    children: [
+                      Icon(
+                        Icons.reply,
+                        size: 18,
+                        color: theme.colorScheme.outline.withValues(
+                          alpha: 0.8,
+                        ),
+                      ),
+                      Text('回复', style: textStyle),
+                    ],
+                  ),
                 ),
-                Text('回复', style: textStyle),
+              ),
+              if (replyControl.translationSwitch ==
+                  .TRANSLATION_SWITCH_SHOW_TRANSLATION) ...[
+                _buildTranslateBtn(
+                  context,
+                  theme,
+                  replyControl,
+                  textStyle,
+                  buttonStyle,
+                ),
+              ] else if (replyItem.replyControl.cardLabels.isNotEmpty) ...[
+                Text(
+                  replyItem.replyControl.cardLabels
+                      .map((e) => e.textContent)
+                      .join('  '),
+                  style: textStyle.copyWith(
+                    color: theme.colorScheme.secondary,
+                  ),
+                ),
               ],
-            ),
+              if (replyLevel == 2 &&
+                  needDivider &&
+                  replyItem.id != replyItem.dialog)
+                SizedBox(
+                  height: 32,
+                  child: TextButton(
+                    onPressed: showDialogue,
+                    style: buttonStyle,
+                    child: Text('查看对话', style: textStyle),
+                  ),
+                )
+              else if (replyLevel == 3 &&
+                  needDivider &&
+                  replyItem.parent != replyItem.root)
+                SizedBox(
+                  height: 32,
+                  child: TextButton(
+                    onPressed: jumpToDialogue,
+                    style: buttonStyle,
+                    child: Text('跳转回复', style: textStyle),
+                  ),
+                ),
+            ],
           ),
         ),
-        const SizedBox(width: 2),
-        if (replyControl.translationSwitch ==
-            .TRANSLATION_SWITCH_SHOW_TRANSLATION) ...[
-          _buildTranslateBtn(
-            context,
-            theme,
-            replyControl,
-            textStyle,
-            buttonStyle,
-          ),
-          const SizedBox(width: 2),
-        ] else if (replyItem.replyControl.cardLabels.isNotEmpty) ...[
-          Text(
-            replyItem.replyControl.cardLabels
-                .map((e) => e.textContent)
-                .join('  '),
-            style: textStyle.copyWith(color: theme.colorScheme.secondary),
-          ),
-          const SizedBox(width: 2),
-        ],
-        if (replyLevel == 2 && needDivider && replyItem.id != replyItem.dialog)
-          SizedBox(
-            height: 32,
-            child: TextButton(
-              onPressed: showDialogue,
-              style: buttonStyle,
-              child: Text('查看对话', style: textStyle),
-            ),
-          )
-        else if (replyLevel == 3 &&
-            needDivider &&
-            replyItem.parent != replyItem.root)
-          SizedBox(
-            height: 32,
-            child: TextButton(
-              onPressed: jumpToDialogue,
-              style: buttonStyle,
-              child: Text('跳转回复', style: textStyle),
-            ),
-          ),
-        const Spacer(),
         ZanButtonGrpc(replyItem: replyItem),
         const SizedBox(width: 5),
       ],


### PR DESCRIPTION
## 变更说明

修复楼中楼回复底部操作栏在内容过长时，点赞按钮被挤出可见区域的问题。

原先这里使用单行 `Row` 布局，当同时出现 `UP主觉得很赞`、`关注的人`、`查看对话` 等标签或操作时，右侧的点赞按钮可能会因为横向空间不足而被裁剪。

现在改为使用 `Wrap`，让这些操作项在宽度不足时自动换行，避免点赞 / 点踩按钮消失。

## 关联 Issue

Fixes #1925

## 测试

- `fvm flutter analyze lib/pages/video/reply/widgets/reply_item_grpc.dart`
- `fvm flutter build apk --debug`
