### PR TITLE
feat: 站内搜索

### DIFF
--- a/lib/common/widgets/selectable_text.dart
+++ b/lib/common/widgets/selectable_text.dart
@@ -1,21 +1,45 @@
-import 'package:PiliPlus/utils/platform_utils.dart';
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+void addSiteSearchMenuItem(
+  EditableTextState state,
+  List<ContextMenuButtonItem> items,
+) {
+  if (!state.textEditingValue.selection.isCollapsed) {
+    items.add(
+      ContextMenuButtonItem(
+        onPressed: () {
+          final selectedText = state.textEditingValue.selection.textInside(
+            state.textEditingValue.text,
+          );
+          Get.toNamed('/searchResult', parameters: {'keyword': selectedText});
+        },
+        label: '站内搜索',
+      ),
+    );
+  }
+}
+
+Widget Function(BuildContext, EditableTextState) siteSearchMenuBuilder() {
+  return (context, state) {
+    final items = state.contextMenuButtonItems;
+    addSiteSearchMenuItem(state, items);
+    return AdaptiveTextSelectionToolbar.buttonItems(
+      buttonItems: items,
+      anchors: state.contextMenuAnchors,
+    );
+  };
+}
 
 Widget selectableText(
   String text, {
   TextStyle? style,
+  Widget Function(BuildContext, EditableTextState)? contextMenuBuilder,
 }) {
-  if (PlatformUtils.isDesktop) {
-    return SelectionArea(
-      child: Text(
-        style: style,
-        text,
-      ),
-    );
-  }
   return SelectableText(
     style: style,
     text,
+    contextMenuBuilder: contextMenuBuilder,
     scrollPhysics: const NeverScrollableScrollPhysics(),
   );
 }
@@ -23,18 +47,12 @@ Widget selectableText(
 Widget selectableRichText(
   TextSpan textSpan, {
   TextStyle? style,
+  Widget Function(BuildContext, EditableTextState)? contextMenuBuilder,
 }) {
-  if (PlatformUtils.isDesktop) {
-    return SelectionArea(
-      child: Text.rich(
-        style: style,
-        textSpan,
-      ),
-    );
-  }
   return SelectableText.rich(
     style: style,
     textSpan,
+    contextMenuBuilder: contextMenuBuilder,
     scrollPhysics: const NeverScrollableScrollPhysics(),
   );
 }

--- a/lib/pages/article/widgets/article_ops.dart
+++ b/lib/pages/article/widgets/article_ops.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:PiliPlus/common/style.dart';
+import 'package:PiliPlus/common/widgets/selectable_text.dart';
 import 'package:PiliPlus/models_new/article/article_view/ops.dart';
 import 'package:PiliPlus/pages/dynamics/widgets/vote.dart';
 import 'package:PiliPlus/utils/app_scheme.dart';
@@ -33,7 +34,10 @@ class ArticleOpus extends StatelessWidget {
           final item = _ops[index];
           switch (item.insert) {
             case String e:
-              return SelectableText(e);
+              return SelectableText(
+                e,
+                contextMenuBuilder: siteSearchMenuBuilder(),
+              );
             case Insert(:final card):
               if (card != null) {
                 if (card.url?.isNotEmpty == true) {

--- a/lib/pages/article/widgets/opus_content.dart
+++ b/lib/pages/article/widgets/opus_content.dart
@@ -3,6 +3,7 @@ import 'dart:math' as math;
 import 'package:PiliPlus/common/assets.dart';
 import 'package:PiliPlus/common/widgets/gesture/tap_gesture_recognizer.dart';
 import 'package:PiliPlus/common/widgets/image/cached_network_svg_image.dart';
+import 'package:PiliPlus/common/widgets/selectable_text.dart';
 import 'package:PiliPlus/common/widgets/image/network_img_layer.dart';
 import 'package:PiliPlus/common/widgets/image_grid/image_grid_view.dart';
 import 'package:PiliPlus/common/widgets/image_viewer/hero.dart';
@@ -191,6 +192,7 @@ class OpusContent extends StatelessWidget {
                       )
                       .toList(),
                 ),
+                contextMenuBuilder: siteSearchMenuBuilder(),
               );
               if (isQuote) {
                 widget = Container(
@@ -314,6 +316,7 @@ class OpusContent extends StatelessWidget {
                     );
                   }).toList(),
                 ),
+                contextMenuBuilder: siteSearchMenuBuilder(),
               );
             case 6:
               final type = element.linkCard!.card!.type;
@@ -660,7 +663,10 @@ class OpusContent extends StatelessWidget {
                   color: colorScheme.onInverseSurface,
                 ),
                 width: .infinity,
-                child: SelectableText.rich(renderer.span!),
+                child: SelectableText.rich(
+                  renderer.span!,
+                  contextMenuBuilder: siteSearchMenuBuilder(),
+                ),
               );
             case 8 when (element.heading?.nodes?.isNotEmpty == true):
               return SelectableText.rich(
@@ -675,6 +681,7 @@ class OpusContent extends StatelessWidget {
                       )
                       .toList(),
                 ),
