### PR TITLE
feat: add AV number display, copy and AV link sharing options

### DIFF
--- a/lib/common/widgets/video_popup_menu.dart
+++ b/lib/common/widgets/video_popup_menu.dart
@@ -10,6 +10,7 @@ import 'package:PiliPlus/pages/search/widgets/search_text.dart';
 import 'package:PiliPlus/pages/video/ai_conclusion/view.dart';
 import 'package:PiliPlus/pages/video/introduction/ugc/controller.dart';
 import 'package:PiliPlus/utils/accounts.dart';
+import 'package:PiliPlus/utils/id_utils.dart';
 import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:PiliPlus/utils/utils.dart';
 import 'package:flutter/material.dart';
@@ -55,6 +56,11 @@ class VideoPopupMenu extends StatelessWidget {
                     videoItem.bvid!,
                     const Icon(CustomIcons.identifier_circle, size: 16),
                     () => Utils.copyText(videoItem.bvid!),
+                  ),
+                  _VideoCustomAction(
+                    'av${IdUtils.bv2av(videoItem.bvid!)}',
+                    const Icon(CustomIcons.identifier_circle, size: 16),
+                    () => Utils.copyText('av${IdUtils.bv2av(videoItem.bvid!)}'),
                   ),
                   _VideoCustomAction(
                     '稍后再看',

--- a/lib/pages/member_search/child/widgets/search_archive_grpc.dart
+++ b/lib/pages/member_search/child/widgets/search_archive_grpc.dart
@@ -32,7 +32,8 @@ class SearchArchiveGrpc extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final arc = item.archive;
-    final bvid = IdUtils.av2bv(arc.aid.toInt());
+    final aid = arc.aid.toInt();
+    final bvid = IdUtils.av2bv(aid);
     final regTitle = Em.regTitle(arc.title);
     final titleStr = regTitle.map((e) => e.text).join();
     void onLongPress() => imageSaveDialog(
@@ -135,6 +136,20 @@ class SearchArchiveGrpc extends StatelessWidget {
                     children: [
                       const Icon(CustomIcons.identifier_circle, size: 16),
                       Text(bvid, style: const TextStyle(fontSize: 13)),
+                    ],
+                  ),
+                ),
+                PopupMenuItem(
+                  height: 45,
+                  onTap: () => Utils.copyText('av$aid'),
+                  child: Row(
+                    spacing: 6,
+                    children: [
+                      const Icon(CustomIcons.identifier_circle, size: 16),
+                      Text(
+                        'av$aid',
+                        style: const TextStyle(fontSize: 13),
+                      ),
                     ],
                   ),
                 ),

--- a/lib/pages/video/introduction/ugc/controller.dart
+++ b/lib/pages/video/introduction/ugc/controller.dart
@@ -15,6 +15,7 @@ import 'package:PiliPlus/models/common/video/source_type.dart';
 import 'package:PiliPlus/models_new/member_card_info/data.dart';
 import 'package:PiliPlus/models_new/relation/data.dart';
 import 'package:PiliPlus/models_new/video/video_ai_conclusion/model_result.dart';
+import 'package:PiliPlus/models_new/video/video_detail/data.dart';
 import 'package:PiliPlus/models_new/video/video_detail/dimension.dart';
 import 'package:PiliPlus/models_new/video/video_detail/episode.dart';
 import 'package:PiliPlus/models_new/video/video_detail/page.dart';
@@ -311,9 +312,54 @@ class UgcIntroController extends CommonIntroController with ReloadMixin {
   // 分享视频
   @override
   void actionShareVideo(BuildContext context) {
+    Widget buildTitle(String label, VoidCallback onTap, {Widget? trailing}) {
+      return ListTile(
+        dense: true,
+        title: Text(label, style: const TextStyle(fontSize: 14)),
+        onTap: () {
+          Get.back();
+          onTap();
+        },
+        trailing: trailing,
+      );
+    }
+
+    Widget buildCopyTitle(String idType, String playedTimePos, String url) {
+      return buildTitle(
+        '复制 $idType 链接',
+        () => Utils.copyText(url),
+        trailing: playedTimePos.isNotEmpty
+            ? iconButton(
+                tooltip: '精确分享',
+                icon: const Icon(Icons.timer_outlined),
+                onPressed: () {
+                  Get.back();
+                  Utils.copyText('$url$playedTimePos');
+                },
+              )
+            : null,
+      );
+    }
+
+    Widget buildShareTitle(
+      String idType,
+      VideoDetailData videoDetail,
+      String url,
+    ) {
+      return buildTitle(
+        '分享视频 ($idType)',
+        () => ShareUtils.shareText(
+          '${videoDetail.title} '
+          'UP主: ${videoDetail.owner!.name!}'
+          ' - $url',
+        ),
+      );
+    }
+
     final videoDetail = this.videoDetail.value;
     final playedTimePos = videoDetailCtr.playedTimePos;
-    String videoUrl = '${HttpString.baseUrl}/video/$bvid';
+    String videoBvUrl = '${HttpString.baseUrl}/video/$bvid';
+    String videoAvUrl = '${HttpString.baseUrl}/video/av${getFavRidType.$1}';
     showDialog(
       context: context,
       builder: (_) => AlertDialog(
@@ -322,27 +368,8 @@ class UgcIntroController extends CommonIntroController with ReloadMixin {
         content: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            ListTile(
-              dense: true,
-              title: const Text(
-                '复制链接',
-                style: TextStyle(fontSize: 14),
-              ),
-              onTap: () {
-                Get.back();
-                Utils.copyText(videoUrl);
-              },
-              trailing: playedTimePos.isNotEmpty
-                  ? iconButton(
-                      tooltip: '精确分享',
-                      icon: const Icon(Icons.timer_outlined),
-                      onPressed: () {
-                        Get.back();
-                        Utils.copyText('$videoUrl$playedTimePos');
-                      },
-                    )
-                  : null,
-            ),
+            buildCopyTitle('BV', playedTimePos, videoBvUrl),
+            buildCopyTitle('AV', playedTimePos, videoAvUrl),
             ListTile(
               dense: true,
               title: const Text(
@@ -351,25 +378,13 @@ class UgcIntroController extends CommonIntroController with ReloadMixin {
               ),
               onTap: () {
                 Get.back();
-                PageUtils.launchURL(videoUrl);
+                PageUtils.launchURL(videoBvUrl);
               },
             ),
-            if (PlatformUtils.isMobile)
-              ListTile(
-                dense: true,
-                title: const Text(
-                  '分享视频',
-                  style: TextStyle(fontSize: 14),
-                ),
-                onTap: () {
-                  Get.back();
-                  ShareUtils.shareText(
-                    '${videoDetail.title} '
-                    'UP主: ${videoDetail.owner!.name!}'
-                    ' - $videoUrl',
-                  );
-                },
-              ),
+            if (PlatformUtils.isMobile) ...[
+              buildShareTitle('BV', videoDetail, videoBvUrl),
+              buildShareTitle('AV', videoDetail, videoAvUrl),
+            ],
             ListTile(
               dense: true,
               title: const Text(

--- a/lib/pages/video/introduction/ugc/view.dart
+++ b/lib/pages/video/introduction/ugc/view.dart
@@ -343,6 +343,17 @@ class _UgcIntroPanelState extends State<UgcIntroPanel> {
         ),
       ),
     ),
+    if (videoDetail.aid != null)
+      GestureDetector(
+        onTap: () => Utils.copyText('av${videoDetail.aid}'),
+        child: Text(
+          'av${videoDetail.aid}',
+          style: TextStyle(
+            fontSize: 14,
+            color: theme.colorScheme.secondary,
+          ),
+        ),
+      ),
     if (videoDetail.descV2?.isNotEmpty == true) ...[
       const SizedBox(height: 8),
       selectableRichText(


### PR DESCRIPTION
## 改动概述
本 PR 在多个入口增加了 AV 号的显示与复制功能，并修改了视频分享弹窗，使其同时支持 BV 和 AV 链接的复制与分享。解决了 #2096 中提出的需求。

## 具体变更
- **视频详情页简介区**：当 `aid` 不为空时，在 BV 号下方显示 `avXXXX`，点击可复制。
- **视频列表弹出菜单**：在原有 BV 号复制选项下方增加复制 AV 号选项。
- **搜索结果弹出菜单**：同样增加复制 AV 号选项。
- **视频分享弹窗**：  现在弹窗内提供 **复制 BV 链接**、**复制 AV 链接**（均支持带当前播放进度的精确分享）以及对应的 **分享视频** 入口。