### PR TITLE
fix: refresh video source when resuming from Android background

### DIFF
--- a/lib/plugin/pl_player/view/view.dart
+++ b/lib/plugin/pl_player/view/view.dart
@@ -79,6 +79,7 @@ import 'package:flutter_volume_controller/flutter_volume_controller.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:get/get.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
+import 'package:media_kit/media_kit.dart';
 import 'package:media_kit_video/media_kit_video.dart';
 import 'package:screen_brightness_platform_interface/screen_brightness_platform_interface.dart';
 import 'package:window_manager/window_manager.dart';
@@ -336,14 +337,45 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
           _pauseDueToPauseUponEnteringBackgroundMode = true;
           player.pause();
         }
-      } else {
+      } else if (state == .resumed) {
         if (_pauseDueToPauseUponEnteringBackgroundMode) {
           _pauseDueToPauseUponEnteringBackgroundMode = false;
-          player?.play();
+          unawaited(_resumeAfterBackground(player));
         }
       }
     }
   }
+
+  Future<void> _resumeAfterBackground(Player? player) async {
+    if (Platform.isAndroid &&
+        !plPlayerController.isLive &&
+        !plPlayerController.isFileSource) {
+      try {
+        if (widget.videoDetailController case final controller?) {
+          controller.playedTime = plPlayerController.position;
+          await controller.queryVideoUrl(fromReset: true);
+          if (_isPlayingAfterResume()) {
+            return;
+          }
+        }
+      } catch (_) {}
+
+      try {
+        final future = plPlayerController.refreshPlayer();
+        if (future != null) {
+          await future;
+          if (_isPlayingAfterResume()) {
+            return;
+          }
+        }
+      } catch (_) {}
+    }
+    await (plPlayerController.videoPlayerController ?? player)?.play();
+  }
+
+  bool _isPlayingAfterResume() =>
+      plPlayerController.videoPlayerController?.state.playing == true ||
+      plPlayerController.playerStatus.isPlaying;
 
   Future<void> setBrightness(double value) async {
     _brightnessValue.value = value;


### PR DESCRIPTION
## Summary

Fixes an Android playback resume issue where video can freeze after the device is locked for a while and then unlocked.

On Pixel 9 Pro, after locking the screen during playback and returning to PiliPlus later, playback may continue for a few seconds and then freeze. The player controls remain responsive, but the video no longer advances.

## Changes

- Only handle automatic resume when lifecycle state is `AppLifecycleState.resumed`.
- On Android non-live, non-local videos:
  - save the current playback position
  - re-query the video URL with `queryVideoUrl(fromReset: true)`
  - resume from the previous position
- Fall back to `refreshPlayer()` or `play()` if re-querying fails.

## Why

The old resume path only called `player.play()` after returning from background. After a longer lock-screen period, the previous stream URL, connection, decoder, or surface state may no longer be valid, so simply calling `play()` can leave the media session alive while the video output is frozen.

Re-querying the video URL and reopening the media source gives the player a clean source while preserving the user's playback position.

## Tested

- Built release APK successfully with Flutter 3.44.4.
- Verified APK signature with `apksigner`.
- Target device context:
  - Pixel 9 Pro
  - Android API 37
  - targetSdk 36