### PR TITLE
feat: 专栏链接卡片点击非图片区域也能跳转到专栏详情页

### DIFF
--- a/lib/pages/whisper_detail/widget/chat_item.dart
+++ b/lib/pages/whisper_detail/widget/chat_item.dart
@@ -246,6 +246,7 @@ class ChatItem extends StatelessWidget {
 
   Widget msgTypeArticleCard_12(dynamic content, Color textColor) {
     return GestureDetector(
+      behavior: HitTestBehavior.opaque,
       onTap: () => Get.toNamed(
         '/articlePage',
         parameters: {


### PR DESCRIPTION
完成了 #2292 的诉求
（第一次贡献代码（如果有做得不标准的地方（见谅QwQ