### PR TITLE
feat: add whitelist to skip SponsorBlock for specific uploaders

### DIFF
--- a/lib/pages/setting/models/model.dart
+++ b/lib/pages/setting/models/model.dart
@@ -1,5 +1,9 @@
+// Modified by barmxds6ch on 2026-06-28.
+// SPDX-License-Identifier: GPL-3.0-only
 import 'package:PiliPlus/common/style.dart';
 import 'package:PiliPlus/models/common/enum_with_label.dart';
+import 'package:PiliPlus/pages/setting/widgets/list_editor_dialog.dart'
+    show ListEditorDialog;
 import 'package:PiliPlus/pages/setting/widgets/normal_item.dart';
 import 'package:PiliPlus/pages/setting/widgets/popup_item.dart';
 import 'package:PiliPlus/pages/setting/widgets/select_dialog.dart';
@@ -110,6 +114,7 @@ class NormalModel extends SettingsModel {
   final String? title;
   final ValueGetter<String>? getTitle;
   final ValueGetter<String>? getSubtitle;
+  final TextStyle? subtitleStyle;
   final Widget Function(ThemeData theme)? getTrailing;
   final void Function(BuildContext context, VoidCallback setState)? onTap;
 
@@ -118,6 +123,7 @@ class NormalModel extends SettingsModel {
     super.leading,
     super.contentPadding,
     super.titleStyle,
+    this.subtitleStyle,
     this.title,
     this.getTitle,
     this.getSubtitle,
@@ -130,6 +136,7 @@ class NormalModel extends SettingsModel {
     super.leading,
     super.contentPadding,
     super.titleStyle,
+    this.subtitleStyle,
     this.title,
     this.getTitle,
     this.getSubtitle,
@@ -153,6 +160,7 @@ class NormalModel extends SettingsModel {
     onTap: onTap,
     contentPadding: contentPadding,
     titleStyle: titleStyle,
+    subtitleStyle: subtitleStyle,
   );
 }
 
@@ -261,6 +269,91 @@ SettingsModel getBanWordModel({
         ),
       );
     },
+  );
+}
+
+/// Creates a list-based UID filter model with user names using ListEditorDialog
+///
+/// 支持显示用户名的 UID 过滤模型
+SettingsModel getListUidWithNameModel({
+  required String title,
+  required Map<int, String> Function() getUidsMap,
+  required void Function(Map<int, String>) setUidsMap,
+  required void Function() onUpdate,
+  Widget? leading,
+  String emptySubtitle = '点击添加',
+  String Function(int count)? countSubtitleBuilder,
+  TextStyle? titleStyle,
+  TextStyle? subtitleStyle,
+}) {
+  return NormalModel(
+    leading: leading,
+    title: title,
+    getSubtitle: () {
+      final uidsMap = getUidsMap();
+      if (uidsMap.isEmpty) return emptySubtitle;
+      return countSubtitleBuilder?.call(uidsMap.length) ??
+          '已屏蔽 ${uidsMap.length} 个用户';
+    },
+    onTap: (context, setState) async {
+      final uidsMap = getUidsMap();
+      // 将 Map 转换为显示格式："用户名 (UID)"
+      final items = uidsMap.entries.map((e) {
+        return '${e.value} (${e.key})';
+      }).toList();
+
+      final result = await showDialog<List<String>>(
+        context: context,
+        builder: (context) {
+          return ListEditorDialog(
+            title: title,
+            initialItems: items,
+            hintText: '输入用户UID',
+            itemLabel: 'UID',
+            keyboardType: TextInputType.number,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            allowEdit: false,
+            validator: (value) {
+              if (value.isEmpty) return '请输入UID';
+              final uid = int.tryParse(value);
+              if (uid == null) return 'UID必须是数字';
+              if (uid <= 0) return 'UID必须大于0';
+              return null;
+            },
+          );
+        },
+      );
+
+      if (result != null) {
+        final newMap = <int, String>{};
+
+        for (final item in result) {
+          // 解析格式 "用户名 (UID)" 或纯数字 "UID"
+          final match = RegExp(r'(.+?)\s*\((\d+)\)$').firstMatch(item);
+          if (match != null) {
+            // 格式: "用户名 (UID)"
+            final name = match.group(1)?.trim() ?? '';
+            final uid = int.tryParse(match.group(2) ?? '');
+            if (uid != null && uid > 0) {
+              newMap[uid] = name;
+            }
+          } else {
+            // 纯数字格式：新添加的UID
+            final uid = int.tryParse(item);
+            if (uid != null && uid > 0) {
+              newMap[uid] = 'UID:$uid'; // 默认名称
+            }
+          }
+        }
+
+        setUidsMap(newMap);
+        onUpdate();
+        setState();
+        SmartDialog.showToast('已保存');
+      }
+    },
+    titleStyle: titleStyle,
+    subtitleStyle: subtitleStyle,
   );
 }
 

