### PR TITLE
add support for custom danmaku font family

### DIFF
--- a/lib/pages/video/widgets/header_mixin.dart
+++ b/lib/pages/video/widgets/header_mixin.dart
@@ -57,6 +57,11 @@ mixin HeaderMixin<T extends StatefulWidget> on State<T> {
 
     final isFullScreen = this.isFullScreen;
 
+    final fontController = TextEditingController(
+      text: DanmakuOptions.danmakuFontFamily,
+    );
+    FocusNode? fontFocus;
+
     showBottomSheet(
       (context, setState) {
         final theme = Theme.of(context);
@@ -121,6 +126,24 @@ mixin HeaderMixin<T extends StatefulWidget> on State<T> {
           DanmakuOptions.danmakuFontWeight = val.toInt();
           setState(() {});
           setOptions();
+        }
+
+        void updateFontFamily(String val) {
+          DanmakuOptions.danmakuFontFamily = val;
+          if (fontController.text != val) {
+            fontController.text = val;
+          }
+          setState(() {});
+          setOptions();
+        }
+
+        if (fontFocus == null) {
+          fontFocus = FocusNode();
+          fontFocus!.addListener(() {
+            if (!fontFocus!.hasFocus) {
+              updateFontFamily(fontController.text);
+            }
+          });
         }
 
         void updateOpacity(double val) {
@@ -354,6 +377,50 @@ mixin HeaderMixin<T extends StatefulWidget> on State<T> {
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
+                      Text('字体选择'),
+                      resetBtn(theme, '', () => updateFontFamily('')),
+                    ],
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(
+                      top: 0,
+                      bottom: 6,
+                      left: 10,
+                      right: 10,
+                    ),
+
+                    child: TextField(
+                      controller: fontController,
+                      focusNode: fontFocus,
+                      decoration: InputDecoration(
+                        hintText: '请输入字体名称，留空为默认',
+                        filled: true,
+                        fillColor: theme.colorScheme.surface.withAlpha(
+                          (0.75 * 255).round(),
+                        ),
+                        contentPadding: const EdgeInsets.all(10),
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(8),
+                          borderSide: BorderSide(
+                            color: theme.colorScheme.outline.withAlpha(
+                              (0.18 * 255).round(),
+                            ),
+                          ),
+                        ),
+                        focusedBorder: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(8),
+                          borderSide: BorderSide(
+                            color: theme.colorScheme.primary.withAlpha(
+                              (0.3 * 255).round(),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
                       Text('描边粗细 ${DanmakuOptions.danmakuStrokeWidth}'),
                       resetBtn(theme, 1.5, () => updateStrokeWidth(1.5)),
                     ],
@@ -518,9 +585,11 @@ mixin HeaderMixin<T extends StatefulWidget> on State<T> {
           ),
         );
       },
-    )?.whenComplete(
-      () => DanmakuOptions.save(plPlayerController.danmakuOpacity.value),
-    );
+    )?.whenComplete(() {
+      fontFocus?.dispose();
+      fontController.dispose();
+      DanmakuOptions.save(plPlayerController.danmakuOpacity.value);
+    });
   }
 }
 

--- a/lib/plugin/pl_player/utils/danmaku_options.dart
+++ b/lib/plugin/pl_player/utils/danmaku_options.dart
@@ -12,6 +12,7 @@ abstract final class DanmakuOptions {
   static double danmakuFontScaleFS = Pref.danmakuFontScaleFS;
   static double danmakuFontScale = Pref.danmakuFontScale;
   static int danmakuFontWeight = Pref.danmakuFontWeight;
+  static String danmakuFontFamily = Pref.danmakuFontFamily;
   static double danmakuShowArea = Pref.danmakuShowArea;
   static double danmakuDuration = Pref.danmakuDuration;
   static double danmakuStaticDuration = Pref.danmakuStaticDuration;
@@ -30,6 +31,7 @@ abstract final class DanmakuOptions {
     return DanmakuOption(
       fontSize: 15 * (notFullscreen ? danmakuFontScale : danmakuFontScaleFS),
       fontWeight: danmakuFontWeight,
+      fontFamily: danmakuFontFamily,
       area: danmakuShowArea,
       duration: danmakuDuration / speed,
       staticDuration: danmakuStaticDuration / speed,
@@ -56,6 +58,7 @@ abstract final class DanmakuOptions {
       SettingBoxKey.danmakuStaticDuration: danmakuStaticDuration,
       SettingBoxKey.danmakuStrokeWidth: danmakuStrokeWidth,
       SettingBoxKey.danmakuFontWeight: danmakuFontWeight,
+      SettingBoxKey.danmakuFontFamily: danmakuFontFamily,
       SettingBoxKey.danmakuLineHeight: danmakuLineHeight,
       SettingBoxKey.danmakuMassiveMode: danmakuMassiveMode,
       SettingBoxKey.danmakuStatic2Scroll: danmakuStatic2Scroll,

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -205,7 +205,8 @@ abstract final class SettingBoxKey {
       danmakuStatic2Scroll = 'danmakuStatic2Scroll',
       danmakuLineHeight = 'danmakuLineHeight',
       danmakuStrokeWidth = 'strokeWidth',
-      danmakuFontWeight = 'fontWeight';
+      danmakuFontWeight = 'fontWeight',
+      danmakuFontFamily = 'danmakuFontFamily';
 
   static const String systemProxyHost = 'systemProxyHost',
       systemProxyPort = 'systemProxyPort';

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -794,6 +794,9 @@ abstract final class Pref {
     defaultValue: PlatformUtils.isMobile ? 5 : 6,
   );
 
+  static String get danmakuFontFamily =>
+      _setting.get(SettingBoxKey.danmakuFontFamily, defaultValue: '');
+
   static bool get enableLongShowControl =>
       _setting.get(SettingBoxKey.enableLongShowControl, defaultValue: false);
 


### PR DESCRIPTION
<img width="997" height="645" alt="image" src="https://github.com/user-attachments/assets/db375d4e-caa1-4e1f-872e-0c221a4f7826" />
允许用户自己填一个字体名

这个pr依赖 bggRGjQaUbCoE/canvas_danmaku/pull/17