### PR TITLE
feat: 新增平板模式竖屏播放页转横屏时全屏选项

### DIFF
--- a/lib/pages/setting/models/play_settings.dart
+++ b/lib/pages/setting/models/play_settings.dart
@@ -188,6 +188,14 @@ List<SettingsModel> get playSettings => [
       setKey: SettingBoxKey.continuePlayInBackground,
       defaultVal: false,
     ),
+  if (PlatformUtils.isMobile)
+    const SwitchModel(
+      title: '平板模式竖屏播放页转横屏时全屏',
+      subtitle: '当开启时，在平板/横屏布局模式下，竖屏旋转到横屏自动全屏',
+      leading: Icon(Icons.screen_rotation_alt_outlined),
+      setKey: SettingBoxKey.enableLandscapeAutoFullscreen,
+      defaultVal: false,
+    ),
   if (Platform.isAndroid) ...[
     SwitchModel(
       title: '后台画中画',

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -365,6 +365,8 @@ class PlPlayerController with BlockConfigMixin {
   late final bool autoExitFullscreen = Pref.autoExitFullscreen;
   late final bool autoPlayEnable = Pref.autoPlayEnable;
   late final bool enableVerticalExpand = Pref.enableVerticalExpand;
+  late final bool enableLandscapeAutoFullscreen =
+      Pref.enableLandscapeAutoFullscreen;
   late final bool pipNoDanmaku = Pref.pipNoDanmaku;
 
   late final bool tempPlayerConf = Pref.tempPlayerConf;
@@ -512,6 +514,7 @@ class PlPlayerController with BlockConfigMixin {
   bool visible = true;
 
   DeviceOrientation? _orientation;
+  bool _initialOrientationHandled = false;
   late final checkIsAutoRotate = Platform.isAndroid && mode != .gravity;
   StreamSubscription<OrientationParams>? _orientationListener;
 
@@ -523,6 +526,12 @@ class PlPlayerController with BlockConfigMixin {
   void _onOrientationChanged(OrientationParams param) {
     _orientation = param.orientation;
     if (!visible) return;
+    if (!_initialOrientationHandled) {
+      _initialOrientationHandled = true;
+      if (enableLandscapeAutoFullscreen) {
+        return;
+      }
+    }
     final orientation = param.orientation;
     final isFullScreen = this.isFullScreen.value;
     if (checkIsAutoRotate &&
@@ -536,7 +545,8 @@ class PlPlayerController with BlockConfigMixin {
     switch (orientation) {
       case .portraitUp:
         if (!_isVertical && controlsLock.value) return;
-        if (!horizontalScreen && !_isVertical && isFullScreen) {
+        if (!_isVertical && isFullScreen &&
+            (!horizontalScreen || enableLandscapeAutoFullscreen)) {
           if (!isManualFS) {
             triggerFullScreen(status: false, orientation: orientation);
           }
@@ -548,13 +558,15 @@ class PlPlayerController with BlockConfigMixin {
         if (!_isVertical && controlsLock.value) return;
         portraitDownMode();
       case .landscapeLeft:
-        if (!horizontalScreen && !isFullScreen) {
+        if ((!horizontalScreen || enableLandscapeAutoFullscreen) &&
+            !isFullScreen) {
           triggerFullScreen(orientation: orientation, isManualFS: false);
         } else {
           landscapeLeftMode();
         }
       case .landscapeRight:
-        if (!horizontalScreen && !isFullScreen) {
+        if ((!horizontalScreen || enableLandscapeAutoFullscreen) &&
+            !isFullScreen) {
           triggerFullScreen(orientation: orientation, isManualFS: false);
         } else {
           landscapeRightMode();

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -151,7 +151,8 @@ abstract final class SettingBoxKey {
       showDynDispute = 'showDynDispute',
       touchSlopH = 'touchSlopH',
       floatingNavBar = 'floatingNavBar',
-      removeSafeArea = 'removeSafeArea';
+      removeSafeArea = 'removeSafeArea',
+      enableLandscapeAutoFullscreen = 'enableLandscapeAutoFullscreen';
 
   static const String minimizeOnExit = 'minimizeOnExit',
       windowSize = 'windowSize',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -978,4 +978,7 @@ abstract final class Pref {
 
   static bool get removeSafeArea =>
       _setting.get(SettingBoxKey.removeSafeArea, defaultValue: false);
+
+  static bool get enableLandscapeAutoFullscreen =>
+      _setting.get(SettingBoxKey.enableLandscapeAutoFullscreen, defaultValue: false);
 }


### PR DESCRIPTION
# 新增平板模式竖屏播放页转横屏时全屏选项

## 概述
为平板/横屏布局模式新增一个设置开关，允许用户在竖屏播放页旋转到横屏时自动进入全屏，弥补了原横屏布局模式下旋转全屏功能被屏蔽的问题。

## 修改内容
- `lib/utils/storage_key.dart`：新增 `enableLandscapeAutoFullscreen` 配置键
- `lib/utils/storage_pref.dart`：新增 `Pref.enableLandscapeAutoFullscreen` getter，默认 `false`
- `lib/pages/setting/models/play_settings.dart`：新增 `SwitchModel` 开关项（仅移动端显示）
- `lib/plugin/pl_player/controller.dart`：
  - 在 `_onOrientationChanged` 中修改 `landscape/portrait` 逻辑，当开关开启时，`horizontalScreen` 不再屏蔽旋转全屏
  - 新增 `_initialOrientationHandled` 标志位，避免进入播放页时初始横屏方向误触自动全屏

## 行为说明
| 开关状态       | 竖屏进入播放页 | 横屏进入播放页 | 竖屏→横屏旋转 | 横屏→竖屏旋转 |
|----------------|----------------|----------------|---------------|---------------|
| 关闭（默认）   | 无全屏         | 无全屏         | 无全屏        | 无全屏        |
| 开启           | 无全屏         | 无全屏         | 自动全屏      | 退出全屏      |