+                contextMenuBuilder: siteSearchMenuBuilder(),
               );
             default:
               if (kDebugMode) debugPrint('unknown type ${element.paraType}');
@@ -691,6 +698,7 @@ class OpusContent extends StatelessWidget {
                         )
                         .toList(),
                   ),
+                  contextMenuBuilder: siteSearchMenuBuilder(),
                 );
               }
 

--- a/lib/pages/audio/view.dart
+++ b/lib/pages/audio/view.dart
@@ -4,6 +4,7 @@ import 'package:PiliPlus/common/assets.dart';
 import 'package:PiliPlus/common/style.dart';
 import 'package:PiliPlus/common/widgets/button/icon_button.dart';
 import 'package:PiliPlus/common/widgets/flutter/refresh_indicator.dart';
+import 'package:PiliPlus/common/widgets/selectable_text.dart';
 import 'package:PiliPlus/common/widgets/gesture/tap_gesture_recognizer.dart';
 import 'package:PiliPlus/common/widgets/image/network_img_layer.dart';
 import 'package:PiliPlus/common/widgets/image_viewer/hero.dart';
@@ -940,6 +941,7 @@ class _AudioPageState extends State<AudioPage> {
                       audioItem.arc.title,
                       style: const TextStyle(height: 1.7, fontSize: 16),
                       scrollPhysics: const NeverScrollableScrollPhysics(),
+                      contextMenuBuilder: siteSearchMenuBuilder(),
                     ),
                     const SizedBox(height: 12),
                     if (audioItem.owner.hasName()) ...[
@@ -1005,6 +1007,7 @@ class _AudioPageState extends State<AudioPage> {
                       SelectableText(
                         audioItem.arc.desc,
                         scrollPhysics: const NeverScrollableScrollPhysics(),
+                        contextMenuBuilder: siteSearchMenuBuilder(),
                       ),
                     ],
                   ],

--- a/lib/pages/dynamics/widgets/content_panel.dart
+++ b/lib/pages/dynamics/widgets/content_panel.dart
@@ -2,6 +2,7 @@
 import 'package:PiliPlus/common/widgets/custom_icon.dart';
 import 'package:PiliPlus/common/widgets/flutter/text/text.dart' as custom_text;
 import 'package:PiliPlus/common/widgets/image_grid/image_grid_view.dart';
+import 'package:PiliPlus/common/widgets/selectable_text.dart';
 import 'package:PiliPlus/models/dynamics/result.dart';
 import 'package:PiliPlus/pages/dynamics/widgets/rich_node_panel.dart';
 import 'package:PiliPlus/utils/page_utils.dart';
@@ -108,11 +109,13 @@ Widget content(
 }
 
 Widget _contextMenuBuilder(EditableTextState state, String text) {
+  final items = state.contextMenuButtonItems
+    ..add(
+      ContextMenuButtonItem(label: '文本', onPressed: () => _onCopyText(text)),
+    );
+  addSiteSearchMenuItem(state, items);
   return AdaptiveTextSelectionToolbar.buttonItems(
-    buttonItems: state.contextMenuButtonItems
-      ..add(
-        ContextMenuButtonItem(label: '文本', onPressed: () => _onCopyText(text)),
-      ),
+    buttonItems: items,
     anchors: state.contextMenuAnchors,
   );
 }
@@ -126,6 +129,7 @@ void _onCopyText(String text) {
         child: SelectableText(
           text,
           style: const TextStyle(fontSize: 15, height: 1.7),
+          contextMenuBuilder: siteSearchMenuBuilder(),
         ),
       ),
     ),

--- a/lib/pages/dynamics_topic/view.dart
+++ b/lib/pages/dynamics_topic/view.dart
@@ -2,6 +2,7 @@ import 'package:PiliPlus/common/assets.dart';
 import 'package:PiliPlus/common/widgets/custom_icon.dart';
 import 'package:PiliPlus/common/widgets/dynamic_sliver_app_bar/dynamic_sliver_app_bar.dart';
 import 'package:PiliPlus/common/widgets/flutter/refresh_indicator.dart';
+import 'package:PiliPlus/common/widgets/selectable_text.dart';
 import 'package:PiliPlus/common/widgets/image/network_img_layer.dart';
 import 'package:PiliPlus/common/widgets/loading_widget/http_error.dart';
 import 'package:PiliPlus/common/widgets/pair.dart';