--- a/lib/pages/setting/widgets/list_editor_dialog.dart
+++ b/lib/pages/setting/widgets/list_editor_dialog.dart
@@ -1,0 +1,260 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:get/get.dart';
+
+/// A dialog for editing a list of strings with add/remove/edit functionality
+/// Follows Material Design 3 style
+class ListEditorDialog extends StatefulWidget {
+  final String title;
+  final List<String> initialItems;
+  final String hintText;
+  final String itemLabel;
+  final TextInputType? keyboardType;
+  final List<TextInputFormatter>? inputFormatters;
+  final String? Function(String)? validator;
+  // When false, existing items use SelectableText instead of editable TextField
+  final bool allowEdit;
+
+  const ListEditorDialog({
+    super.key,
+    required this.title,
+    required this.initialItems,
+    this.hintText = '点击添加按钮添加项目',
+    this.itemLabel = '项目',
+    this.keyboardType,
+    this.inputFormatters,
+    this.validator,
+    this.allowEdit = true,
+  });
+
+  @override
+  State<ListEditorDialog> createState() => _ListEditorDialogState();
+}
+
+class _ListEditorDialogState extends State<ListEditorDialog> {
+  late List<String> _items;
+  late List<TextEditingController> _controllers;
+  final TextEditingController _addController = TextEditingController();
+  final FocusNode _addFocusNode = FocusNode();
+
+  @override
+  void initState() {
+    super.initState();
+    _items = List<String>.from(widget.initialItems);
+    _controllers = _items.map((e) => TextEditingController(text: e)).toList();
+  }
+
+  @override
+  void dispose() {
+    for (final c in _controllers) {
+      c.dispose();
+    }
+    _addController.dispose();
+    _addFocusNode.dispose();
+    super.dispose();
+  }
+
+  void _addItem() {
+    final value = _addController.text.trim();
+    if (value.isEmpty) return;
+
+    if (widget.validator != null) {
+      final error = widget.validator!(value);
+      if (error != null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(error), duration: const Duration(seconds: 2)),
+        );
+        return;
+      }
+    }
+
+    if (!_items.contains(value)) {
+      setState(() {
+        _items.add(value);
+        _controllers.add(TextEditingController(text: value));
+        _addController.clear();
+      });
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('该${widget.itemLabel}已存在'),
+          duration: const Duration(seconds: 2),
+        ),
+      );
+    }
+  }
+
+  void _commitEdit(int index) {
+    final value = _controllers[index].text.trim();
+    if (value.isEmpty || value == _items[index]) {
+      // Revert if empty or unchanged
+      _controllers[index].text = _items[index];
+      return;
+    }
+
+    if (widget.validator != null) {
+      final error = widget.validator!(value);
+      if (error != null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(error), duration: const Duration(seconds: 2)),
+        );
+        _controllers[index].text = _items[index];
+        return;
+      }
+    }
+
+    if (_items.contains(value)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('该${widget.itemLabel}已存在'),
+          duration: const Duration(seconds: 2),
+        ),
+      );
+      _controllers[index].text = _items[index];
+      return;
+    }
+
+    setState(() {
+      _items[index] = value;
+    });
+  }
+
+  void _removeItem(int index) {
+    _controllers[index].dispose();
+    setState(() {
+      _items.removeAt(index);
+      _controllers.removeAt(index);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return AlertDialog(
+      title: Text(widget.title),
+      contentPadding: const EdgeInsets.fromLTRB(24, 12, 24, 0),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _addController,
+                    focusNode: _addFocusNode,
+                    keyboardType: widget.keyboardType,
+                    inputFormatters: widget.inputFormatters,
+                    decoration: InputDecoration(
+                      hintText: widget.hintText,
+                      isDense: true,
+                    ),
+                    onSubmitted: (_) => _addItem(),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                IconButton(
+                  icon: const Icon(Icons.add_circle_outline),
+                  onPressed: _addItem,
+                  tooltip: '添加',
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            if (_items.isEmpty)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 16),
+                child: Center(
+                  child: Text(
+                    '暂无${widget.itemLabel}',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: theme.colorScheme.outline,
+                    ),
+                  ),
+                ),
+              )
+            else
+              Flexible(
+                child: Container(
+                  constraints: const BoxConstraints(maxHeight: 300),
+                  child: ListView.builder(
+                    shrinkWrap: true,
+                    itemCount: _items.length,
+                    itemBuilder: (context, index) {
+                      return Card(
+                        margin: const EdgeInsets.only(bottom: 8),
+                        child: ListTile(
+                          dense: true,
+                          contentPadding: const EdgeInsets.only(
+                            left: 12,
+                            right: 4,
+                            top: 4,
+                            bottom: 4,
+                          ),
+                          title: widget.allowEdit
+                              ? TextField(
+                                  controller: _controllers[index],
+                                  keyboardType: widget.keyboardType,
+                                  inputFormatters: widget.inputFormatters,
+                                  style: theme.textTheme.bodyMedium,
+                                  decoration: const InputDecoration(
+                                    isDense: true,
+                                    border: InputBorder.none,
+                                    contentPadding: EdgeInsets.zero,
+                                  ),
+                                  onSubmitted: (_) => _commitEdit(index),
+                                  onTapOutside: (_) => _commitEdit(index),
+                                )
+                              : SelectableText(
+                                  _items[index],
+                                  style: theme.textTheme.bodyMedium,
+                                ),
+                          trailing: IconButton(
+                                icon: const Icon(Icons.delete_outline,
+                                    size: 20),
+                                onPressed: () => _removeItem(index),
+                                tooltip: '删除',
+                                padding: EdgeInsets.zero,
+                                constraints: const BoxConstraints(
+                                  minWidth: 32,
+                                  minHeight: 32,
+                                ),
+                              ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+      actionsPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      actions: [
+        TextButton(
+          onPressed: Get.back,
+          child: Text(
+            '取消',
+            style: TextStyle(color: theme.colorScheme.outline),
+          ),
+        ),
+        FilledButton(
+          onPressed: () {
+            // Commit any in-progress edits before saving
+            for (int i = 0; i < _items.length; i++) {
+              final value = _controllers[i].text.trim();
+              if (value.isNotEmpty && value != _items[i]) {
+                _items[i] = value;
+              }
+            }
+            Get.back(result: _items);
+          },
+          child: const Text('保存'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/pages/setting/widgets/normal_item.dart
+++ b/lib/pages/setting/widgets/normal_item.dart
@@ -1,3 +1,5 @@
+// Modified by barmxds6ch on 2026-06-28.
+// SPDX-License-Identifier: GPL-3.0-only
 import 'package:PiliPlus/common/widgets/flutter/list_tile.dart';
 import 'package:flutter/material.dart' hide ListTile;
 
@@ -11,6 +13,7 @@ class NormalItem extends StatefulWidget {
   final void Function(BuildContext context, VoidCallback setState)? onTap;
   final EdgeInsetsGeometry? contentPadding;
   final TextStyle? titleStyle;
+  final TextStyle? subtitleStyle;
 
   const NormalItem({
     this.title,
@@ -22,6 +25,7 @@ class NormalItem extends StatefulWidget {
     this.onTap,
     this.contentPadding,
     this.titleStyle,
+    this.subtitleStyle,
     super.key,
   }) : assert(title != null || getTitle != null);
 
@@ -37,9 +41,11 @@ class _NormalItemState extends State<NormalItem> {
     if ((widget.subtitle ?? widget.getSubtitle?.call()) case final text?) {
       subtitle = Text(
         text,
-        style: theme.textTheme.labelMedium!.copyWith(
-          color: theme.colorScheme.outline,
-        ),
+        style:
+            widget.subtitleStyle ??
+            theme.textTheme.labelMedium!.copyWith(
+              color: theme.colorScheme.outline,
+            ),
       );
     }
     return ListTile(

--- a/lib/pages/sponsor_block/block_mixin.dart
+++ b/lib/pages/sponsor_block/block_mixin.dart
@@ -1,3 +1,5 @@
+// Modified by barmxds6ch on 2026-06-28.
+// SPDX-License-Identifier: GPL-3.0-only
 import 'dart:async' show StreamSubscription, Timer;
 import 'dart:math' as math;
 
@@ -54,6 +56,8 @@ mixin BlockMixin on GetxController {
   bool get preInitPlayer;
   int get currPosInMilliseconds;
   bool get isFullScreen => false;
+
+  int? get ownerMid => null;
 
   bool get isUgc;
   late final isBlock = isUgc || !blockConfig.enablePgcSkip;
@@ -117,6 +121,10 @@ mixin BlockMixin on GetxController {
 
   Future<void> handleSBData(List<SegmentItemModel> list) async {
     if (list.isNotEmpty) {
+      final currentOwnerMid = ownerMid;
+      final isWhitelisted =
+          currentOwnerMid != null &&
+          Pref.blockWhitelist.keys.contains(currentOwnerMid);
       try {
         Future<void>? future;
         final duration = list.first.videoDuration ?? timeLength!;
@@ -130,10 +138,18 @@ mixin BlockMixin on GetxController {
               )
               .map(
                 (item) {
-                  final segmentModel = SegmentModel.fromItemModel(
+                  final rawSegmentModel = SegmentModel.fromItemModel(
                     item,
                     isBlock ? blockConfig : null,
                   );
+                  final segmentModel = isWhitelisted
+                      ? SegmentModel(
+                          uuid: rawSegmentModel.uuid,
+                          segmentType: rawSegmentModel.segmentType,
+                          segment: rawSegmentModel.segment,
+                          skipType: SkipType.showOnly,
+                        )
+                      : rawSegmentModel;
                   if (segmentModel.segment == const (0, 0)) {
                     videoLabel?.value +=
                         '${videoLabel!.value.isNotEmpty ? '/' : ''}${segmentModel.segmentType.title}';

--- a/lib/pages/sponsor_block/view.dart
+++ b/lib/pages/sponsor_block/view.dart
@@ -1,3 +1,5 @@
+// Modified by barmxds6ch on 2026-06-28.
+// SPDX-License-Identifier: GPL-3.0-only
 import 'package:PiliPlus/common/widgets/pair.dart';
 import 'package:PiliPlus/http/constants.dart';
 import 'package:PiliPlus/http/init.dart';
@@ -6,6 +8,8 @@ import 'package:PiliPlus/http/sponsor_block.dart';
 import 'package:PiliPlus/models/common/sponsor_block/segment_type.dart';
 import 'package:PiliPlus/models/common/sponsor_block/skip_type.dart';
 import 'package:PiliPlus/models_new/sponsor_block/user_info.dart';
+import 'package:PiliPlus/pages/setting/models/model.dart'
+    show getListUidWithNameModel;
 import 'package:PiliPlus/pages/setting/slide_color_picker.dart';
 import 'package:PiliPlus/utils/filtering_text.dart';
 import 'package:PiliPlus/utils/page_utils.dart';
@@ -487,6 +491,21 @@ class _SponsorBlockPageState extends State<SponsorBlockPage> {
           dividerL,
           SliverToBoxAdapter(child: _serverStatusItem(theme, titleStyle)),
           dividerL,
+          SliverToBoxAdapter(
+            child: getListUidWithNameModel(
+              title: '跳过豁免名单',
+              emptySubtitle: '点击添加用户',
+              countSubtitleBuilder: (count) => '已加入 $count 个用户',
+              getUidsMap: () => Pref.blockWhitelist,
+              setUidsMap: (map) {
+                Pref.blockWhitelist = map;
+              },
+              onUpdate: () {},
+              titleStyle: titleStyle,
+              subtitleStyle: subTitleStyle,
+            ).widget,
+          ),
+          sliverDivider,
           SliverToBoxAdapter(
             child: _blockLimitItem(theme, titleStyle, subTitleStyle),
           ),

--- a/lib/pages/video/controller.dart
+++ b/lib/pages/video/controller.dart
@@ -1,3 +1,5 @@
+// Modified by barmxds6ch on 2026-06-28.
+// SPDX-License-Identifier: GPL-3.0-only
 import 'dart:async';
 import 'dart:math' show min;
 import 'dart:ui';
@@ -126,6 +128,21 @@ class VideoDetailController extends GetxController
   bool get setSystemBrightness => plPlayerController.setSystemBrightness;
   bool get removeSafeArea => plPlayerController.removeSafeArea;
   double get uiScale => plPlayerController.uiScale;
+
+  @override
+  int? get ownerMid {
+    final introController = Get.isRegistered<UgcIntroController>(tag: heroTag)
+        ? Get.find<UgcIntroController>(tag: heroTag)
+        : null;
+    return introController?.videoDetail.value.owner?.mid;
+  }
+
+  String? get ownerName {
+    final introController = Get.isRegistered<UgcIntroController>(tag: heroTag)
+        ? Get.find<UgcIntroController>(tag: heroTag)
+        : null;
+    return introController?.videoDetail.value.owner?.name;
+  }
 
   late VideoItem firstVideo;
   String? videoUrl;

--- a/lib/pages/video/widgets/header_control.dart
+++ b/lib/pages/video/widgets/header_control.dart
@@ -1,3 +1,5 @@
+// Modified by barmxds6ch on 2026-06-28.
+// SPDX-License-Identifier: GPL-3.0-only
 import 'dart:async' show Timer;
 import 'dart:convert' show jsonDecode, utf8;
 import 'dart:io' show Platform, File;
@@ -517,6 +519,41 @@ class HeaderControlState extends State<HeaderControl>
                         setting.put(SettingBoxKey.CDNService, result.name);
                         SmartDialog.showToast('已设置为 ${result.desc}，正在重载视频');
                         videoDetailCtr.queryVideoUrl(fromReset: true);
+                      }
+                    },
+                  ),
+                if (videoDetailCtr.isUgc && videoDetailCtr.ownerMid != null)
+                  ListTile(
+                    dense: true,
+                    title: Text(
+                      '${Pref.blockWhitelist.keys.contains(videoDetailCtr.ownerMid) ? '' : '不'}跳过此UP主',
+                      style: titleStyle,
+                    ),
+                    leading: const Icon(
+                      Icons.person_add_alt_1_outlined,
+                      size: 20,
+                    ),
+                    onTap: () {
+                      Get.back();
+                      final currentMap = Map<int, String>.from(
+                        Pref.blockWhitelist,
+                      );
+                      final ownerMid = videoDetailCtr.ownerMid;
+                      final ownerName = videoDetailCtr.ownerName;
+                      final isWhitelisted =
+                          ownerMid != null &&
+                          currentMap.keys.contains(ownerMid);
+                      if (ownerMid != null) {
+                        if (isWhitelisted) {
+                          currentMap.remove(ownerMid);
+                        } else {
+                          currentMap[ownerMid] =
+                              ownerName ?? ownerMid.toString();
+                        }
+                        Pref.blockWhitelist = currentMap;
+                        SmartDialog.showToast(
+                          '已将UP主${isWhitelisted ? '移出' : '加入'}豁免名单，重启视频生效',
+                        );
                       }
                     },
                   ),

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -1,3 +1,5 @@
+// Modified by barmxds6ch on 2026-06-28.
+// SPDX-License-Identifier: GPL-3.0-only
 // ignore_for_file: constant_identifier_names
 
 abstract final class SettingBoxKey {
@@ -182,6 +184,7 @@ abstract final class SettingBoxKey {
 
   static const String enableSponsorBlock = 'enableSponsorBlock',
       blockSettings = 'blockSettings',
+      blockWhitelist = 'blockWhitelist',
       blockLimit = 'blockLimit',
       blockColor = 'blockColor',
       blockUserID = 'blockUserID',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -1,3 +1,5 @@
+// Modified by barmxds6ch on 2026-06-28.
+// SPDX-License-Identifier: GPL-3.0-only
 import 'dart:io';
 
 import 'package:PiliPlus/common/widgets/gesture/horizontal_drag_gesture_recognizer.dart'
@@ -133,6 +135,47 @@ abstract final class Pref {
         )
         .toList();
   }
+
+  static Map<int, String> get blockWhitelist {
+    final data = _setting.get(SettingBoxKey.blockWhitelist);
+
+    if (data is Set) {
+      final map = <int, String>{};
+      for (final mid in data) {
+        if (mid is int) {
+          map[mid] = 'UID:$mid';
+        }
+      }
+      _setting.put(SettingBoxKey.blockWhitelist, map);
+      return map;
+    }
+
+    if (data is Map) {
+      final map = <int, String>{};
+      for (final entry in data.entries) {
+        final key = entry.key;
+        final value = entry.value;
+        int? uid;
+        if (key is int) {
+          uid = key;
+        } else if (key is String) {
+          uid = int.tryParse(key);
+        }
+        if (uid != null && value is String) {
+          map[uid] = value;
+        }
+      }
+      if (map.isNotEmpty && data.keys.first is! int) {
+        _setting.put(SettingBoxKey.blockWhitelist, map);
+      }
+      return map;
+    }
+
+    return <int, String>{};
+  }
+
+  static set blockWhitelist(Map<int, String> blockWhitelist) =>
+      _setting.put(SettingBoxKey.blockWhitelist, blockWhitelist);
 
   static List<Color> get blockColor {
     final list = _setting.get(SettingBoxKey.blockColor) as List?;

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -1,3 +1,5 @@
+// Modified by barmxds6ch on 2026-06-28.
+// SPDX-License-Identifier: GPL-3.0-only
 import 'dart:convert' show JsonEncoder, base64;
 import 'dart:math' show Random;
 
@@ -8,7 +10,23 @@ import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 abstract final class Utils {
   static final random = Random();
 
-  static const jsonEncoder = JsonEncoder.withIndent('    ');
+  static Object? _toEncodable(Object? value) {
+    if (value is Map) {
+      return value.map((k, v) => MapEntry(k.toString(), v));
+    }
+    if (value is num || value is bool || value is String || value == null) {
+      return value;
+    }
+    try {
+      final result = (value as dynamic).toJson();
+      if (result != null) {
+        return result;
+      }
+    } catch (_) {}
+    return value.toString();
+  }
+
+  static const jsonEncoder = JsonEncoder.withIndent('    ', _toEncodable);
 
   static final numericRegex = RegExp(r'^[\d\.]+$');
   static bool isStringNumeric(String str) {


### PR DESCRIPTION
## 功能说明
为“空降助手”（SponsorBlock）增加 **UP 主白名单/豁免名单** 功能。  
启用后，指定 UP 主的所有视频将**不会**自动跳过赞助片段（仅显示标记，不执行跳转），方便在追更特定创作者时保留完整观看体验。

## 主要改动
- **存储层**：新增 `SettingBoxKey.blockWhitelist` 及 `Pref.blockWhitelist`
- **设置页 UI**：在“空降助手”设置页增加“跳过豁免名单”入口（基于 `getListUidWithNameModel`）
- **播放器快捷开关**：在视频播放器“更多设置”菜单中增加“跳过此 UP 主”一键切换按钮
- **播放逻辑适配**：`BlockMixin` 增加 `ownerMid` getter，命中白名单时将 `skipType` 强制改为 `SkipType.showOnly`（仅提示不跳转）

## 其他改动
- `NormalModel` 增加 `subtitleStyle` 参数，用于定制副标题样式
- `Utils.jsonEncoder` 增加自定义 `_toEncodable`，增强 Map 等类型的序列化支持

## 致谢 / 代码来源
感谢 [PiliNara](https://github.com/Starfallan/PiliNara) 项目（作者 [Starfallan](https://github.com/Starfallan)）：
- 本 PR 中的 `ListEditorDialog`（`lib/pages/setting/widgets/list_editor_dialog.dart`）**完整复制** 自 PiliNara，**未做任何修改**，特此声明并致谢。
- `getListUidWithNameModel` 的函数设计思路也参考了 PiliNara 的实现，在其基础上增加了 `titleStyle`/`subtitleStyle` 等扩展参数。
