### PR TITLE
fix: preInitPlayer 导致 HDR 播放颜色异常

### DIFF
--- a/lib/pages/video/view.dart
+++ b/lib/pages/video/view.dart
@@ -311,13 +311,11 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
       if (plPlayerController.autoEnterFullScreen) {
         plPlayerController.triggerFullScreen();
       }
-      return plPlayerController.play();
-    } else {
-      return videoDetailController.playerInit(
-        autoplay: true,
-        autoFullScreenFlag: true,
-      );
     }
+    return videoDetailController.playerInit(
+      autoplay: true,
+      autoFullScreenFlag: true,
+    );
   }
 
   @override

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -749,7 +749,7 @@ class PlPlayerController with BlockConfigMixin {
       player,
       configuration: VideoControllerConfiguration(
         enableHardwareAcceleration: hwdec != null,
-        androidAttachSurfaceAfterVideoParameters: false,
+        androidAttachSurfaceAfterVideoParameters: true,
         hwdec: hwdec,
       ),
     );


### PR DESCRIPTION
开启'提前初始化播放器'后，用户点击播放时仅调用 play()
取消暂停，跳过了 playerInit() → setDataSource() 流程，
mpv 视频输出未能重新初始化，HDR 元数据未正确应用。

修复方案：
1. handlePlay() 中 preInitPlayer 分支也调用 playerInit()， 确保 setDataSource() 始终执行（全平台）
2. androidAttachSurfaceAfterVideoParameters 设为 true， Surface 在视频参数已知后才附加（仅 Android）