### PR TITLE
fix(player): [AI-Generated] MTK 设备 AAudio seek 后画面冻结

### DIFF
--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -723,9 +723,14 @@ class PlPlayerController with BlockConfigMixin {
 
   Future<Player> _initPlayer() async {
     assert(_videoPlayerController == null);
+    // 部分设备（如联发科 MTK）的 AAudio HAL 在 seek/flush 后
+    // AAudioStream_getTimestamp 返回异常，会导致视频调度器死等音频时钟而画面冻结。
+    // 当用户单独选用 aaudio 时强制前置 opensles 规避，opensles 不可用时才回退 aaudio。
+    final audioOutput = Pref.audioOutput;
     final opt = {
       'video-sync': Pref.videoSync,
-      if (Platform.isAndroid) 'ao': Pref.audioOutput,
+      if (Platform.isAndroid)
+        'ao': audioOutput == 'aaudio' ? 'opensles,aaudio' : audioOutput,
       'volume':
           (PlatformUtils.isMobile ? Pref.playerVolume : volume.value * 100)
               .toString(),


### PR DESCRIPTION
> ⚠️ 本 PR 由 AI (WorkBuddy) 生成，含实机调试与源码分析，建议 review 后决定是否合并。

## 问题

联发科(MTK)设备在设置中**仅选用 AAudio 输出**时，seek 后画面冻结，但音频正常播放。

**复现**：Samsung SM-X730 (mt6991, Android 16) + PiliPlus v2.0.9，音频输出选 AAudio → 播放视频 → 拖动进度条。

## 根因

mpv 音视频同步以 ao 上报的播放时间戳为主时钟。MTK AAudio HAL 在 seek 的 flush+restart 后，`AAudioStream_getTimestamp()` 返回异常值，导致音频时钟卡住，视频调度器死等"未到点"的帧 → 画面冻结。而 AAudio 播放路径独立运作，音频照常播出。

默认配置（opensles,aaudio,audiotrack）不触发，因为 opensles 优先初始化，不依赖 HAL 时间戳查询。仅当用户单独选 AAudio 时才强制走 `ao_aaudio` 踩雷。

## 修复

`lib/plugin/pl_player/controller.dart`：用户仅选 `aaudio` 时，传 `opensles,aaudio` 给 mpv，让 opensles 优先（不依赖 HAL 时间戳，seek 后可靠），opensles 初始化失败才回退 aaudio。

```dart
final audioOutput = Pref.audioOutput;
'ao': audioOutput == 'aaudio' ? 'opensles,aaudio' : audioOutput,
```

对非 MTK 设备零影响（它们默认就用 opensles）。代价是放弃 AAudio 的低延迟优势（B 站视频场景 OpenSL ES 与 AAudio 主观无差异）。

## 验证

修复版 APK 在 SM-X730 实测：仅选 AAudio + seek → 正常快进，音画同步。

## 备注

更彻底的 C 层根治（改 mpv `ao_aaudio.c`，getTimestamp 异常时回退采样计数估算）需在 media-kit/mpv 层面处理，不在本仓库范围。