### PR TITLE
fix(ios): Rebuild decode pipeline and restore hwdec on iOS resume from background

### DIFF
--- a/lib/pages/video/controller.dart
+++ b/lib/pages/video/controller.dart
@@ -747,6 +747,8 @@ class VideoDetailController extends GetxController
     if (seek == null || seek == Duration.zero) {
       seek = getFirstSegment();
     }
+    plPlayerController.onAfterIosMediaReopened =
+        () => setSubtitle(vttSubtitlesIndex.value);
     await plPlayerController.setDataSource(
       isFileSource
           ? FileSource(
@@ -1262,6 +1264,7 @@ class VideoDetailController extends GetxController
 
   @override
   void onClose() {
+    plPlayerController.onAfterIosMediaReopened = null;
     cid.close();
     if (isFileSource) {
       cacheLocalProgress();

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -1715,6 +1715,7 @@ class PlPlayerController with BlockConfigMixin {
       final resumePosition = player.state.position;
       final media = player.current.last.copyWith(start: resumePosition);
 
+      danmakuController?.clear();
       player.setProperty('hwdec', hwdec!);
       await player.open(media, play: false);
       await player.setRate(_playbackSpeed.value);

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -1718,15 +1718,32 @@ class PlPlayerController with BlockConfigMixin {
       danmakuController?.clear();
       player.setProperty('hwdec', hwdec!);
       await player.open(media, play: false);
-      await player.setRate(_playbackSpeed.value);
+
+      if (isLive) {
+        await setPlaybackSpeed(1.0);
+      } else if (_videoPlayerController?.state.rate != _playbackSpeed.value) {
+        await setPlaybackSpeed(_playbackSpeed.value);
+      }
+
+      if (isAnim && superResolutionType.value != SuperResolutionType.disable) {
+        try {
+          await setShader();
+        } catch (e, st) {
+          if (kDebugMode) {
+            debugPrint('recover: setShader failed: $e\n$st');
+          }
+        }
+      }
+      _initVideoFit();
 
       position = resumePosition;
       updatePositionSecond();
       sliderPosition = resumePosition;
       updateSliderPositionSecond();
+      _heartDuration = resumePosition.inSeconds;
 
       if (shouldPlay) {
-        await player.play();
+        await play(hideControls: true);
       }
       await onAfterIosMediaReopened?.call();
     } catch (err, stackTrace) {

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -164,6 +164,9 @@ class PlPlayerController with BlockConfigMixin {
 
   late DataSource dataSource;
 
+  /// After iOS hwdec recovery [Player.open], mirroring [setDataSource] `onInit` (e.g. subtitles).
+  Future<void> Function()? onAfterIosMediaReopened;
+
   Timer? _timer;
   StreamSubscription<Duration>? _subForSeek;
 
@@ -1625,6 +1628,7 @@ class PlPlayerController with BlockConfigMixin {
       showSystemBar();
     }
     danmakuController = null;
+    onAfterIosMediaReopened = null;
     _stopOrientationListener();
     _disableAutoEnterPip();
     setPlayCallBack(null);
@@ -1723,6 +1727,7 @@ class PlPlayerController with BlockConfigMixin {
       if (shouldPlay) {
         await player.play();
       }
+      await onAfterIosMediaReopened?.call();
     } catch (err, stackTrace) {
       if (kDebugMode) {
         debugPrint('recover hwdec after resume failed: $err');

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -1734,9 +1734,20 @@ class PlPlayerController with BlockConfigMixin {
   }
 
   Future<void> onAppResumed({bool shouldResumePlayback = false}) async {
-    await _recoverIosHwdecAfterResume(
-      shouldResumePlayback: shouldResumePlayback,
-    );
+    if (!Platform.isIOS) {
+      return;
+    }
+    final player = _videoPlayerController;
+    final needsIosHwdecRecovery = hwdec != null &&
+        !onlyPlayAudio.value &&
+        (shouldResumePlayback || (player?.state.playing ?? false));
+    if (needsIosHwdecRecovery) {
+      await _recoverIosHwdecAfterResume(
+        shouldResumePlayback: shouldResumePlayback,
+      );
+    } else if (shouldResumePlayback) {
+      await player?.play();
+    }
   }
 
   late final Map<String, ui.Image?> previewCache = {};

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -900,6 +900,8 @@ class PlPlayerController with BlockConfigMixin {
     return null;
   }
 
+  bool _recoveringHwdec = false;
+
   // 开始播放
   Future<void> _initializePlayer() async {
     if (_instance == null) return;
@@ -1687,6 +1689,53 @@ class PlPlayerController with BlockConfigMixin {
     onlyPlayAudio.value = !onlyPlayAudio.value;
     videoPlayerController?.setVideoTrack(
       onlyPlayAudio.value ? VideoTrack.no() : VideoTrack.auto(),
+    );
+  }
+
+  // iOS 从后台恢复时，重建解码链路并恢复 hwdec。
+  Future<void> _recoverIosHwdecAfterResume({
+    bool shouldResumePlayback = false,
+  }) async {
+    if (!Platform.isIOS || hwdec == null) {
+      return;
+    }
+
+    final player = _videoPlayerController;
+    if (player == null || player.current.isEmpty || _recoveringHwdec) {
+      return;
+    }
+
+    _recoveringHwdec = true;
+    try {
+      final shouldPlay = shouldResumePlayback || player.state.playing;
+      final resumePosition = player.state.position;
+      final media = player.current.last.copyWith(start: resumePosition);
+
+      player.setProperty('hwdec', hwdec!);
+      await player.open(media, play: false);
+      await player.setRate(_playbackSpeed.value);
+
+      position = resumePosition;
+      updatePositionSecond();
+      sliderPosition = resumePosition;
+      updateSliderPositionSecond();
+
+      if (shouldPlay) {
+        await player.play();
+      }
+    } catch (err, stackTrace) {
+      if (kDebugMode) {
+        debugPrint('recover hwdec after resume failed: $err');
+        debugPrint(stackTrace.toString());
+      }
+    } finally {
+      _recoveringHwdec = false;
+    }
+  }
+
+  Future<void> onAppResumed({bool shouldResumePlayback = false}) async {
+    await _recoverIosHwdecAfterResume(
+      shouldResumePlayback: shouldResumePlayback,
     );
   }
 

--- a/lib/plugin/pl_player/view/view.dart
+++ b/lib/plugin/pl_player/view/view.dart
@@ -300,18 +300,27 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (!plPlayerController.continuePlayInBackground.value) {
-      late final player = plPlayerController.videoPlayerController;
-      if (const <AppLifecycleState>[.paused, .detached].contains(state)) {
-        if (player != null && player.state.playing) {
-          _pauseDueToPauseUponEnteringBackgroundMode = true;
-          player.pause();
-        }
-      } else {
-        if (_pauseDueToPauseUponEnteringBackgroundMode) {
-          _pauseDueToPauseUponEnteringBackgroundMode = false;
-          player?.play();
-        }
+    final player = plPlayerController.videoPlayerController;
+    if (!plPlayerController.continuePlayInBackground.value &&
+        const <AppLifecycleState>[.paused, .detached].contains(state)) {
+      if (player != null && player.state.playing) {
+        _pauseDueToPauseUponEnteringBackgroundMode = true;
+        player.pause();
+      }
+    }
+
+    if (state == AppLifecycleState.resumed) {
+      final shouldResumePlayback = _pauseDueToPauseUponEnteringBackgroundMode;
+      _pauseDueToPauseUponEnteringBackgroundMode = false;
+      if (Platform.isIOS) {
+        // iOS 恢复前台时交由 controller 恢复硬解链路
+        unawaited(
+          plPlayerController.onAppResumed(
+            shouldResumePlayback: shouldResumePlayback,
+          ),
+        );
+      } else if (shouldResumePlayback) {
+        player?.play();
       }
     }
   }

--- a/lib/plugin/pl_player/view/view.dart
+++ b/lib/plugin/pl_player/view/view.dart
@@ -313,7 +313,6 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
       final shouldResumePlayback = _pauseDueToPauseUponEnteringBackgroundMode;
       _pauseDueToPauseUponEnteringBackgroundMode = false;
       if (Platform.isIOS) {
-        // iOS 恢复前台时交由 controller 恢复硬解链路
         unawaited(
           plPlayerController.onAppResumed(
             shouldResumePlayback: shouldResumePlayback,


### PR DESCRIPTION
Fixes #1960 
# Summary
On iOS, returning the app to the foreground could leave hardware decode in a bad state. This change rebuilds the decode path on resume by reapplying hwdec, reopening the current item at the saved position, restoring playback speed and UI position, and resuming playback when appropriate.

# Details
- `PlPlayerController`: Add `_recoverIosHwdecAfterResume` (guarded by platform, `hwdec`, non-empty `current`, and a re-entrancy flag) and a public `onAppResumed({shouldResumePlayback})` entry point.
- `PLVideoPlayer` lifecycle: On `AppLifecycleState.resumed`, call `onAppResumed` on iOS (non-blocking). Non‑iOS still uses a simple play() when playback had been paused due to backgrounding. Pause-on-background behavior is unchanged for the “don’t continue in background” case.

# Test plan
- [x] iPhone (physical device): play with hardware decode → background → foreground; decode/video recovers without needing a manual workaround.
