### PR TITLE
修复平板侧边栏"动态"标签未对齐

### DIFF
--- a/lib/pages/main/view.dart
+++ b/lib/pages/main/view.dart
@@ -510,7 +510,12 @@ class _MainAppState extends PopScopeState<MainApp>
                     ? Text(dynCount.toString())
                     : null,
                 padding: const .symmetric(horizontal: 6),
-                child: icon,
+                // Keep the same 24px box as the other icons so the label stays
+                // aligned in the horizontal NavigationDrawer layout.
+                child: SizedBox.square(
+                  dimension: 24,
+                  child: Center(child: icon),
+                ),
               );
             },
           )


### PR DESCRIPTION
问题
平板布局下的侧边栏(NavigationDrawer)里,"动态"一项的文字比"首页""我的"往左偏了约 3dp,三项标签左缘没对齐。

原因
NavigationDrawer 的每个 destination 是固定布局 Row([SizedBox(16), icon, SizedBox(12), label]),标签横向位置 = 16 + 图标宽度 + 12。而"动态"图标在 nav_bar_config.dart 里是 size: 21,其余两项是 size: 24——图标框窄了 3px,导致"动态"标签整体左移约 3dp。

影响范围
仅影响横向排布的侧边抽屉。底部栏 / rail / 悬浮栏中图标是居中的,不受影响。

<img width="878" height="796" alt="piliplus_align_compare" src="https://github.com/user-attachments/assets/a2ef89dc-df0d-46c9-a34c-e3467f637ce2" />
