### PR TITLE
feat: add tag filter

### DIFF
--- a/lib/http/video.dart
+++ b/lib/http/video.dart
@@ -178,6 +178,7 @@ abstract final class VideoHttp {
       for (final i in res.data['data']['list']) {
         if (!GlobalData().blackMids.contains(i['owner']['mid']) &&
             !RecommendFilter.filterTitle(i['title']) &&
+            !RecommendFilter.filterTagInJson(i) &&
             !RecommendFilter.filterLikeRatio(
               i['stat']['like'],
               i['stat']['view'],
@@ -868,6 +869,7 @@ abstract final class VideoHttp {
   static bool _canAddRank(Map i) {
     if (!GlobalData().blackMids.contains(i['owner']['mid']) &&
         !RecommendFilter.filterTitle(i['title']) &&
+        !RecommendFilter.filterTagInJson(i) &&
         !RecommendFilter.filterLikeRatio(
           i['stat']['like'],
           i['stat']['view'],

--- a/lib/models/home/rcmd/result.dart
+++ b/lib/models/home/rcmd/result.dart
@@ -16,6 +16,7 @@ class RcmdVideoItemAppModel extends BaseRcmdVideoItemModel {
     cid = json['player_args']?['cid'];
     cover = json['cover'];
     stat = RcmdStat.fromJson(json);
+    tags = BaseVideoItemModel.parseTags(json);
     // 改用player_args中的duration作为原始数据（秒数）
     duration = json['player_args']?['duration'] ?? 0;
     //duration = json['cover_right_text'];

--- a/lib/models/model_hot_video_item.dart
+++ b/lib/models/model_hot_video_item.dart
@@ -32,6 +32,7 @@ class HotVideoItemModel extends HorizontalVideoModel with MultiSelectData {
     duration = json["duration"];
     owner = Owner.fromJson(json["owner"]);
     stat = HotStat.fromJson(json['stat']);
+    tags = BaseVideoItemModel.parseTags(json);
     dimension = json['dimension'] == null
         ? null
         : Dimension.fromJson(json['dimension']);

--- a/lib/models/model_rec_video_item.dart
+++ b/lib/models/model_rec_video_item.dart
@@ -24,6 +24,7 @@ class RcmdVideoItemModel extends BaseRcmdVideoItemModel {
     pubdate = json["pubdate"];
     owner = Owner.fromJson(json["owner"]);
     stat = Stat.fromJson(json["stat"]);
+    tags = BaseVideoItemModel.parseTags(json);
     isFollowed = json["is_followed"] == 1;
     // rcmdReason = json["rcmd_reason"] != null
     //     ? RcmdReason.fromJson(json["rcmd_reason"])

--- a/lib/models/model_video.dart
+++ b/lib/models/model_video.dart
@@ -12,7 +12,48 @@ abstract class BaseVideoItemModel extends BaseSimpleVideoItemModel {
   int? aid;
   String? desc;
   int? pubdate;
+  List<String>? tags;
   bool isFollowed = false;
+
+  static List<String>? parseTags(dynamic data) {
+    final tags = <String>[];
+
+    void addTag(dynamic value) {
+      if (value is String) {
+        if (value.isNotEmpty) {
+          tags.add(value);
+        }
+      } else if (value is Map) {
+        addTag(value['tag_name']);
+        addTag(value['tagName']);
+        addTag(value['name']);
+        addTag(value['title']);
+      } else if (value is Iterable) {
+        for (final item in value) {
+          addTag(item);
+        }
+      }
+    }
+
+    if (data is Map) {
+      addTag(data['tag']);
+      addTag(data['tags']);
+      addTag(data['tag_name']);
+      addTag(data['tagName']);
+      addTag(data['tag_info']);
+      addTag(data['tag_list']);
+      final args = data['args'];
+      if (args is Map) {
+        addTag(args['tag']);
+        addTag(args['tags']);
+        addTag(args['tag_name']);
+      }
+    } else {
+      addTag(data);
+    }
+
+    return tags.isEmpty ? null : tags;
+  }
 }
 
 abstract class BaseOwner {

--- a/lib/pages/setting/models/recommend_settings.dart
+++ b/lib/pages/setting/models/recommend_settings.dart
@@ -64,6 +64,14 @@ List<SettingsModel> get recommendSettings => [
     },
   ),
   getBanWordModel(
+    title: '标签关键词过滤',
+    key: SettingBoxKey.banWordForTag,
+    onChanged: (value) {
+      RecommendFilter.tagRegExp = value;
+      RecommendFilter.enableTagFilter = value.pattern.isNotEmpty;
+    },
+  ),
+  getBanWordModel(
     title: 'App推荐/热门/排行榜: 视频分区关键词过滤',
     key: SettingBoxKey.banWordForZone,
     onChanged: (value) {

--- a/lib/utils/recommend_filter.dart
+++ b/lib/utils/recommend_filter.dart
@@ -12,6 +12,8 @@ abstract final class RecommendFilter {
     caseSensitive: false,
   );
   static bool enableFilter = rcmdRegExp.pattern.isNotEmpty;
+  static RegExp tagRegExp = RegExp(Pref.banWordForTag, caseSensitive: false);
+  static bool enableTagFilter = tagRegExp.pattern.isNotEmpty;
 
   static bool filter(BaseVideoItemModel videoItem) {
     //由于相关视频中没有已关注标签，只能视为非关注视频
@@ -35,10 +37,19 @@ abstract final class RecommendFilter {
     return (enableFilter && rcmdRegExp.hasMatch(title));
   }
 
+  static bool filterTag(Iterable<String>? tags) {
+    return enableTagFilter && tags != null && tags.any(tagRegExp.hasMatch);
+  }
+
+  static bool filterTagInJson(Map json) {
+    return filterTag(BaseVideoItemModel.parseTags(json));
+  }
+
   static bool filterAll(BaseVideoItemModel videoItem) {
     return (videoItem.duration > 0 &&
             videoItem.duration < minDurationForRcmd) ||
         filterLikeRatio(videoItem.stat.like, videoItem.stat.view) ||
-        filterTitle(videoItem.title);
+        filterTitle(videoItem.title) ||
+        filterTag(videoItem.tags);
   }
 }

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -54,6 +54,7 @@ abstract final class SettingBoxKey {
       minLikeRatioForRecommend = 'minLikeRatioForRecommend',
       exemptFilterForFollowed = 'exemptFilterForFollowed',
       banWordForRecommend = 'banWordForRecommend',
+      banWordForTag = 'banWordForTag',
       applyFilterToRelatedVideos = 'applyFilterToRelatedVideos',
       autoUpdate = 'autoUpdate',
       autoClearCache = 'autoClearCache',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -279,6 +279,9 @@ abstract final class Pref {
   static String get banWordForRecommend =>
       _setting.get(SettingBoxKey.banWordForRecommend, defaultValue: '');
 
+  static String get banWordForTag =>
+      _setting.get(SettingBoxKey.banWordForTag, defaultValue: '');
+
   static String get banWordForReply =>
       _setting.get(SettingBoxKey.banWordForReply, defaultValue: '');
 


### PR DESCRIPTION
新增推荐流设置中的视频标签关键词过滤，与原有的标题关键词过滤/视频分区关键词过滤并列，使用方式也相同，只要有任意一个标签命中关键词就过滤
<img width="864" height="1836" alt="32c41697a0c2aaf09abf3ba375d1cd71" src="https://github.com/user-attachments/assets/d84342aa-9aa9-45f7-9d61-dfe69f3f7527" />
<img width="864" height="1844" alt="f9cabd6bf891167d5431c9304267cfe1" src="https://github.com/user-attachments/assets/5bdf033b-6dd1-487f-814d-c08f830fbf45" />
