### PR TITLE
feat: desktop auto-play next episode and keyboard shortcuts

### DIFF
--- a/lib/pages/setting/models/play_settings.dart
+++ b/lib/pages/setting/models/play_settings.dart
@@ -251,6 +251,13 @@ List<SettingsModel> get playSettings => [
       onChanged: (value) =>
           videoPlayerServiceHandler!.enableBackgroundPlay = value,
     ),
+  const SwitchModel(
+    title: '自动播放下一集',
+    subtitle: '播放完当前视频后自动播放下一集（播放顺序为"播完暂停"时生效）',
+    leading: Icon(Icons.skip_next_outlined),
+    setKey: SettingBoxKey.autoPlayNext,
+    defaultVal: true,
+  ),
   PopupModel(
     title: '播放顺序',
     leading: const Icon(Icons.repeat),

--- a/lib/pages/video/view.dart
+++ b/lib/pages/video/view.dart
@@ -60,6 +60,7 @@ import 'package:PiliPlus/utils/num_utils.dart';
 import 'package:PiliPlus/utils/page_utils.dart';
 import 'package:PiliPlus/utils/storage.dart';
 import 'package:PiliPlus/utils/storage_key.dart';
+import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:PiliPlus/utils/theme_utils.dart';
 import 'package:extended_nested_scroll_view/extended_nested_scroll_view.dart';
 import 'package:floating/floating.dart';
@@ -260,6 +261,9 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
           case PlayRepeat.autoPlayRelated:
             exitFlag = !introController.nextPlay();
           case PlayRepeat.pause:
+            if (Pref.autoPlayNext) {
+              exitFlag = !introController.nextPlay();
+            }
         }
       }
 

--- a/lib/pages/video/widgets/player_focus.dart
+++ b/lib/pages/video/widgets/player_focus.dart
@@ -265,7 +265,8 @@ class PlayerFocus extends StatelessWidget {
             }
             return true;
 
-          case LogicalKeyboardKey.bracketLeft:
+          case LogicalKeyboardKey.bracketLeft ||
+              LogicalKeyboardKey.braceLeft:
             if (introController case final introController?) {
               if (!introController.prevPlay()) {
                 SmartDialog.showToast('已经是第一集了');
@@ -273,7 +274,8 @@ class PlayerFocus extends StatelessWidget {
             }
             return true;
 
-          case LogicalKeyboardKey.bracketRight:
+          case LogicalKeyboardKey.bracketRight ||
+              LogicalKeyboardKey.braceRight:
             if (introController case final introController?) {
               if (!introController.nextPlay()) {
                 SmartDialog.showToast('已经是最后一集了');

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -153,6 +153,8 @@ abstract final class SettingBoxKey {
       floatingNavBar = 'floatingNavBar',
       removeSafeArea = 'removeSafeArea';
 
+  static const String autoPlayNext = 'autoPlayNext';
+
   static const String minimizeOnExit = 'minimizeOnExit',
       windowSize = 'windowSize',
       windowPosition = 'windowPosition',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -836,6 +836,9 @@ abstract final class Pref {
   static double get defaultToastOp =>
       _setting.get(SettingBoxKey.defaultToastOp, defaultValue: 1.0);
 
+  static bool get autoPlayNext =>
+      _setting.get(SettingBoxKey.autoPlayNext, defaultValue: true);
+
   static PlayRepeat get playRepeat =>
       PlayRepeat.values[_video.get(
         VideoBoxKey.playRepeat,


### PR DESCRIPTION
- 新增 `{`、`}` 快捷键，与 `[`、`]` 等价，用于切换上一集/下一集
- 新增"自动播放下一集"设置项（默认开启）
- 当播放顺序为"播完暂停"时，若开启设置则自动播放下一集
- 适配桌面端画中画模式，PiP 状态下保持自动播放与快捷键可用