@@ -253,6 +254,7 @@ class _DynTopicPageState extends State<DynTopicPage>
               SelectableText(
                 response.topicItem!.description!,
                 style: TextStyle(color: colorScheme.onSurfaceVariant),
+                contextMenuBuilder: siteSearchMenuBuilder(),
               ),
               const SizedBox(height: 10),
               Row(

--- a/lib/pages/member/widget/user_info_card.dart
+++ b/lib/pages/member/widget/user_info_card.dart
@@ -2,6 +2,7 @@ import 'package:PiliPlus/common/assets.dart';
 import 'package:PiliPlus/common/style.dart';
 import 'package:PiliPlus/common/widgets/avatars.dart';
 import 'package:PiliPlus/common/widgets/image_viewer/hero.dart';
+import 'package:PiliPlus/common/widgets/selectable_text.dart';
 import 'package:PiliPlus/common/widgets/pendant_avatar.dart';
 import 'package:PiliPlus/common/widgets/scroll_physics.dart';
 import 'package:PiliPlus/common/widgets/view_safe_area.dart';
@@ -309,6 +310,7 @@ class UserInfoCard extends StatelessWidget {
       child: SelectableText(
         card.sign!.trim().replaceAll(RegExp(r'\n{2,}'), '\n'),
         style: const TextStyle(fontSize: 14),
+        contextMenuBuilder: siteSearchMenuBuilder(),
       ),
     );
   }

--- a/lib/pages/music/view.dart
+++ b/lib/pages/music/view.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:PiliPlus/common/widgets/badge.dart';
 import 'package:PiliPlus/common/widgets/custom_icon.dart';
 import 'package:PiliPlus/common/widgets/flutter/refresh_indicator.dart';
+import 'package:PiliPlus/common/widgets/selectable_text.dart';
 import 'package:PiliPlus/common/widgets/image/network_img_layer.dart';
 import 'package:PiliPlus/common/widgets/image_viewer/hero.dart';
 import 'package:PiliPlus/common/widgets/marquee.dart';
@@ -561,6 +562,7 @@ class _MusicDetailPageState extends CommonDynPageState<MusicDetailPage> {
                   if (!item.album.isNullOrEmpty) '专辑：${item.album}',
                   if (!item.musicSource.isNullOrEmpty) '出处：${item.musicSource}',
                 ].join('\n'),
+                contextMenuBuilder: siteSearchMenuBuilder(),
               ),
               const Divider(),
               Row(

--- a/lib/pages/pgc_review/child/view.dart
+++ b/lib/pages/pgc_review/child/view.dart
@@ -6,6 +6,7 @@ import 'package:PiliPlus/common/widgets/dialog/simple_dialog_option.dart';
 import 'package:PiliPlus/common/widgets/flutter/refresh_indicator.dart';
 import 'package:PiliPlus/common/widgets/image/network_img_layer.dart';
 import 'package:PiliPlus/common/widgets/loading_widget/http_error.dart';
+import 'package:PiliPlus/common/widgets/selectable_text.dart';
 import 'package:PiliPlus/common/widgets/sliver/sliver_floating_header.dart';
 import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/models/common/image_type.dart';
@@ -290,6 +291,7 @@ class _PgcReviewChildPageState extends State<PgcReviewChildPage>
                 SelectableText(
                   item.content!,
                   style: const TextStyle(height: 1.75),
+                  contextMenuBuilder: siteSearchMenuBuilder(),
                 ),
               Builder(
                 builder: (context) {

--- a/lib/pages/video/ai_conclusion/view.dart
+++ b/lib/pages/video/ai_conclusion/view.dart
@@ -41,6 +41,7 @@ class AiConclusionPanel extends CommonSlidePage {
                   fontSize: 15,
                   height: 1.5,
                 ),
+                contextMenuBuilder: siteSearchMenuBuilder(),
               ),
             ),
           ),

