### PR TITLE
feat(ui/ux): 在打开稍后再看时预加载未看完视频数量

### DIFF
--- a/lib/pages/later/child_view.dart
+++ b/lib/pages/later/child_view.dart
@@ -33,8 +33,8 @@ class _LaterViewChildPageState extends State<LaterViewChildPage>
   @override
   void initState() {
     super.initState();
-    _laterController = Get.put(
-      LaterController(widget.laterViewType),
+    _laterController = Get.putOrFind(
+      () => LaterController(widget.laterViewType),
       tag: widget.laterViewType.type.toString(),
     );
   }

--- a/lib/pages/later/view.dart
+++ b/lib/pages/later/view.dart
@@ -50,6 +50,13 @@ class _LaterPageState extends State<LaterPage>
       length: LaterViewType.values.length,
       vsync: this,
     )..addListener(listener);
+
+    for (final type in LaterViewType.values) {
+      Get.put(
+        LaterController(type),
+        tag: type.type.toString(),
+      );
+    }
   }
 
   @override


### PR DESCRIPTION
## 问题

在刚打开稍后再看时，未看完视频的计数不会显示，如图：

<img width="1206" height="2622" alt="Weixin Image_20260701204122_51_114" src="https://github.com/user-attachments/assets/242e69a8-3b60-4453-974e-4f3439ab7d4d" />

必须要点未看完一次之后才能看到计数，如图：

<img width="1206" height="2622" alt="Weixin Image_20260701204123_52_114" src="https://github.com/user-attachments/assets/cc8a045b-0924-44af-b28e-bc112fdb4585" />

## 效果

在刚打开稍后再看时，可以同时看到全部和未看完视频的计数