### PR TITLE
​feat: 全屏播放器状态栏添加充电图标

### DIFF
--- a/lib/pages/video/widgets/header_control.dart
+++ b/lib/pages/video/widgets/header_control.dart
@@ -135,6 +135,8 @@ mixin TimeBatteryMixin<T extends StatefulWidget> on State<T> {
       () async {
         try {
           _batteryLevel.value = await _battery.batteryLevel;
+          final state = await _battery.batteryState;
+          _isCharging.value = state == BatteryState.charging;
         } catch (_) {}
       },
     );
@@ -150,15 +152,29 @@ mixin TimeBatteryMixin<T extends StatefulWidget> on State<T> {
               if (batteryLevel == null) {
                 return const SizedBox.shrink();
               }
-              return Text(
-                '$batteryLevel%',
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontSize: 13,
-                ),
-              );
-            },
-          ),
+              return Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    '$batteryLevel%',
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 13,
+                    ),
+                  ),
+                  if (_isCharging.value)
+                    const Padding(
+                      padding: EdgeInsets.only(left: 2),
+                      child: Icon(
+                        Icons.electric_bolt,
+                        color: Colors.amber,
+                        size: 13,
+                      ),
+                    ),
+                  ],
+                );
+              },
+            ),
           const SizedBox(width: 10),
         ],
         Obx(

--- a/lib/pages/video/widgets/header_control.dart
+++ b/lib/pages/video/widgets/header_control.dart
@@ -1,4 +1,4 @@
-import 'dart:async' show Timer;
+import 'dart:async' show Timer, StreamSubscription;
 import 'dart:convert' show jsonDecode, utf8;
 import 'dart:io' show Platform, File;
 import 'dart:typed_data' show Uint8List;
@@ -128,6 +128,27 @@ mixin TimeBatteryMixin<T extends StatefulWidget> on State<T> {
   late final RxnInt _batteryLevel = RxnInt();
   late final RxBool _isCharging = false.obs;
   late final _showBatteryLevel = Pref.showBatteryLevel;
+
+  StreamSubscription<BatteryState>? _batterySubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _batterySubscription = _battery.onBatteryStateChanged.listen((BatteryState state) async {
+      _isCharging.value = state == BatteryState.charging;
+      try {
+        _batteryLevel.value = await _battery.batteryLevel;
+      } catch (_) {}
+    });
+  }
+
+  @override
+  void dispose() {
+    stopClock();
+    _batterySubscription?.cancel();
+    super.dispose();
+  }
+  
   void getBatteryLevelIfNeeded() {
     if (!_showCurrTime || !_showBatteryLevel) return;
     EasyThrottle.throttle(
@@ -167,7 +188,7 @@ mixin TimeBatteryMixin<T extends StatefulWidget> on State<T> {
                     const Padding(
                       padding: EdgeInsets.only(left: 2),
                       child: Icon(
-                        Icons.electric_bolt,
+                        Icons.bolt,
                         color: Colors.amber,
                         size: 13,
                       ),

--- a/lib/pages/video/widgets/header_control.dart
+++ b/lib/pages/video/widgets/header_control.dart
@@ -94,6 +94,7 @@ mixin TimeBatteryMixin<T extends StatefulWidget> on State<T> {
   @override
   void dispose() {
     stopClock();
+    _batterySubscription?.cancel();
     super.dispose();
   }
 
@@ -145,15 +146,8 @@ mixin TimeBatteryMixin<T extends StatefulWidget> on State<T> {
         _batteryLevel.value = await _battery.batteryLevel;
       } catch (_) {}
     });
-  }
-
-  @override
-  void dispose() {
-    stopClock();
-    _batterySubscription?.cancel();
-    super.dispose();
-  }
-  
+  };
+      
   void getBatteryLevelIfNeeded() {
     if (!_showCurrTime || !_showBatteryLevel) return;
     EasyThrottle.throttle(

--- a/lib/pages/video/widgets/header_control.dart
+++ b/lib/pages/video/widgets/header_control.dart
@@ -146,7 +146,7 @@ mixin TimeBatteryMixin<T extends StatefulWidget> on State<T> {
         _batteryLevel.value = await _battery.batteryLevel;
       } catch (_) {}
     });
-  };
+  }
       
   void getBatteryLevelIfNeeded() {
     if (!_showCurrTime || !_showBatteryLevel) return;

--- a/lib/pages/video/widgets/header_control.dart
+++ b/lib/pages/video/widgets/header_control.dart
@@ -134,6 +134,11 @@ mixin TimeBatteryMixin<T extends StatefulWidget> on State<T> {
   @override
   void initState() {
     super.initState();
+
+    _battery.batteryState.then((state) {
+      _isCharging.value = state == BatteryState.charging;
+    }).catchError((_) {});
+      
     _batterySubscription = _battery.onBatteryStateChanged.listen((BatteryState state) async {
       _isCharging.value = state == BatteryState.charging;
       try {
@@ -189,7 +194,6 @@ mixin TimeBatteryMixin<T extends StatefulWidget> on State<T> {
                       padding: EdgeInsets.only(left: 2),
                       child: Icon(
                         Icons.bolt,
-                        color: Colors.amber,
                         size: 13,
                       ),
                     ),

--- a/lib/pages/video/widgets/header_control.dart
+++ b/lib/pages/video/widgets/header_control.dart
@@ -126,6 +126,7 @@ mixin TimeBatteryMixin<T extends StatefulWidget> on State<T> {
 
   late final _battery = Battery();
   late final RxnInt _batteryLevel = RxnInt();
+  late final RxBool _isCharging = false.obs;
   late final _showBatteryLevel = Pref.showBatteryLevel;
   void getBatteryLevelIfNeeded() {
     if (!_showCurrTime || !_showBatteryLevel) return;


### PR DESCRIPTION
在全屏播放器状态栏的电量百分比旁添加了充电状态图标，并支持插拔线时实时刷新显示。
这样用户无需下拉打开系统状态栏，就可以直观确认充电工作状态是否正常。

Co-authored-by: Gemini 3.5 Flash Ex