--- a/lib/pages/video/introduction/pgc/widgets/intro_detail.dart
+++ b/lib/pages/video/introduction/pgc/widgets/intro_detail.dart
@@ -130,6 +130,7 @@ class _IntroDetailState extends State<PgcIntroPanel>
         selectableText(
           widget.item.title!,
           style: const TextStyle(fontSize: 16),
+          contextMenuBuilder: siteSearchMenuBuilder(),
         ),
         const SizedBox(height: 4),
         Row(
@@ -174,6 +175,7 @@ class _IntroDetailState extends State<PgcIntroPanel>
           selectableText(
             widget.item.evaluate!,
             style: textStyle,
+            contextMenuBuilder: siteSearchMenuBuilder(),
           ),
         ],
         if (widget.item.actors?.isNotEmpty == true) ...[

--- a/lib/pages/video/introduction/ugc/view.dart
+++ b/lib/pages/video/introduction/ugc/view.dart
@@ -348,6 +348,7 @@ class _UgcIntroPanelState extends State<UgcIntroPanel> {
       selectableRichText(
         style: const TextStyle(height: 1.4),
         buildContent(theme, videoDetail),
+        contextMenuBuilder: siteSearchMenuBuilder(),
       ),
     ],
     Obx(() {

--- a/lib/pages/video/reply/widgets/reply_item_grpc.dart
+++ b/lib/pages/video/reply/widgets/reply_item_grpc.dart
@@ -13,6 +13,7 @@ import 'package:PiliPlus/common/widgets/gesture/tap_gesture_recognizer.dart';
 import 'package:PiliPlus/common/widgets/image/network_img_layer.dart';
 import 'package:PiliPlus/common/widgets/image_grid/image_grid_view.dart';
 import 'package:PiliPlus/common/widgets/pendant_avatar.dart';
+import 'package:PiliPlus/common/widgets/selectable_text.dart';
 import 'package:PiliPlus/grpc/bilibili/main/community/reply/v1.pb.dart'
     show ReplyInfo, ReplyControl, Content, Url;
 import 'package:PiliPlus/grpc/reply.dart';
@@ -1167,7 +1168,7 @@ class ReplyItemGrpc extends StatelessWidget {
                       message,
                       style: const TextStyle(fontSize: 15, height: 1.7),
                       contextMenuBuilder: (_, editableTextState) =>
-                          _filterMenuBuilder(context, editableTextState),
+                          _contextMenuBuilder(context, editableTextState),
                     ),
                   ),
                 ),
@@ -1201,20 +1202,19 @@ class ReplyItemGrpc extends StatelessWidget {
     );
   }
 
-  static Widget _filterMenuBuilder(
+  static Widget _contextMenuBuilder(
     BuildContext context,
     EditableTextState editableTextState,
   ) {
     final items = editableTextState.contextMenuButtonItems;
     if (!editableTextState.textEditingValue.selection.isCollapsed) {
+      final selectedText = editableTextState.textEditingValue.selection
+          .textInside(editableTextState.textEditingValue.text);
       items.add(
         ContextMenuButtonItem(
           onPressed: () {
             Navigator.of(context).pop();
-            final select = editableTextState.textEditingValue;
-            String text = RegExp.escape(
-              select.selection.textInside(select.text),
-            );
+            String text = RegExp.escape(selectedText);
             if (ReplyGrpc.enableFilter) text = '|$text';
 
             showConfirmDialog(
@@ -1246,6 +1246,7 @@ class ReplyItemGrpc extends StatelessWidget {
           label: '加入过滤',
         ),
       );
+      addSiteSearchMenuItem(editableTextState, items);
     }
     return AdaptiveTextSelectionToolbar.buttonItems(
       buttonItems: items,

--- a/lib/pages/whisper_detail/widget/chat_item.dart
+++ b/lib/pages/whisper_detail/widget/chat_item.dart
@@ -5,6 +5,7 @@ import 'package:PiliPlus/common/constants.dart';
 import 'package:PiliPlus/common/style.dart';
 import 'package:PiliPlus/common/widgets/badge.dart';
 import 'package:PiliPlus/common/widgets/gesture/tap_gesture_recognizer.dart';
+import 'package:PiliPlus/common/widgets/selectable_text.dart';
 import 'package:PiliPlus/common/widgets/image/network_img_layer.dart';
 import 'package:PiliPlus/common/widgets/image_viewer/hero.dart';
 import 'package:PiliPlus/grpc/bilibili/im/interfaces/v1.pb.dart'
@@ -717,7 +718,10 @@ class ChatItem extends StatelessWidget {
         return '';
       },
     );
-    return SelectableText.rich(TextSpan(children: children));
+    return SelectableText.rich(
+      TextSpan(children: children),
+      contextMenuBuilder: siteSearchMenuBuilder(),
+    );
   }
 
   Widget msgTypeNotifyMsg_10(ThemeData theme, content) {
@@ -759,7 +763,10 @@ class ChatItem extends StatelessWidget {
             ),
             Divider(color: theme.colorScheme.primary.withValues(alpha: 0.05)),
             if ((content['text'] as String?)?.isNotEmpty == true)
-              SelectableText(content['text']),
+              SelectableText(
+                content['text'],
+                contextMenuBuilder: siteSearchMenuBuilder(),
+              ),
             if (modules != null && modules.isNotEmpty) ...[
               const SizedBox(height: 4),
               ...modules.map(


### PR DESCRIPTION
B站官方的评论区关键词实际一坨，但是选择关键词搜索的需求实际存在。
为所有内容源自 API 返回结果的 `SelectableText` 添加了 “站内搜索”选项，避免了复制后手动返回主页搜索的麻烦。
(Co-authored by DeepSeek-V4-Flash)