### PR TITLE
Support Windows media play pause key/支持windows媒体暂停热键

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ import 'package:PiliPlus/services/account_service.dart';
 import 'package:PiliPlus/services/download/download_service.dart';
 import 'package:PiliPlus/services/logger.dart';
 import 'package:PiliPlus/services/service_locator.dart';
+import 'package:PiliPlus/services/windows_media_control_service.dart';
 import 'package:PiliPlus/utils/cache_manager.dart';
 import 'package:PiliPlus/utils/calc_window_position.dart';
 import 'package:PiliPlus/utils/date_utils.dart';
@@ -115,6 +116,7 @@ void main() async {
       setupServiceLocator(),
     ]);
   } else if (Platform.isWindows) {
+    WindowsMediaControlService.init();
     if (await WebViewEnvironment.getAvailableVersion() != null) {
       webViewEnvironment = await WebViewEnvironment.create(
         settings: WebViewEnvironmentSettings(

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -29,6 +29,7 @@ import 'package:PiliPlus/plugin/pl_player/models/play_status.dart';
 import 'package:PiliPlus/plugin/pl_player/models/video_fit_type.dart';
 import 'package:PiliPlus/plugin/pl_player/utils/fullscreen.dart';
 import 'package:PiliPlus/services/service_locator.dart';
+import 'package:PiliPlus/services/windows_media_control_service.dart';
 import 'package:PiliPlus/utils/accounts.dart';
 import 'package:PiliPlus/utils/android/android_helper.dart';
 import 'package:PiliPlus/utils/android/bindings.g.dart';
@@ -493,6 +494,22 @@ class PlPlayerController with BlockConfigMixin {
     }
   }
 
+  static void _enableWindowsMediaControls() {
+    if (!Platform.isWindows) return;
+    WindowsMediaControlService.setHandlers(
+      onPlay: playCurrentIfExists,
+      onPause: pauseIfExists,
+      onPlayPause: playOrPauseIfExists,
+    );
+    WindowsMediaControlService.enablePlayPauseHotKey();
+  }
+
+  static void _disableWindowsMediaControls() {
+    if (!Platform.isWindows) return;
+    WindowsMediaControlService.clearHandlers();
+    WindowsMediaControlService.disablePlayPauseHotKey();
+  }
+
   // try to get PlayerStatus
   static PlayerStatus? getPlayerStatusIfExists() {
     return _instance?.playerStatus.value;
@@ -855,6 +872,7 @@ class PlPlayerController with BlockConfigMixin {
         return;
       }
       _videoPlayerController = player;
+      _enableWindowsMediaControls();
       if (isAnim && superResolutionType.value != .disable) {
         await setShader();
       }
@@ -1677,6 +1695,7 @@ class PlPlayerController with BlockConfigMixin {
     _videoPlayerController = null;
     _videoController = null;
     _instance = null;
+    _disableWindowsMediaControls();
     videoPlayerServiceHandler?.clear();
   }
 

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -477,6 +477,18 @@ class PlPlayerController with BlockConfigMixin {
     return _playCallBack?.call();
   }
 
+  static Future<void>? playCurrentIfExists() {
+    return _instance?.play();
+  }
+
+  static Future<void> playOrPauseIfExists() async {
+    if (_instance?.playerStatus.isPlaying ?? false) {
+      await pauseIfExists();
+    } else {
+      await playCurrentIfExists();
+    }
+  }
+
   // try to get PlayerStatus
   static PlayerStatus? getPlayerStatusIfExists() {
     return _instance?.playerStatus.value;

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -477,15 +477,19 @@ class PlPlayerController with BlockConfigMixin {
     return _playCallBack?.call();
   }
 
-  static Future<void>? playCurrentIfExists() {
-    return _instance?.play();
+  static Future<void> playCurrentIfExists() {
+    return _instance?.play() ?? Future.value();
   }
 
   static Future<void> playOrPauseIfExists() async {
-    if (_instance?.playerStatus.isPlaying ?? false) {
-      await pauseIfExists();
+    final instance = _instance;
+    if (instance == null) {
+      return;
+    }
+    if (instance.playerStatus.value.isPlaying) {
+      await instance.pause();
     } else {
-      await playCurrentIfExists();
+      await instance.play();
     }
   }
 

--- a/lib/services/windows_media_control_service.dart
+++ b/lib/services/windows_media_control_service.dart
@@ -1,11 +1,16 @@
-import 'package:PiliPlus/plugin/pl_player/controller.dart';
 import 'package:flutter/services.dart';
+
+typedef MediaControlHandler = Future<void> Function();
 
 class WindowsMediaControlService {
   WindowsMediaControlService._();
 
   static const MethodChannel _channel = MethodChannel('PiliPlus');
   static bool _initialized = false;
+  static bool _playPauseHotKeyEnabled = false;
+  static MediaControlHandler? _onPlay;
+  static MediaControlHandler? _onPause;
+  static MediaControlHandler? _onPlayPause;
 
   static void init() {
     if (_initialized) return;
@@ -13,16 +18,48 @@ class WindowsMediaControlService {
     _channel.setMethodCallHandler(_handleMethodCall);
   }
 
+  static void setHandlers({
+    MediaControlHandler? onPlay,
+    MediaControlHandler? onPause,
+    MediaControlHandler? onPlayPause,
+  }) {
+    _onPlay = onPlay;
+    _onPause = onPause;
+    _onPlayPause = onPlayPause;
+  }
+
+  static void clearHandlers() {
+    _onPlay = null;
+    _onPause = null;
+    _onPlayPause = null;
+  }
+
+  static Future<void> enablePlayPauseHotKey() async {
+    if (_playPauseHotKeyEnabled) {
+      return;
+    }
+    await _channel.invokeMethod('SystemMediaControl.enablePlayPauseHotKey');
+    _playPauseHotKeyEnabled = true;
+  }
+
+  static Future<void> disablePlayPauseHotKey() async {
+    if (!_playPauseHotKeyEnabled) {
+      return;
+    }
+    await _channel.invokeMethod('SystemMediaControl.disablePlayPauseHotKey');
+    _playPauseHotKeyEnabled = false;
+  }
+
   static Future<void> _handleMethodCall(MethodCall call) async {
     switch (call.method) {
       case 'SystemMediaControl.playPause':
-        await PlPlayerController.playOrPauseIfExists();
+        await _onPlayPause?.call();
         return;
       case 'SystemMediaControl.play':
-        await PlPlayerController.playCurrentIfExists();
+        await _onPlay?.call();
         return;
       case 'SystemMediaControl.pause':
-        await PlPlayerController.pauseIfExists();
+        await _onPause?.call();
         return;
       default:
         throw MissingPluginException(

--- a/lib/services/windows_media_control_service.dart
+++ b/lib/services/windows_media_control_service.dart
@@ -24,6 +24,10 @@ class WindowsMediaControlService {
       case 'SystemMediaControl.pause':
         await PlPlayerController.pauseIfExists();
         return;
+      default:
+        throw MissingPluginException(
+          'No implementation found for method ${call.method} on channel PiliPlus',
+        );
     }
   }
 }

--- a/lib/services/windows_media_control_service.dart
+++ b/lib/services/windows_media_control_service.dart
@@ -1,0 +1,29 @@
+import 'package:PiliPlus/plugin/pl_player/controller.dart';
+import 'package:flutter/services.dart';
+
+class WindowsMediaControlService {
+  WindowsMediaControlService._();
+
+  static const MethodChannel _channel = MethodChannel('PiliPlus');
+  static bool _initialized = false;
+
+  static void init() {
+    if (_initialized) return;
+    _initialized = true;
+    _channel.setMethodCallHandler(_handleMethodCall);
+  }
+
+  static Future<void> _handleMethodCall(MethodCall call) async {
+    switch (call.method) {
+      case 'SystemMediaControl.playPause':
+        await PlPlayerController.playOrPauseIfExists();
+        return;
+      case 'SystemMediaControl.play':
+        await PlPlayerController.playCurrentIfExists();
+        return;
+      case 'SystemMediaControl.pause':
+        await PlPlayerController.pauseIfExists();
+        return;
+    }
+  }
+}

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -10,6 +10,14 @@ namespace {
 
 constexpr int kMediaPlayPauseHotKeyId = 1;
 constexpr UINT kMediaPlayPauseKey = VK_MEDIA_PLAY_PAUSE;
+constexpr char kSystemMediaPlayPauseMethod[] =
+    "SystemMediaControl.playPause";
+constexpr char kSystemMediaPlayMethod[] = "SystemMediaControl.play";
+constexpr char kSystemMediaPauseMethod[] = "SystemMediaControl.pause";
+constexpr char kEnablePlayPauseHotKeyMethod[] =
+    "SystemMediaControl.enablePlayPauseHotKey";
+constexpr char kDisablePlayPauseHotKeyMethod[] =
+    "SystemMediaControl.disablePlayPauseHotKey";
 
 void InvokeMediaControl(
     const std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>&
@@ -47,9 +55,20 @@ bool FlutterWindow::OnCreate() {
       std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
           flutter_controller_->engine()->messenger(), "PiliPlus",
           &flutter::StandardMethodCodec::GetInstance());
-  media_play_pause_hot_key_registered_ =
-      RegisterHotKey(GetHandle(), kMediaPlayPauseHotKeyId, MOD_NOREPEAT,
-                     kMediaPlayPauseKey) != 0;
+  media_control_channel_->SetMethodCallHandler(
+      [this](const flutter::MethodCall<flutter::EncodableValue>& call,
+             std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>
+                 result) {
+        if (call.method_name() == kEnablePlayPauseHotKeyMethod) {
+          EnableMediaPlayPauseHotKey();
+          result->Success();
+        } else if (call.method_name() == kDisablePlayPauseHotKeyMethod) {
+          DisableMediaPlayPauseHotKey();
+          result->Success();
+        } else {
+          result->NotImplemented();
+        }
+      });
 
   SetChildContent(flutter_controller_->view()->GetNativeWindow());
 
@@ -66,10 +85,7 @@ bool FlutterWindow::OnCreate() {
 }
 
 void FlutterWindow::OnDestroy() {
-  if (media_play_pause_hot_key_registered_) {
-    UnregisterHotKey(GetHandle(), kMediaPlayPauseHotKeyId);
-    media_play_pause_hot_key_registered_ = false;
-  }
+  DisableMediaPlayPauseHotKey();
   media_control_channel_ = nullptr;
 
   if (flutter_controller_) {
@@ -79,6 +95,23 @@ void FlutterWindow::OnDestroy() {
   Win32Window::OnDestroy();
 }
 
+void FlutterWindow::EnableMediaPlayPauseHotKey() {
+  if (media_play_pause_hot_key_registered_) {
+    return;
+  }
+  media_play_pause_hot_key_registered_ =
+      RegisterHotKey(GetHandle(), kMediaPlayPauseHotKeyId, MOD_NOREPEAT,
+                     kMediaPlayPauseKey) != 0;
+}
+
+void FlutterWindow::DisableMediaPlayPauseHotKey() {
+  if (!media_play_pause_hot_key_registered_) {
+    return;
+  }
+  UnregisterHotKey(GetHandle(), kMediaPlayPauseHotKeyId);
+  media_play_pause_hot_key_registered_ = false;
+}
+
 LRESULT
 FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
                               WPARAM const wparam,
@@ -86,8 +119,7 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
   switch (message) {
     case WM_HOTKEY:
       if (wparam == kMediaPlayPauseHotKeyId) {
-        InvokeMediaControl(media_control_channel_,
-                           "SystemMediaControl.playPause");
+        InvokeMediaControl(media_control_channel_, kSystemMediaPlayPauseMethod);
         return 0;
       }
       break;
@@ -97,13 +129,13 @@ FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
       switch (command) {
         case APPCOMMAND_MEDIA_PLAY_PAUSE:
           InvokeMediaControl(media_control_channel_,
-                             "SystemMediaControl.playPause");
+                             kSystemMediaPlayPauseMethod);
           return 1;
         case APPCOMMAND_MEDIA_PLAY:
-          InvokeMediaControl(media_control_channel_, "SystemMediaControl.play");
+          InvokeMediaControl(media_control_channel_, kSystemMediaPlayMethod);
           return 1;
         case APPCOMMAND_MEDIA_PAUSE:
-          InvokeMediaControl(media_control_channel_, "SystemMediaControl.pause");
+          InvokeMediaControl(media_control_channel_, kSystemMediaPauseMethod);
           return 1;
       }
       break;

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -1,8 +1,24 @@
 #include "flutter_window.h"
 
 #include <optional>
+#include <windowsx.h>
 
 #include "flutter/generated_plugin_registrant.h"
+
+namespace {
+
+constexpr int kMediaPlayPauseHotKeyId = 0xB3;
+
+void InvokeMediaControl(
+    const std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>&
+        channel,
+    const std::string& method) {
+  if (channel) {
+    channel->InvokeMethod(method, nullptr);
+  }
+}
+
+}  // namespace
 
 FlutterWindow::FlutterWindow(const flutter::DartProject& project)
     : project_(project) {}
@@ -25,6 +41,13 @@ bool FlutterWindow::OnCreate() {
     return false;
   }
   RegisterPlugins(flutter_controller_->engine());
+  media_control_channel_ =
+      std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+          flutter_controller_->engine()->messenger(), "PiliPlus",
+          &flutter::StandardMethodCodec::GetInstance());
+  media_play_pause_hot_key_registered_ =
+      RegisterHotKey(GetHandle(), kMediaPlayPauseHotKeyId, MOD_NOREPEAT,
+                     VK_MEDIA_PLAY_PAUSE) != 0;
 
   SetChildContent(flutter_controller_->view()->GetNativeWindow());
 
@@ -41,6 +64,12 @@ bool FlutterWindow::OnCreate() {
 }
 
 void FlutterWindow::OnDestroy() {
+  if (media_play_pause_hot_key_registered_) {
+    UnregisterHotKey(GetHandle(), kMediaPlayPauseHotKeyId);
+    media_play_pause_hot_key_registered_ = false;
+  }
+  media_control_channel_ = nullptr;
+
   if (flutter_controller_) {
     flutter_controller_ = nullptr;
   }
@@ -52,6 +81,33 @@ LRESULT
 FlutterWindow::MessageHandler(HWND hwnd, UINT const message,
                               WPARAM const wparam,
                               LPARAM const lparam) noexcept {
+  switch (message) {
+    case WM_HOTKEY:
+      if (wparam == kMediaPlayPauseHotKeyId) {
+        InvokeMediaControl(media_control_channel_,
+                           "SystemMediaControl.playPause");
+        return 0;
+      }
+      break;
+
+    case WM_APPCOMMAND: {
+      const int command = GET_APPCOMMAND_LPARAM(lparam);
+      switch (command) {
+        case APPCOMMAND_MEDIA_PLAY_PAUSE:
+          InvokeMediaControl(media_control_channel_,
+                             "SystemMediaControl.playPause");
+          return 1;
+        case APPCOMMAND_MEDIA_PLAY:
+          InvokeMediaControl(media_control_channel_, "SystemMediaControl.play");
+          return 1;
+        case APPCOMMAND_MEDIA_PAUSE:
+          InvokeMediaControl(media_control_channel_, "SystemMediaControl.pause");
+          return 1;
+      }
+      break;
+    }
+  }
+
   // Give Flutter, including plugins, an opportunity to handle window messages.
   if (flutter_controller_) {
     std::optional<LRESULT> result =

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -1,13 +1,15 @@
 #include "flutter_window.h"
 
 #include <optional>
+#include <string>
 #include <windowsx.h>
 
 #include "flutter/generated_plugin_registrant.h"
 
 namespace {
 
-constexpr int kMediaPlayPauseHotKeyId = 0xB3;
+constexpr int kMediaPlayPauseHotKeyId = 1;
+constexpr UINT kMediaPlayPauseKey = VK_MEDIA_PLAY_PAUSE;
 
 void InvokeMediaControl(
     const std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>&
@@ -47,7 +49,7 @@ bool FlutterWindow::OnCreate() {
           &flutter::StandardMethodCodec::GetInstance());
   media_play_pause_hot_key_registered_ =
       RegisterHotKey(GetHandle(), kMediaPlayPauseHotKeyId, MOD_NOREPEAT,
-                     VK_MEDIA_PLAY_PAUSE) != 0;
+                     kMediaPlayPauseKey) != 0;
 
   SetChildContent(flutter_controller_->view()->GetNativeWindow());
 

--- a/windows/runner/flutter_window.h
+++ b/windows/runner/flutter_window.h
@@ -25,6 +25,9 @@ class FlutterWindow : public Win32Window {
                          LPARAM const lparam) noexcept override;
 
  private:
+  void EnableMediaPlayPauseHotKey();
+  void DisableMediaPlayPauseHotKey();
+
   // The project to run.
   flutter::DartProject project_;
 

--- a/windows/runner/flutter_window.h
+++ b/windows/runner/flutter_window.h
@@ -3,6 +3,8 @@
 
 #include <flutter/dart_project.h>
 #include <flutter/flutter_view_controller.h>
+#include <flutter/method_channel.h>
+#include <flutter/standard_method_codec.h>
 
 #include <memory>
 
@@ -28,6 +30,11 @@ class FlutterWindow : public Win32Window {
 
   // The Flutter instance hosted by this window.
   std::unique_ptr<flutter::FlutterViewController> flutter_controller_;
+
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
+      media_control_channel_;
+
+  bool media_play_pause_hot_key_registered_ = false;
 };
 
 #endif  // RUNNER_FLUTTER_WINDOW_H_


### PR DESCRIPTION
Added Windows media key processing function, which can be used to activate play/pause of hotkeys on various external devices

Changes:
- Handles WM_APPCOMMAND media play/pause messages in the Windows runner.
- Registers a Windows media play/pause hotkey so playback can be toggled while the app is in the background.
- Bridges native media commands to the existing player controller through MethodChannel.

Tested:
- Built Windows release locally.
- Verified Media_Play_Pause toggles video playback.

添加了Windows媒体键处理功能，可用于多种外置设备激活热键的播放/暂停。

更改：
- 在Windows运行程序中处理WM_APPCOMMAND媒体播放/暂停消息。
- 注册Windows媒体播放/暂停热键，以便在应用程序处于后台时切换播放。
- 通过MethodChannel将原生媒体命令桥接到现有的播放器控制器。

测试：
- 在本地构建了Windows版本。
- 验证Media_Play_Pause可切换视频播放。