### PR TITLE
fix(player): preserve default codec preferences after upgrade

### DIFF
--- a/lib/pages/setting/models/video_settings.dart
+++ b/lib/pages/setting/models/video_settings.dart
@@ -357,12 +357,10 @@ Future<void> _showCodecsDialog(
     ),
   );
   if (res != null) {
-    await (res.isEmpty
-        ? GStorage.setting.delete(SettingBoxKey.preferCodecs)
-        : GStorage.setting.put(
-            SettingBoxKey.preferCodecs,
-            res.map((i) => i.name).toList(),
-          ));
+    await GStorage.setting.put(
+      SettingBoxKey.preferCodecs,
+      res.map((i) => i.name).toList(),
+    );
     setState();
   }
 }

--- a/lib/pages/setting/models/video_settings.dart
+++ b/lib/pages/setting/models/video_settings.dart
@@ -127,10 +127,8 @@ List<SettingsModel> get videoSettings => [
   NormalModel(
     title: '首选解码格式',
     leading: const Icon(Icons.movie_creation_outlined),
-    getSubtitle: () {
-      final list = Pref.preferCodecs;
-      return '首选解码格式：${(list.isEmpty ? '第一个可用' : list.map((i) => i.name).join(","))}，请根据设备支持情况与需求调整';
-    },
+    getSubtitle: () =>
+        '首选解码格式：${(Pref.preferCodecs.map((i) => i.name).join(","))}，请根据设备支持情况与需求调整',
     onTap: _showCodecsDialog,
   ),
   if (kDebugMode || Platform.isAndroid)
@@ -356,7 +354,7 @@ Future<void> _showCodecsDialog(
       values: {for (final e in VideoDecodeFormatType.values) e: e.name},
     ),
   );
-  if (res != null) {
+  if (res != null && res.isNotEmpty) {
     await GStorage.setting.put(
       SettingBoxKey.preferCodecs,
       res.map((i) => i.name).toList(),

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -267,10 +267,13 @@ abstract final class Pref {
     }
 
     final codecs = _setting.get(SettingBoxKey.preferCodecs);
-    if (codecs is List && codecs.isNotEmpty) {
+    if (codecs is List) {
       return codecs.map((i) => VideoDecodeFormatType.values.byName(i)).toList();
     }
-    return const [];
+    return const [
+      VideoDecodeFormatType.AVC,
+      VideoDecodeFormatType.AV1,
+    ];
   }
 
   static String get hardwareDecoding => _setting.get(

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -270,10 +270,7 @@ abstract final class Pref {
     if (codecs is List) {
       return codecs.map((i) => VideoDecodeFormatType.values.byName(i)).toList();
     }
-    return const [
-      VideoDecodeFormatType.AVC,
-      VideoDecodeFormatType.AV1,
-    ];
+    return const <VideoDecodeFormatType>[.AVC, .AV1];
   }
 
   static String get hardwareDecoding => _setting.get(


### PR DESCRIPTION
在https://github.com/bggRGjQaUbCoE/PiliPlus/pull/2426 的改动中的[feat: codec list options](https://github.com/bggRGjQaUbCoE/PiliPlus/pull/2426/commits/dee3580c4a9483818a8e38fd433ceb572410e0d7)中优化了原版的首选解码格式的选择逻辑，且做了旧key的升级适配。但是有个问题：

旧版本未修改过解码设置时，默认顺序是 AVC、AV1。升级后由于没有设置过，没有旧设置的key，就会变成“选择服务器下发的第一个可用解码格式”，可能导致更新后播放体验变化。

比如在我的设备上表现现为，新版本打开部分视频，会默认选择AV1，然后toast提示：”无法加载解码器, Could not open codec，可能会切换至软解“，随后就回退到了软解。而这对于原本不修改这个选项的用户，可能就意识不到是哪里出问题了。

在这个小commit调整后：
未配置过：继续使用 AVC、AV1
用户主动清空：保存空列表，使用第一个可用（维持原逻辑）
已有设置：保持原有选择（维持原逻辑）

这样可以使升级的未修改过设置的老用户保持旧默认行为。

麻烦佬看下，感谢！