### PR TITLE
feat: 新增应用界面字体设置

### DIFF
--- a/assets/fonts/licenses/OFL-LXGWWenKaiGBScreen.txt
+++ b/assets/fonts/licenses/OFL-LXGWWenKaiGBScreen.txt
@@ -1,0 +1,96 @@
+Copyright 2021-2026 LXGW (https://github.com/lxgw/LxgwWenKai-Screen)
+Copyright 2021-2026 LXGW (https://github.com/lxgw/LxgwWenKai), with Reserved Font Name '霞鹜', '霞鶩', '落霞孤鹜', '落霞孤鶩' and 'LXGW'. [ADDITIONAL PERMISSION] The Reserved Font Names '霞鹜', '霞鶩', '落霞孤鹜', '落霞孤鶩' and 'LXGW' may continue to be used in Modified Versions recompiled from the Original Version, without modifications to the font source code; or in Modified Versions subsetted or converted to other formats (e.g., WOFF/WOFF2) solely for web font delivery, provided such Modified Versions are not made available as installable desktop fonts (e.g., on mainstream platforms like Google Fonts, or third-party non-commercial platforms recognized by the author @lxgw; other web font platforms please contact the author @lxgw for confirmation).
+Copyright 2022-2026 LXGW (https://github.com/lxgw/LxgwWenKaiGB), with Reserved Font Name '霞鹜', '霞鶩', '落霞孤鹜', '落霞孤鶩' and 'LXGW'. [ADDITIONAL PERMISSION] The Reserved Font Names '霞鹜', '霞鶩', '落霞孤鹜', '落霞孤鶩' and 'LXGW' may continue to be used in Modified Versions recompiled from the Original Version, without modifications to the font source code; or in Modified Versions subsetted or converted to other formats (e.g., WOFF/WOFF2) solely for web font delivery, provided such Modified Versions are not made available as installable desktop fonts (e.g., on mainstream platforms like Google Fonts, or third-party non-commercial platforms recognized by the author @lxgw; other web font platforms please contact the author @lxgw for confirmation).
+Copyright 2020 The Klee Project Authors (https://github.com/fontworks-fonts/Klee)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://openfontlicense.org
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/assets/fonts/licenses/OFL-SourceHanSerifCN.txt
+++ b/assets/fonts/licenses/OFL-SourceHanSerifCN.txt
@@ -1,0 +1,96 @@
+Copyright 2017-2022 Adobe (http://www.adobe.com/), with Reserved Font
+Name 'Source'. Source is a trademark of Adobe in the United States
+and/or other countries.
+
+This Font Software is licensed under the SIL Open Font License,
+Version 1.1.
+
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font
+creation efforts of academic and linguistic communities, and to
+provide a free and open framework in which fonts may be shared and
+improved in partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply to
+any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software
+components as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to,
+deleting, or substituting -- in part or in whole -- any of the
+components of the Original Version, by changing formats or by porting
+the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed,
+modify, redistribute, and sell modified and unmodified copies of the
+Font Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components, in
+Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the
+corresponding Copyright Holder. This restriction only applies to the
+primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created using
+the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/assets/fonts/licenses/SOURCES.md
+++ b/assets/fonts/licenses/SOURCES.md
@@ -1,0 +1,15 @@
+# Downloadable UI Font Sources
+
+## LXGW WenKai GB Screen
+
+- Source: https://github.com/lxgw/LxgwWenKai-Screen/releases/tag/v1.522
+- Download: https://github.com/lxgw/LxgwWenKai-Screen/releases/download/v1.522/LXGWWenKaiGBScreen.ttf
+- SHA-256: `23ec023913e1851925eb94462c4b0ccd1d78bb89533745aaa8cc682ccd339dc0`
+- License: `OFL-LXGWWenKaiGBScreen.txt`
+
+## Source Han Serif CN
+
+- Source: https://github.com/adobe-fonts/source-han-serif/releases/tag/2.003R
+- Download: https://raw.githubusercontent.com/adobe-fonts/source-han-serif/2.003R/SubsetOTF/CN/SourceHanSerifCN-Regular.otf
+- SHA-256: `3754ea669c530e2473354f8f6d9f79680a44d7e26ec7d00eeabee4a7e0753c5d`
+- License: `OFL-SourceHanSerifCN.txt`

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,7 @@ import 'package:PiliPlus/models/common/theme/theme_color_type.dart';
 import 'package:PiliPlus/plugin/pl_player/utils/fullscreen.dart';
 import 'package:PiliPlus/router/app_pages.dart';
 import 'package:PiliPlus/services/account_service.dart';
+import 'package:PiliPlus/services/app_font_manager.dart';
 import 'package:PiliPlus/services/download/download_service.dart';
 import 'package:PiliPlus/services/logger.dart';
 import 'package:PiliPlus/services/service_locator.dart';
@@ -99,6 +100,7 @@ void main() async {
     if (kDebugMode) debugPrint('GStorage init error: $e');
     exit(0);
   }
+  await AppFontManager.init();
   ScaledWidgetsFlutterBinding.instance.scaleFactor = Pref.uiScale;
   await Future.wait([
     _initDownPath(),

--- a/lib/models/common/app_font_family.dart
+++ b/lib/models/common/app_font_family.dart
@@ -1,0 +1,56 @@
+enum AppFontFamily {
+  system(label: '系统默认'),
+  lxgwWenKaiGbScreen(
+    label: '霞鹜文楷',
+    fontFamily: 'LXGW WenKai GB Screen',
+    fileName: 'LXGWWenKaiGBScreen-1.522.ttf',
+    downloadUrl:
+        'https://github.com/lxgw/LxgwWenKai-Screen/releases/download/v1.522/LXGWWenKaiGBScreen.ttf',
+    downloadSize: 26037854,
+    sha256: '23ec023913e1851925eb94462c4b0ccd1d78bb89533745aaa8cc682ccd339dc0',
+  ),
+  sourceHanSerifCn(
+    label: '思源宋体',
+    fontFamily: 'Source Han Serif CN',
+    fileName: 'SourceHanSerifCN-Regular-2.003.otf',
+    downloadUrl:
+        'https://raw.githubusercontent.com/adobe-fonts/source-han-serif/2.003R/SubsetOTF/CN/SourceHanSerifCN-Regular.otf',
+    downloadSize: 11626108,
+    sha256: '3754ea669c530e2473354f8f6d9f79680a44d7e26ec7d00eeabee4a7e0753c5d',
+  ),
+  ;
+
+  const AppFontFamily({
+    required this.label,
+    this.fontFamily,
+    this.fileName,
+    this.downloadUrl,
+    this.downloadSize,
+    this.sha256,
+  }) : assert(
+         (fontFamily == null &&
+                 fileName == null &&
+                 downloadUrl == null &&
+                 downloadSize == null &&
+                 sha256 == null) ||
+             (fontFamily != null &&
+                 fileName != null &&
+                 downloadUrl != null &&
+                 downloadSize != null &&
+                 sha256 != null),
+       );
+
+  final String label;
+  final String? fontFamily;
+  final String? fileName;
+  final String? downloadUrl;
+  final int? downloadSize;
+  final String? sha256;
+
+  bool get isSystem => this == system;
+
+  static AppFontFamily fromName(Object? value) => values.firstWhere(
+    (item) => item.name == value,
+    orElse: () => system,
+  );
+}

--- a/lib/models/common/app_font_family.dart
+++ b/lib/models/common/app_font_family.dart
@@ -1,20 +1,24 @@
 enum AppFontFamily {
   system(label: '系统默认'),
-  lxgwWenKaiGbScreen(
-    label: '霞鹜文楷',
-    fontFamily: 'LXGW WenKai GB Screen',
-    fileName: 'LXGWWenKaiGBScreen-1.522.ttf',
-    downloadUrl:
-        'https://github.com/lxgw/LxgwWenKai-Screen/releases/download/v1.522/LXGWWenKaiGBScreen.ttf',
-    downloadSize: 26037854,
-    sha256: '23ec023913e1851925eb94462c4b0ccd1d78bb89533745aaa8cc682ccd339dc0',
+  lxgwZhenKaiGb(
+    label: '霞鹜臻楷',
+    fontFamily: 'LXGW ZhenKai GB',
+    fileName: 'LXGWZhenKaiGB-Regular.ttf',
+    downloadUrls: [
+      'https://mirrors.aliyun.com/CTAN/fonts/lxgw-fonts/LXGWZhenKaiGB-Regular.ttf',
+      'https://mirrors.ctan.org/fonts/lxgw-fonts/LXGWZhenKaiGB-Regular.ttf',
+    ],
+    downloadSize: 17545474,
+    sha256: '40876902a7ce25268ab710ad8fe6e2b63bc002aa4b68d22fd45fc1243726ced5',
   ),
   sourceHanSerifCn(
     label: '思源宋体',
     fontFamily: 'Source Han Serif CN',
     fileName: 'SourceHanSerifCN-Regular-2.003.otf',
-    downloadUrl:
-        'https://raw.githubusercontent.com/adobe-fonts/source-han-serif/2.003R/SubsetOTF/CN/SourceHanSerifCN-Regular.otf',
+    downloadUrls: [
+      'https://mirrors.tuna.tsinghua.edu.cn/adobe-fonts/source-han-serif/SubsetOTF/CN/SourceHanSerifCN-Regular.otf',
+      'https://raw.githubusercontent.com/adobe-fonts/source-han-serif/2.003R/SubsetOTF/CN/SourceHanSerifCN-Regular.otf',
+    ],
     downloadSize: 11626108,
     sha256: '3754ea669c530e2473354f8f6d9f79680a44d7e26ec7d00eeabee4a7e0753c5d',
   ),
@@ -24,18 +28,18 @@ enum AppFontFamily {
     required this.label,
     this.fontFamily,
     this.fileName,
-    this.downloadUrl,
+    this.downloadUrls,
     this.downloadSize,
     this.sha256,
   }) : assert(
          (fontFamily == null &&
                  fileName == null &&
-                 downloadUrl == null &&
+                 downloadUrls == null &&
                  downloadSize == null &&
                  sha256 == null) ||
              (fontFamily != null &&
                  fileName != null &&
-                 downloadUrl != null &&
+                 downloadUrls != null &&
                  downloadSize != null &&
                  sha256 != null),
        );
@@ -43,7 +47,7 @@ enum AppFontFamily {
   final String label;
   final String? fontFamily;
   final String? fileName;
-  final String? downloadUrl;
+  final List<String>? downloadUrls;
   final int? downloadSize;
   final String? sha256;
 

--- a/lib/models/common/app_font_family.dart
+++ b/lib/models/common/app_font_family.dart
@@ -21,6 +21,39 @@ enum AppFontFamily {
     downloadSize: 17545474,
     sha256: '40876902a7ce25268ab710ad8fe6e2b63bc002aa4b68d22fd45fc1243726ced5',
   ),
+  lxgwNeoXiHeiScreen(
+    label: '霞鹜新晰黑',
+    fontFamily: 'LXGW Neo XiHei Screen',
+    fileName: 'LXGWNeoXiHeiScreen.ttf',
+    downloadUrls: [
+      'https://mirrors.aliyun.com/CTAN/fonts/lxgw-fonts/LXGWNeoXiHeiScreen.ttf',
+      'https://mirrors.ctan.org/fonts/lxgw-fonts/LXGWNeoXiHeiScreen.ttf',
+    ],
+    downloadSize: 7608410,
+    sha256: 'fc6bbcc2695488073dfe8ad89bde89563cc963fbe04fb7a48c141988f9ba9620',
+  ),
+  lxgwZhuqueFangsong(
+    label: '霞鹜朱雀仿宋',
+    fontFamily: 'LXGW Zhuque Fangsong',
+    fileName: 'LXGWZhuqueFangsong-Regular.ttf',
+    downloadUrls: [
+      'https://mirrors.aliyun.com/CTAN/fonts/lxgw-fonts/LXGWZhuqueFangsong-Regular.ttf',
+      'https://mirrors.ctan.org/fonts/lxgw-fonts/LXGWZhuqueFangsong-Regular.ttf',
+    ],
+    downloadSize: 8824084,
+    sha256: '558c62730844fe54ba220146ed62f859d4e2880188d92d985f8921c6e3743bc4',
+  ),
+  sourceHanSansCn(
+    label: '思源黑体',
+    fontFamily: 'Source Han Sans CN',
+    fileName: 'SourceHanSansCN-Regular-2.005.otf',
+    downloadUrls: [
+      'https://mirrors.tuna.tsinghua.edu.cn/adobe-fonts/source-han-sans/SubsetOTF/CN/SourceHanSansCN-Regular.otf',
+      'https://raw.githubusercontent.com/adobe-fonts/source-han-sans/2.005R/SubsetOTF/CN/SourceHanSansCN-Regular.otf',
+    ],
+    downloadSize: 8429224,
+    sha256: 'e2bc8a2e7f37474b774fff8db758681ece40bb6947a90d571bce9dd60671a8e4',
+  ),
   sourceHanSerifCn(
     label: '思源宋体',
     fontFamily: 'Source Han Serif CN',
@@ -32,6 +65,62 @@ enum AppFontFamily {
     downloadSize: 11626108,
     sha256: '3754ea669c530e2473354f8f6d9f79680a44d7e26ec7d00eeabee4a7e0753c5d',
   ),
+  miSans(
+    label: 'MiSans',
+    fontFamily: 'MiSans',
+    fileName: 'MiSans-Regular.ttf',
+    downloadUrls: [
+      'https://hyperos.mi.com/font-download/MiSans.zip',
+    ],
+    downloadSize: 8122324,
+    sha256: '9c120f0a849bc0aa5048daae2a3c0f6eecd828b5b33fce682a9622833f5feea6',
+    downloadArchive: AppFontDownloadArchive(
+      entryName: 'MiSans/ttf/MiSans-Regular.ttf',
+      downloadSize: 227880072,
+      sha256:
+          'b6aa1fc827035922612df8edf36e5609bca1c5441e25cd57572204569b7b81d9',
+    ),
+    licenseUrl: 'https://hyperos.mi.com/font/zh/download/',
+    licenseNotice: '本软件将使用 MiSans。下载和使用即表示你同意小米官方许可协议。',
+  ),
+  harmonyOsSansSc(
+    label: 'HarmonyOS Sans',
+    fontFamily: 'HarmonyOS Sans SC',
+    fileName: 'HarmonyOS_Sans_SC_Regular.ttf',
+    downloadUrls: [
+      'https://developer.huawei.com/images/download/general/HarmonyOS-Sans.zip',
+    ],
+    downloadSize: 8261128,
+    sha256: '297b088424be212207df2ce8b98e335468b782aa6b96832af0b8b773d711e2b1',
+    downloadArchive: AppFontDownloadArchive(
+      entryName:
+          'HarmonyOS Sans/HarmonyOS_Sans_SC/HarmonyOS_Sans_SC_Regular.ttf',
+      downloadSize: 52165952,
+      sha256:
+          'fb02c86e358cd9aad8d4dfa957ee502381e7ee2e94499a9133add4324b6ce69a',
+      licenseEntryName: 'HarmonyOS Sans/HarmonyOS_Sans_SC/LICENSE.txt',
+      licenseFileName: 'HarmonyOS-Sans-LICENSE.txt',
+    ),
+    licenseUrl:
+        'https://developer.huawei.com/consumer/cn/doc/design-guides/font-0000001828772001',
+    licenseNotice: '本软件将使用 HarmonyOS Sans。下载和使用即表示你同意华为官方许可协议。',
+  ),
+  fusionPixel(
+    label: '缝合像素字体',
+    fontFamily: 'Fusion Pixel 12px Proportional zh_hans',
+    fileName: 'fusion-pixel-12px-proportional-zh_hans.otf',
+    downloadUrls: [
+      'https://github.com/TakWolf/fusion-pixel-font/releases/download/2026.07.01/fusion-pixel-font-12px-proportional-otf-v2026.07.01.zip',
+    ],
+    downloadSize: 4923444,
+    sha256: '3928b779becceb88a23c415d2c27c8fdaddf43698a34f95ba95f5b0ce8423c9a',
+    downloadArchive: AppFontDownloadArchive(
+      entryName: 'fusion-pixel-12px-proportional-zh_hans.otf',
+      downloadSize: 24685008,
+      sha256:
+          '29eb03b52e5ed1299e963406455904eb721c77553783b9bd2807e0901a2df294',
+    ),
+  ),
   ;
 
   const AppFontFamily({
@@ -41,17 +130,25 @@ enum AppFontFamily {
     this.downloadUrls,
     this.downloadSize,
     this.sha256,
+    this.downloadArchive,
+    this.licenseUrl,
+    this.licenseNotice,
   }) : assert(
          (fontFamily == null &&
                  fileName == null &&
                  downloadUrls == null &&
                  downloadSize == null &&
-                 sha256 == null) ||
+                 sha256 == null &&
+                 downloadArchive == null &&
+                 licenseUrl == null &&
+                 licenseNotice == null) ||
              (fontFamily != null &&
                  fileName != null &&
                  downloadUrls != null &&
                  downloadSize != null &&
-                 sha256 != null),
+                 sha256 != null &&
+                 ((licenseUrl == null && licenseNotice == null) ||
+                     (licenseUrl != null && licenseNotice != null))),
        );
 
   final String label;
@@ -60,11 +157,35 @@ enum AppFontFamily {
   final List<String>? downloadUrls;
   final int? downloadSize;
   final String? sha256;
+  final AppFontDownloadArchive? downloadArchive;
+  final String? licenseUrl;
+  final String? licenseNotice;
 
   bool get isSystem => this == system;
+
+  int? get transferSize => downloadArchive?.downloadSize ?? downloadSize;
 
   static AppFontFamily fromName(Object? value) => values.firstWhere(
     (item) => item.name == value,
     orElse: () => system,
   );
+}
+
+final class AppFontDownloadArchive {
+  const AppFontDownloadArchive({
+    required this.entryName,
+    required this.downloadSize,
+    required this.sha256,
+    this.licenseEntryName,
+    this.licenseFileName,
+  }) : assert(
+         (licenseEntryName == null && licenseFileName == null) ||
+             (licenseEntryName != null && licenseFileName != null),
+       );
+
+  final String entryName;
+  final int downloadSize;
+  final String sha256;
+  final String? licenseEntryName;
+  final String? licenseFileName;
 }

--- a/lib/models/common/app_font_family.dart
+++ b/lib/models/common/app_font_family.dart
@@ -1,5 +1,15 @@
 enum AppFontFamily {
   system(label: '系统默认'),
+  lxgwWenKaiGbScreen(
+    label: '霞鹜文楷',
+    fontFamily: 'LXGW WenKai GB Screen',
+    fileName: 'LXGWWenKaiGBScreen-1.522.ttf',
+    downloadUrls: [
+      'https://github.com/lxgw/LxgwWenKai-Screen/releases/download/v1.522/LXGWWenKaiGBScreen.ttf',
+    ],
+    downloadSize: 26037854,
+    sha256: '23ec023913e1851925eb94462c4b0ccd1d78bb89533745aaa8cc682ccd339dc0',
+  ),
   lxgwZhenKaiGb(
     label: '霞鹜臻楷',
     fontFamily: 'LXGW ZhenKai GB',

--- a/lib/pages/setting/models/style_settings.dart
+++ b/lib/pages/setting/models/style_settings.dart
@@ -7,6 +7,7 @@ import 'package:PiliPlus/common/widgets/dialog/dialog.dart';
 import 'package:PiliPlus/common/widgets/image/network_img_layer.dart';
 import 'package:PiliPlus/common/widgets/scale_app.dart';
 import 'package:PiliPlus/common/widgets/stateful_builder.dart';
+import 'package:PiliPlus/models/common/app_font_family.dart';
 import 'package:PiliPlus/models/common/bar_hide_type.dart';
 import 'package:PiliPlus/models/common/dynamic/dynamic_badge_mode.dart';
 import 'package:PiliPlus/models/common/dynamic/up_panel_position.dart';
@@ -20,10 +21,12 @@ import 'package:PiliPlus/pages/mine/controller.dart';
 import 'package:PiliPlus/pages/setting/models/model.dart';
 import 'package:PiliPlus/pages/setting/slide_color_picker.dart';
 import 'package:PiliPlus/pages/setting/widgets/dual_slider_dialog.dart';
+import 'package:PiliPlus/pages/setting/widgets/app_font_family_dialog.dart';
 import 'package:PiliPlus/pages/setting/widgets/multi_select_dialog.dart';
 import 'package:PiliPlus/pages/setting/widgets/select_dialog.dart';
 import 'package:PiliPlus/pages/setting/widgets/slider_dialog.dart';
 import 'package:PiliPlus/plugin/pl_player/utils/fullscreen.dart';
+import 'package:PiliPlus/services/app_font_manager.dart';
 import 'package:PiliPlus/utils/extension/file_ext.dart';
 import 'package:PiliPlus/utils/extension/get_ext.dart';
 import 'package:PiliPlus/utils/extension/num_ext.dart';
@@ -81,6 +84,12 @@ List<SettingsModel> get styleSettings => [
     setKey: SettingBoxKey.useSideBar,
     defaultVal: false,
     needReboot: true,
+  ),
+  NormalModel(
+    title: 'App字体',
+    getSubtitle: () => '当前：${Pref.appFontFamily.label}',
+    leading: const Icon(Icons.font_download_outlined),
+    onTap: _showAppFontFamilyDialog,
   ),
   SplitModel(
     normalModel: const NormalModel.split(
@@ -644,6 +653,33 @@ Future<void> _showFontWeightDialog(BuildContext context) async {
   );
   if (res != null) {
     await GStorage.setting.put(SettingBoxKey.appFontWeight, res.toInt() - 1);
+    Get.updateMyAppTheme();
+  }
+}
+
+Future<void> _showAppFontFamilyDialog(
+  BuildContext context,
+  VoidCallback setState,
+) async {
+  final current = Pref.appFontFamily;
+  final res = await showDialog<AppFontFamily>(
+    context: context,
+    builder: (context) => AppFontFamilyDialog(value: current),
+  );
+  if (res != null && res != current) {
+    if (!res.isSystem) {
+      SmartDialog.showLoading(msg: '正在加载字体');
+      try {
+        await AppFontManager.load(res);
+      } catch (error) {
+        SmartDialog.showToast(error.toString());
+        return;
+      } finally {
+        SmartDialog.dismiss(status: SmartStatus.loading);
+      }
+    }
+    await GStorage.setting.put(SettingBoxKey.appFontFamily, res.name);
+    if (context.mounted) setState();
     Get.updateMyAppTheme();
   }
 }

--- a/lib/pages/setting/widgets/app_font_family_dialog.dart
+++ b/lib/pages/setting/widgets/app_font_family_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:PiliPlus/models/common/app_font_family.dart';
 import 'package:PiliPlus/services/app_font_manager.dart';
+import 'package:PiliPlus/utils/page_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 
@@ -11,10 +12,40 @@ class AppFontFamilyDialog extends StatelessWidget {
 
   final AppFontFamily value;
 
-  static String _sizeLabel(AppFontFamily font) =>
-      '${(font.downloadSize! / (1024 * 1024)).toStringAsFixed(1)} MB';
+  static String _sizeLabel(int bytes) =>
+      '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+
+  Future<bool> _confirmLicense(
+    BuildContext context,
+    AppFontFamily font,
+  ) async {
+    if (font.licenseUrl == null) return true;
+    return await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: Text('使用 ${font.label}'),
+            content: Text(font.licenseNotice!),
+            actions: [
+              TextButton(
+                onPressed: () => PageUtils.launchURL(font.licenseUrl!),
+                child: const Text('查看许可协议'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('取消'),
+              ),
+              FilledButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('同意并下载'),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+  }
 
   Future<void> _download(BuildContext context, AppFontFamily font) async {
+    if (!await _confirmLicense(context, font) || !context.mounted) return;
     try {
       await AppFontManager.download(font);
       if (context.mounted) {
@@ -47,10 +78,10 @@ class AppFontFamilyDialog extends StatelessWidget {
         : progress != null
         ? progress.total > 0
               ? '正在下载 ${(progressValue! * 100).round()}%'
-              : '正在连接 GitHub'
+              : '正在连接下载源'
         : downloaded
-        ? '已下载 · ${_sizeLabel(font)}'
-        : _sizeLabel(font);
+        ? '已下载 · ${_sizeLabel(font.downloadSize!)}'
+        : _sizeLabel(font.transferSize!);
 
     Widget? trailing;
     if (!font.isSystem) {

--- a/lib/pages/setting/widgets/app_font_family_dialog.dart
+++ b/lib/pages/setting/widgets/app_font_family_dialog.dart
@@ -1,0 +1,140 @@
+import 'package:PiliPlus/models/common/app_font_family.dart';
+import 'package:PiliPlus/services/app_font_manager.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
+
+class AppFontFamilyDialog extends StatelessWidget {
+  const AppFontFamilyDialog({
+    super.key,
+    required this.value,
+  });
+
+  final AppFontFamily value;
+
+  static String _sizeLabel(AppFontFamily font) =>
+      '${(font.downloadSize! / (1024 * 1024)).toStringAsFixed(1)} MB';
+
+  Future<void> _download(BuildContext context, AppFontFamily font) async {
+    try {
+      await AppFontManager.download(font);
+      if (context.mounted) {
+        SmartDialog.showToast('${font.label}下载完成');
+      }
+    } catch (error) {
+      if (context.mounted) {
+        SmartDialog.showToast(error.toString());
+      }
+    }
+  }
+
+  void _select(BuildContext context, AppFontFamily font) {
+    if (AppFontManager.isDownloaded(font)) {
+      Navigator.of(context).pop(font);
+    }
+  }
+
+  Widget _buildTile(
+    BuildContext context,
+    AppFontFamily font, [
+    AppFontDownloadProgress? progress,
+  ]) {
+    final downloaded = AppFontManager.isDownloaded(font);
+    final progressValue = progress == null || progress.total <= 0
+        ? null
+        : progress.received / progress.total;
+    final subtitle = font.isSystem
+        ? null
+        : progress != null
+        ? progress.total > 0
+              ? '正在下载 ${(progressValue! * 100).round()}%'
+              : '正在连接 GitHub'
+        : downloaded
+        ? '已下载 · ${_sizeLabel(font)}'
+        : _sizeLabel(font);
+
+    Widget? trailing;
+    if (!font.isSystem) {
+      trailing = SizedBox.square(
+        dimension: 40,
+        child: progress != null
+            ? Center(
+                child: SizedBox.square(
+                  dimension: 22,
+                  child: CircularProgressIndicator(
+                    value: progressValue,
+                    strokeWidth: 2.5,
+                  ),
+                ),
+              )
+            : downloaded
+            ? Tooltip(
+                message: '已下载',
+                child: Icon(
+                  Icons.download_done_rounded,
+                  color: ColorScheme.of(context).primary,
+                ),
+              )
+            : IconButton(
+                tooltip: '下载字体',
+                onPressed: () => _download(context, font),
+                icon: const Icon(Icons.download_rounded),
+              ),
+      );
+    }
+
+    return ListTile(
+      dense: true,
+      leading: Radio<AppFontFamily>(
+        value: font,
+        enabled: downloaded,
+      ),
+      title: Text(
+        font.label,
+        style: TextTheme.of(context).titleMedium,
+      ),
+      subtitle: subtitle == null
+          ? null
+          : Text(
+              subtitle,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+      trailing: trailing,
+      onTap: downloaded ? () => _select(context, font) : null,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      clipBehavior: Clip.hardEdge,
+      title: const Text('App字体'),
+      constraints: const BoxConstraints(minWidth: 300, maxWidth: 380),
+      contentPadding: const EdgeInsets.symmetric(vertical: 12),
+      content: Material(
+        type: MaterialType.transparency,
+        child: SingleChildScrollView(
+          child: RadioGroup<AppFontFamily>(
+            groupValue: value,
+            onChanged: (font) {
+              if (font != null) _select(context, font);
+            },
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: AppFontFamily.values
+                  .map((font) {
+                    if (font.isSystem) return _buildTile(context, font);
+                    return ValueListenableBuilder(
+                      valueListenable: AppFontManager.downloadProgressOf(font),
+                      builder: (context, progress, _) =>
+                          _buildTile(context, font, progress),
+                    );
+                  })
+                  .toList(growable: false),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/app_font_archive_extractor.dart
+++ b/lib/services/app_font_archive_extractor.dart
@@ -1,0 +1,31 @@
+import 'package:archive/archive_io.dart';
+
+abstract final class AppFontArchiveExtractor {
+  static void extract(Map<String, String?> args) {
+    final input = InputFileStream(args['archivePath']!);
+    try {
+      final archive = ZipDecoder().decodeStream(input);
+
+      void extractEntry(String entryName, String outputPath) {
+        final entry = archive.findFile(entryName);
+        if (entry == null || !entry.isFile) {
+          throw StateError('压缩包中缺少所需文件');
+        }
+        final output = OutputFileStream(outputPath);
+        try {
+          entry.writeContent(output);
+        } finally {
+          output.closeSync();
+        }
+      }
+
+      extractEntry(args['entryName']!, args['outputPath']!);
+      final licenseEntryName = args['licenseEntryName'];
+      if (licenseEntryName != null) {
+        extractEntry(licenseEntryName, args['licenseOutputPath']!);
+      }
+    } finally {
+      input.closeSync();
+    }
+  }
+}

--- a/lib/services/app_font_manager.dart
+++ b/lib/services/app_font_manager.dart
@@ -148,35 +148,55 @@ abstract final class AppFontManager {
     try {
       await _fontDirectory.create(recursive: true);
       _deleteFile(temporary);
-      final response = await _dio.download(
-        font.downloadUrl!,
-        temporary.path,
-        deleteOnError: true,
-        onReceiveProgress: (received, total) {
-          final percent = total > 0 ? received * 100 ~/ total : -1;
-          if (percent != lastPercent) {
-            lastPercent = percent;
-            progress.value = (received: received, total: total);
+      Object? lastError;
+      StackTrace? lastStackTrace;
+      for (final url in font.downloadUrls!) {
+        try {
+          _deleteFile(temporary);
+          progress.value = (received: 0, total: -1);
+          lastPercent = -1;
+          final response = await _dio.download(
+            url,
+            temporary.path,
+            deleteOnError: true,
+            onReceiveProgress: (received, total) {
+              final percent = total > 0 ? received * 100 ~/ total : -1;
+              if (percent != lastPercent) {
+                lastPercent = percent;
+                progress.value = (received: received, total: total);
+              }
+            },
+          );
+          final statusCode = response.statusCode;
+          if (statusCode == null || statusCode < 200 || statusCode >= 300) {
+            throw AppFontDownloadException(
+              '字体下载失败（HTTP ${statusCode ?? '-'}）',
+            );
           }
-        },
+
+          if (await temporary.length() != font.downloadSize) {
+            throw const AppFontDownloadException('字体文件大小校验失败，请重试');
+          }
+          final digest = await sha256.bind(temporary.openRead()).first;
+          if (digest.toString() != font.sha256) {
+            throw const AppFontDownloadException('SHA-256 校验失败，请重试');
+          }
+
+          _deleteFile(target);
+          await temporary.rename(target.path);
+          return;
+        } catch (error, stackTrace) {
+          _deleteFile(temporary);
+          lastError = error is AppFontDownloadException
+              ? error
+              : _downloadException(error);
+          lastStackTrace = stackTrace;
+        }
+      }
+      Error.throwWithStackTrace(
+        lastError ?? const AppFontDownloadException('字体下载失败，请稍后重试'),
+        lastStackTrace ?? StackTrace.current,
       );
-      final statusCode = response.statusCode;
-      if (statusCode == null || statusCode < 200 || statusCode >= 300) {
-        throw AppFontDownloadException(
-          'GitHub 下载失败（HTTP ${statusCode ?? '-'}）',
-        );
-      }
-
-      if (await temporary.length() != font.downloadSize) {
-        throw const AppFontDownloadException('字体文件大小校验失败，请重试');
-      }
-      final digest = await sha256.bind(temporary.openRead()).first;
-      if (digest.toString() != font.sha256) {
-        throw const AppFontDownloadException('SHA-256 校验失败，请重试');
-      }
-
-      _deleteFile(target);
-      await temporary.rename(target.path);
     } catch (error, stackTrace) {
       _deleteFile(temporary);
       final exception = error is AppFontDownloadException
@@ -193,15 +213,15 @@ abstract final class AppFontManager {
       final statusCode = error.response?.statusCode;
       if (statusCode != null) {
         return AppFontDownloadException(
-          'GitHub 下载失败（HTTP $statusCode）',
+          '字体下载失败（HTTP $statusCode）',
         );
       }
       if (error.type == DioExceptionType.connectionTimeout ||
           error.type == DioExceptionType.receiveTimeout ||
           error.type == DioExceptionType.sendTimeout) {
-        return const AppFontDownloadException('GitHub 连接超时，请检查网络后重试');
+        return const AppFontDownloadException('字体下载连接超时，请检查网络后重试');
       }
-      return const AppFontDownloadException('无法从 GitHub 下载字体，请检查网络');
+      return const AppFontDownloadException('无法下载字体，请检查网络');
     }
     if (error is FileSystemException) {
       return const AppFontDownloadException('字体文件保存失败，请检查存储空间');

--- a/lib/services/app_font_manager.dart
+++ b/lib/services/app_font_manager.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:PiliPlus/models/common/app_font_family.dart';
+import 'package:PiliPlus/services/app_font_archive_extractor.dart';
 import 'package:PiliPlus/utils/path_utils.dart';
 import 'package:PiliPlus/utils/storage.dart';
 import 'package:PiliPlus/utils/storage_key.dart';
@@ -53,6 +54,13 @@ abstract final class AppFontManager {
   static File _fontFile(AppFontFamily font) =>
       File(path.join(_fontDirectory.path, font.fileName!));
 
+  static File? _fontLicenseFile(AppFontFamily font) {
+    final fileName = font.downloadArchive?.licenseFileName;
+    return fileName == null
+        ? null
+        : File(path.join(_fontDirectory.path, fileName));
+  }
+
   static ValueListenable<AppFontDownloadProgress?> downloadProgressOf(
     AppFontFamily font,
   ) => _progress[font]!;
@@ -80,6 +88,11 @@ abstract final class AppFontManager {
       for (final font in AppFontFamily.values) {
         if (!font.isSystem) {
           _deleteFile(File('${_fontFile(font).path}.part'));
+          _deleteFile(File('${_fontFile(font).path}.extract'));
+          final licenseFile = _fontLicenseFile(font);
+          if (licenseFile != null) {
+            _deleteFile(File('${licenseFile.path}.part'));
+          }
         }
       }
 
@@ -142,12 +155,19 @@ abstract final class AppFontManager {
   static Future<void> _download(AppFontFamily font) async {
     final target = _fontFile(font);
     final temporary = File('${target.path}.part');
+    final extracted = File('${target.path}.extract');
+    final licenseTarget = _fontLicenseFile(font);
+    final licenseTemporary = licenseTarget == null
+        ? null
+        : File('${licenseTarget.path}.part');
     final progress = _progress[font]!..value = (received: 0, total: -1);
     int lastPercent = -1;
 
     try {
       await _fontDirectory.create(recursive: true);
       _deleteFile(temporary);
+      _deleteFile(extracted);
+      if (licenseTemporary != null) _deleteFile(licenseTemporary);
       Object? lastError;
       StackTrace? lastStackTrace;
       for (final url in font.downloadUrls!) {
@@ -174,19 +194,43 @@ abstract final class AppFontManager {
             );
           }
 
-          if (await temporary.length() != font.downloadSize) {
-            throw const AppFontDownloadException('字体文件大小校验失败，请重试');
-          }
-          final digest = await sha256.bind(temporary.openRead()).first;
-          if (digest.toString() != font.sha256) {
-            throw const AppFontDownloadException('SHA-256 校验失败，请重试');
+          final downloadArchive = font.downloadArchive;
+          await _verifyFile(
+            temporary,
+            downloadArchive?.downloadSize ?? font.downloadSize!,
+            downloadArchive?.sha256 ?? font.sha256!,
+          );
+
+          File fontPayload = temporary;
+          if (downloadArchive != null) {
+            _deleteFile(extracted);
+            if (licenseTemporary != null) _deleteFile(licenseTemporary);
+            await compute(AppFontArchiveExtractor.extract, {
+              'archivePath': temporary.path,
+              'entryName': downloadArchive.entryName,
+              'outputPath': extracted.path,
+              'licenseEntryName': downloadArchive.licenseEntryName,
+              'licenseOutputPath': licenseTemporary?.path,
+            });
+            await _verifyFile(extracted, font.downloadSize!, font.sha256!);
+            fontPayload = extracted;
           }
 
+          if (licenseTarget != null && licenseTemporary != null) {
+            if (!licenseTemporary.existsSync()) {
+              throw const AppFontDownloadException('字体许可文件提取失败，请重试');
+            }
+            _deleteFile(licenseTarget);
+            await licenseTemporary.rename(licenseTarget.path);
+          }
           _deleteFile(target);
-          await temporary.rename(target.path);
+          await fontPayload.rename(target.path);
+          _deleteFile(temporary);
           return;
         } catch (error, stackTrace) {
           _deleteFile(temporary);
+          _deleteFile(extracted);
+          if (licenseTemporary != null) _deleteFile(licenseTemporary);
           lastError = error is AppFontDownloadException
               ? error
               : _downloadException(error);
@@ -199,12 +243,28 @@ abstract final class AppFontManager {
       );
     } catch (error, stackTrace) {
       _deleteFile(temporary);
+      _deleteFile(extracted);
+      if (licenseTemporary != null) _deleteFile(licenseTemporary);
       final exception = error is AppFontDownloadException
           ? error
           : _downloadException(error);
       Error.throwWithStackTrace(exception, stackTrace);
     } finally {
       progress.value = null;
+    }
+  }
+
+  static Future<void> _verifyFile(
+    File file,
+    int expectedSize,
+    String expectedSha256,
+  ) async {
+    if (await file.length() != expectedSize) {
+      throw const AppFontDownloadException('字体文件大小校验失败，请重试');
+    }
+    final digest = await sha256.bind(file.openRead()).first;
+    if (digest.toString() != expectedSha256) {
+      throw const AppFontDownloadException('SHA-256 校验失败，请重试');
     }
   }
 

--- a/lib/services/app_font_manager.dart
+++ b/lib/services/app_font_manager.dart
@@ -1,0 +1,217 @@
+import 'dart:io';
+
+import 'package:PiliPlus/models/common/app_font_family.dart';
+import 'package:PiliPlus/utils/path_utils.dart';
+import 'package:PiliPlus/utils/storage.dart';
+import 'package:PiliPlus/utils/storage_key.dart';
+import 'package:PiliPlus/utils/storage_pref.dart';
+import 'package:crypto/crypto.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:path/path.dart' as path;
+
+typedef AppFontDownloadProgress = ({int received, int total});
+
+final class AppFontDownloadException implements Exception {
+  const AppFontDownloadException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+abstract final class AppFontManager {
+  static final Dio _dio = Dio(
+    BaseOptions(
+      connectTimeout: const Duration(seconds: 30),
+      receiveTimeout: const Duration(minutes: 2),
+      followRedirects: true,
+      maxRedirects: 8,
+      headers: const {
+        HttpHeaders.acceptHeader: 'application/octet-stream',
+        HttpHeaders.userAgentHeader: 'PiliPlus font downloader',
+      },
+      validateStatus: (status) =>
+          status != null && status >= 200 && status < 300,
+    ),
+  );
+
+  static final Map<AppFontFamily, ValueNotifier<AppFontDownloadProgress?>>
+  _progress = {
+    for (final font in AppFontFamily.values)
+      if (!font.isSystem) font: ValueNotifier<AppFontDownloadProgress?>(null),
+  };
+  static final Map<AppFontFamily, Future<void>> _downloads = {};
+  static final Set<AppFontFamily> _loadedFonts = {};
+  static bool _initialized = false;
+
+  static Directory get _fontDirectory =>
+      Directory(path.join(appSupportDirPath, PathUtils.appFontDir));
+
+  static File _fontFile(AppFontFamily font) =>
+      File(path.join(_fontDirectory.path, font.fileName!));
+
+  static ValueListenable<AppFontDownloadProgress?> downloadProgressOf(
+    AppFontFamily font,
+  ) => _progress[font]!;
+
+  static bool isDownloaded(AppFontFamily font) {
+    if (font.isSystem) return true;
+    try {
+      final file = _fontFile(font);
+      return file.existsSync() && file.lengthSync() == font.downloadSize;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  static String? fontFamilyFor(AppFontFamily font) =>
+      _loadedFonts.contains(font) ? font.fontFamily : null;
+
+  static Future<void> init() async {
+    if (_initialized) return;
+    _initialized = true;
+
+    final selected = Pref.appFontFamily;
+    try {
+      await _fontDirectory.create(recursive: true);
+      for (final font in AppFontFamily.values) {
+        if (!font.isSystem) {
+          _deleteFile(File('${_fontFile(font).path}.part'));
+        }
+      }
+
+      if (selected.isSystem) return;
+      if (!isDownloaded(selected)) {
+        await GStorage.setting.delete(SettingBoxKey.appFontFamily);
+        return;
+      }
+      await load(selected);
+    } catch (error) {
+      if (!selected.isSystem) {
+        try {
+          await GStorage.setting.delete(SettingBoxKey.appFontFamily);
+        } catch (_) {}
+      }
+      if (kDebugMode) {
+        debugPrint('App font restore failed: $error');
+      }
+    }
+  }
+
+  static Future<void> load(AppFontFamily font) async {
+    if (font.isSystem || _loadedFonts.contains(font)) return;
+    if (!isDownloaded(font)) {
+      throw const AppFontDownloadException('字体文件不完整，请重新下载');
+    }
+
+    try {
+      final bytes = await _fontFile(font).readAsBytes();
+      final loader = FontLoader(font.fontFamily!)
+        ..addFont(Future.value(ByteData.sublistView(bytes)));
+      await loader.load();
+      _loadedFonts.add(font);
+    } catch (error, stackTrace) {
+      _deleteFile(_fontFile(font));
+      Error.throwWithStackTrace(
+        const AppFontDownloadException('字体加载失败，请重新下载'),
+        stackTrace,
+      );
+    }
+  }
+
+  static Future<void> download(AppFontFamily font) {
+    if (font.isSystem) return Future.value();
+    if (isDownloaded(font)) return Future.value();
+
+    final existing = _downloads[font];
+    if (existing != null) return existing;
+
+    late final Future<void> task;
+    task = _download(font).whenComplete(() {
+      if (identical(_downloads[font], task)) {
+        _downloads.remove(font);
+      }
+    });
+    _downloads[font] = task;
+    return task;
+  }
+
+  static Future<void> _download(AppFontFamily font) async {
+    final target = _fontFile(font);
+    final temporary = File('${target.path}.part');
+    final progress = _progress[font]!..value = (received: 0, total: -1);
+    int lastPercent = -1;
+
+    try {
+      await _fontDirectory.create(recursive: true);
+      _deleteFile(temporary);
+      final response = await _dio.download(
+        font.downloadUrl!,
+        temporary.path,
+        deleteOnError: true,
+        onReceiveProgress: (received, total) {
+          final percent = total > 0 ? received * 100 ~/ total : -1;
+          if (percent != lastPercent) {
+            lastPercent = percent;
+            progress.value = (received: received, total: total);
+          }
+        },
+      );
+      final statusCode = response.statusCode;
+      if (statusCode == null || statusCode < 200 || statusCode >= 300) {
+        throw AppFontDownloadException(
+          'GitHub 下载失败（HTTP ${statusCode ?? '-'}）',
+        );
+      }
+
+      if (await temporary.length() != font.downloadSize) {
+        throw const AppFontDownloadException('字体文件大小校验失败，请重试');
+      }
+      final digest = await sha256.bind(temporary.openRead()).first;
+      if (digest.toString() != font.sha256) {
+        throw const AppFontDownloadException('SHA-256 校验失败，请重试');
+      }
+
+      _deleteFile(target);
+      await temporary.rename(target.path);
+    } catch (error, stackTrace) {
+      _deleteFile(temporary);
+      final exception = error is AppFontDownloadException
+          ? error
+          : _downloadException(error);
+      Error.throwWithStackTrace(exception, stackTrace);
+    } finally {
+      progress.value = null;
+    }
+  }
+
+  static AppFontDownloadException _downloadException(Object error) {
+    if (error is DioException) {
+      final statusCode = error.response?.statusCode;
+      if (statusCode != null) {
+        return AppFontDownloadException(
+          'GitHub 下载失败（HTTP $statusCode）',
+        );
+      }
+      if (error.type == DioExceptionType.connectionTimeout ||
+          error.type == DioExceptionType.receiveTimeout ||
+          error.type == DioExceptionType.sendTimeout) {
+        return const AppFontDownloadException('GitHub 连接超时，请检查网络后重试');
+      }
+      return const AppFontDownloadException('无法从 GitHub 下载字体，请检查网络');
+    }
+    if (error is FileSystemException) {
+      return const AppFontDownloadException('字体文件保存失败，请检查存储空间');
+    }
+    return const AppFontDownloadException('字体下载失败，请稍后重试');
+  }
+
+  static void _deleteFile(File file) {
+    try {
+      if (file.existsSync()) file.deleteSync();
+    } catch (_) {}
+  }
+}

--- a/lib/utils/path_utils.dart
+++ b/lib/utils/path_utils.dart
@@ -12,6 +12,7 @@ String get defDownloadPath =>
     path.join(appSupportDirPath, PathUtils.downloadDir);
 
 abstract final class PathUtils {
+  static const appFontDir = 'fonts';
   static const videoNameType1 = '0.mp4';
   static const _fileExt = '.m4s';
   static const audioNameType2 = 'audio$_fileExt';

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -127,6 +127,7 @@ abstract final class SettingBoxKey {
       retryDelay = 'retryDelay',
       liveQuality = 'liveQuality',
       liveQualityCellular = 'liveQualityCellular',
+      appFontFamily = 'appFontFamily',
       appFontWeight = 'appFontWeight',
       fastForBackwardDuration = 'fastForBackwardDuration',
       recordSearchHistory = 'recordSearchHistory',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -4,6 +4,7 @@ import 'package:PiliPlus/common/widgets/gesture/horizontal_drag_gesture_recogniz
     show deviceTouchSlop;
 import 'package:PiliPlus/common/widgets/pair.dart';
 import 'package:PiliPlus/http/constants.dart';
+import 'package:PiliPlus/models/common/app_font_family.dart';
 import 'package:PiliPlus/models/common/bar_hide_type.dart';
 import 'package:PiliPlus/models/common/dynamic/dynamic_badge_mode.dart';
 import 'package:PiliPlus/models/common/dynamic/dynamics_type.dart';
@@ -589,6 +590,10 @@ abstract final class Pref {
 
   static int get appFontWeight =>
       _setting.get(SettingBoxKey.appFontWeight, defaultValue: -1);
+
+  static AppFontFamily get appFontFamily => AppFontFamily.fromName(
+    _setting.get(SettingBoxKey.appFontFamily),
+  );
 
   static bool get enableDragSubtitle =>
       _setting.get(SettingBoxKey.enableDragSubtitle, defaultValue: false);

--- a/lib/utils/theme_utils.dart
+++ b/lib/utils/theme_utils.dart
@@ -1,4 +1,5 @@
 import 'package:PiliPlus/common/style.dart';
+import 'package:PiliPlus/services/app_font_manager.dart';
 import 'package:PiliPlus/utils/extension/theme_ext.dart';
 import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:flutter/cupertino.dart' show CupertinoThemeData;
@@ -38,9 +39,14 @@ abstract final class ThemeUtils {
     final fontWeight = appFontWeight == -1
         ? null
         : FontWeight.values[appFontWeight];
-    late final textStyle = TextStyle(fontWeight: fontWeight);
+    final fontFamily = AppFontManager.fontFamilyFor(Pref.appFontFamily);
+    late final textStyle = TextStyle(
+      fontFamily: fontFamily,
+      fontWeight: fontWeight,
+    );
     ThemeData themeData = ThemeData(
       colorScheme: colorScheme,
+      fontFamily: fontFamily,
       useMaterial3: true,
       textTheme: fontWeight == null
           ? null
@@ -73,6 +79,7 @@ abstract final class ThemeUtils {
         titleTextStyle: TextStyle(
           fontSize: 16,
           color: colorScheme.onSurface,
+          fontFamily: fontFamily,
           fontWeight: fontWeight,
         ),
       ),
@@ -83,7 +90,10 @@ abstract final class ThemeUtils {
         actionTextColor: colorScheme.primary,
         backgroundColor: colorScheme.secondaryContainer,
         closeIconColor: colorScheme.secondary,
-        contentTextStyle: TextStyle(color: colorScheme.onSecondaryContainer),
+        contentTextStyle: TextStyle(
+          color: colorScheme.onSecondaryContainer,
+          fontFamily: fontFamily,
+        ),
         elevation: 20,
       ),
       popupMenuTheme: PopupMenuThemeData(
@@ -108,6 +118,7 @@ abstract final class ThemeUtils {
         titleTextStyle: TextStyle(
           fontSize: 18,
           color: colorScheme.onSurface,
+          fontFamily: fontFamily,
           fontWeight: fontWeight,
         ),
         backgroundColor: colorScheme.surface,
@@ -122,8 +133,9 @@ abstract final class ThemeUtils {
       // ignore: deprecated_member_use
       sliderTheme: const SliderThemeData(year2023: false),
       tooltipTheme: TooltipThemeData(
-        textStyle: const TextStyle(
+        textStyle: TextStyle(
           color: Colors.white,
+          fontFamily: fontFamily,
           fontSize: 14,
         ),
         decoration: BoxDecoration(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -273,6 +273,7 @@ flutter:
     - path: assets/images/live/
     - path: assets/images/paycoins/
     - path: assets/shaders/
+    - path: assets/fonts/licenses/
 
   fonts:
     - family: digital_id_num

--- a/test/models/common/app_font_family_test.dart
+++ b/test/models/common/app_font_family_test.dart
@@ -17,10 +17,24 @@ void main() {
         AppFontFamily.sourceHanSerifCn.fontFamily,
         'Source Han Serif CN',
       );
+      expect(
+        AppFontFamily.sourceHanSansCn.fontFamily,
+        'Source Han Sans CN',
+      );
+      expect(AppFontFamily.miSans.fontFamily, 'MiSans');
+      expect(
+        AppFontFamily.harmonyOsSansSc.fontFamily,
+        'HarmonyOS Sans SC',
+      );
       expect(AppFontFamily.lxgwWenKaiGbScreen.label, '霞鹜文楷');
       expect(AppFontFamily.lxgwZhenKaiGb.label, '霞鹜臻楷');
+      expect(AppFontFamily.lxgwNeoXiHeiScreen.label, '霞鹜新晰黑');
+      expect(AppFontFamily.lxgwZhuqueFangsong.label, '霞鹜朱雀仿宋');
+      expect(AppFontFamily.sourceHanSansCn.label, '思源黑体');
       expect(AppFontFamily.sourceHanSerifCn.label, '思源宋体');
+      expect(AppFontFamily.fusionPixel.label, '缝合像素字体');
       expect(AppFontFamily.system.downloadUrls, isNull);
+      expect(AppFontFamily.system.transferSize, isNull);
       expect(AppFontFamily.system.isSystem, isTrue);
 
       for (final item in AppFontFamily.values.skip(1)) {
@@ -31,7 +45,20 @@ void main() {
           expect(url, startsWith('https://'));
         }
         expect(item.downloadSize, greaterThan(0));
+        expect(item.transferSize, greaterThanOrEqualTo(item.downloadSize!));
         expect(item.sha256, hasLength(64));
+        expect(item.licenseUrl == null, item.licenseNotice == null);
+
+        final archive = item.downloadArchive;
+        if (archive != null) {
+          expect(archive.entryName, isNotEmpty);
+          expect(archive.downloadSize, greaterThan(0));
+          expect(archive.sha256, hasLength(64));
+          expect(
+            archive.licenseEntryName == null,
+            archive.licenseFileName == null,
+          );
+        }
       }
     });
 

--- a/test/models/common/app_font_family_test.dart
+++ b/test/models/common/app_font_family_test.dart
@@ -6,6 +6,10 @@ void main() {
     test('uses stable runtime font metadata', () {
       expect(AppFontFamily.system.fontFamily, isNull);
       expect(
+        AppFontFamily.lxgwWenKaiGbScreen.fontFamily,
+        'LXGW WenKai GB Screen',
+      );
+      expect(
         AppFontFamily.lxgwZhenKaiGb.fontFamily,
         'LXGW ZhenKai GB',
       );
@@ -13,6 +17,7 @@ void main() {
         AppFontFamily.sourceHanSerifCn.fontFamily,
         'Source Han Serif CN',
       );
+      expect(AppFontFamily.lxgwWenKaiGbScreen.label, '霞鹜文楷');
       expect(AppFontFamily.lxgwZhenKaiGb.label, '霞鹜臻楷');
       expect(AppFontFamily.sourceHanSerifCn.label, '思源宋体');
       expect(AppFontFamily.system.downloadUrls, isNull);

--- a/test/models/common/app_font_family_test.dart
+++ b/test/models/common/app_font_family_test.dart
@@ -6,22 +6,25 @@ void main() {
     test('uses stable runtime font metadata', () {
       expect(AppFontFamily.system.fontFamily, isNull);
       expect(
-        AppFontFamily.lxgwWenKaiGbScreen.fontFamily,
-        'LXGW WenKai GB Screen',
+        AppFontFamily.lxgwZhenKaiGb.fontFamily,
+        'LXGW ZhenKai GB',
       );
       expect(
         AppFontFamily.sourceHanSerifCn.fontFamily,
         'Source Han Serif CN',
       );
-      expect(AppFontFamily.lxgwWenKaiGbScreen.label, '霞鹜文楷');
+      expect(AppFontFamily.lxgwZhenKaiGb.label, '霞鹜臻楷');
       expect(AppFontFamily.sourceHanSerifCn.label, '思源宋体');
-      expect(AppFontFamily.system.downloadUrl, isNull);
+      expect(AppFontFamily.system.downloadUrls, isNull);
       expect(AppFontFamily.system.isSystem, isTrue);
 
       for (final item in AppFontFamily.values.skip(1)) {
         expect(item.isSystem, isFalse);
         expect(item.fileName, isNotEmpty);
-        expect(item.downloadUrl, startsWith('https://'));
+        expect(item.downloadUrls, isNotEmpty);
+        for (final url in item.downloadUrls!) {
+          expect(url, startsWith('https://'));
+        }
         expect(item.downloadSize, greaterThan(0));
         expect(item.sha256, hasLength(64));
       }

--- a/test/models/common/app_font_family_test.dart
+++ b/test/models/common/app_font_family_test.dart
@@ -1,0 +1,41 @@
+import 'package:PiliPlus/models/common/app_font_family.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppFontFamily', () {
+    test('uses stable runtime font metadata', () {
+      expect(AppFontFamily.system.fontFamily, isNull);
+      expect(
+        AppFontFamily.lxgwWenKaiGbScreen.fontFamily,
+        'LXGW WenKai GB Screen',
+      );
+      expect(
+        AppFontFamily.sourceHanSerifCn.fontFamily,
+        'Source Han Serif CN',
+      );
+      expect(AppFontFamily.lxgwWenKaiGbScreen.label, '霞鹜文楷');
+      expect(AppFontFamily.sourceHanSerifCn.label, '思源宋体');
+      expect(AppFontFamily.system.downloadUrl, isNull);
+      expect(AppFontFamily.system.isSystem, isTrue);
+
+      for (final item in AppFontFamily.values.skip(1)) {
+        expect(item.isSystem, isFalse);
+        expect(item.fileName, isNotEmpty);
+        expect(item.downloadUrl, startsWith('https://'));
+        expect(item.downloadSize, greaterThan(0));
+        expect(item.sha256, hasLength(64));
+      }
+    });
+
+    test('restores persisted names', () {
+      for (final item in AppFontFamily.values) {
+        expect(AppFontFamily.fromName(item.name), item);
+      }
+    });
+
+    test('falls back to the system font for unknown values', () {
+      expect(AppFontFamily.fromName(null), AppFontFamily.system);
+      expect(AppFontFamily.fromName('removedFont'), AppFontFamily.system);
+    });
+  });
+}

--- a/test/pages/setting/widgets/app_font_family_dialog_test.dart
+++ b/test/pages/setting/widgets/app_font_family_dialog_test.dart
@@ -27,18 +27,24 @@ void main() {
       ),
     );
 
-    expect(find.text('系统默认'), findsOneWidget);
-    expect(find.text('霞鹜文楷'), findsOneWidget);
-    expect(find.text('思源宋体'), findsOneWidget);
+    for (final font in AppFontFamily.values) {
+      expect(find.text(font.label), findsOneWidget);
+    }
     expect(find.text('24.8 MB'), findsOneWidget);
     expect(find.text('11.1 MB'), findsOneWidget);
-    expect(find.byTooltip('下载字体'), findsNWidgets(2));
+    expect(
+      find.byTooltip('下载字体'),
+      findsNWidgets(AppFontFamily.values.length - 1),
+    );
 
     final radios = tester
         .widgetList<Radio<AppFontFamily>>(
           find.byType(Radio<AppFontFamily>),
         )
         .toList(growable: false);
-    expect(radios.map((radio) => radio.enabled), [true, false, false]);
+    expect(
+      radios.map((radio) => radio.enabled),
+      [true, ...List.filled(AppFontFamily.values.length - 1, false)],
+    );
   });
 }

--- a/test/pages/setting/widgets/app_font_family_dialog_test.dart
+++ b/test/pages/setting/widgets/app_font_family_dialog_test.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+import 'package:PiliPlus/models/common/app_font_family.dart';
+import 'package:PiliPlus/pages/setting/widgets/app_font_family_dialog.dart';
+import 'package:PiliPlus/utils/path_utils.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late final Directory supportDir;
+
+  setUpAll(() {
+    supportDir = Directory.systemTemp.createTempSync('piliplus-font-test-');
+    appSupportDirPath = supportDir.path;
+  });
+
+  tearDownAll(() {
+    supportDir.deleteSync(recursive: true);
+  });
+
+  testWidgets('offers downloads before custom fonts can be selected', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: AppFontFamilyDialog(value: AppFontFamily.system),
+      ),
+    );
+
+    expect(find.text('系统默认'), findsOneWidget);
+    expect(find.text('霞鹜文楷'), findsOneWidget);
+    expect(find.text('思源宋体'), findsOneWidget);
+    expect(find.text('24.8 MB'), findsOneWidget);
+    expect(find.text('11.1 MB'), findsOneWidget);
+    expect(find.byTooltip('下载字体'), findsNWidgets(2));
+
+    final radios = tester
+        .widgetList<Radio<AppFontFamily>>(
+          find.byType(Radio<AppFontFamily>),
+        )
+        .toList(growable: false);
+    expect(radios.map((radio) => radio.enabled), [true, false, false]);
+  });
+}

--- a/test/services/app_font_archive_extractor_test.dart
+++ b/test/services/app_font_archive_extractor_test.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:PiliPlus/services/app_font_archive_extractor.dart';
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('extracts the selected font and license entries', () {
+    final directory = Directory.systemTemp.createTempSync(
+      'piliplus-font-test-',
+    );
+    addTearDown(() => directory.deleteSync(recursive: true));
+
+    final fontBytes = Uint8List.fromList([1, 2, 3, 4]);
+    final licenseBytes = Uint8List.fromList([5, 6, 7]);
+    final archive = Archive()
+      ..addFile(ArchiveFile('fonts/font.ttf', fontBytes.length, fontBytes))
+      ..addFile(
+        ArchiveFile('fonts/LICENSE.txt', licenseBytes.length, licenseBytes),
+      );
+    final archivePath = '${directory.path}/font.zip';
+    File(archivePath).writeAsBytesSync(ZipEncoder().encode(archive));
+
+    final fontPath = '${directory.path}/font.ttf';
+    final licensePath = '${directory.path}/LICENSE.txt';
+    AppFontArchiveExtractor.extract({
+      'archivePath': archivePath,
+      'entryName': 'fonts/font.ttf',
+      'outputPath': fontPath,
+      'licenseEntryName': 'fonts/LICENSE.txt',
+      'licenseOutputPath': licensePath,
+    });
+
+    expect(File(fontPath).readAsBytesSync(), fontBytes);
+    expect(File(licensePath).readAsBytesSync(), licenseBytes);
+  });
+
+  test('rejects an archive without the requested font', () {
+    final directory = Directory.systemTemp.createTempSync(
+      'piliplus-font-test-',
+    );
+    addTearDown(() => directory.deleteSync(recursive: true));
+
+    final archivePath = '${directory.path}/font.zip';
+    File(archivePath).writeAsBytesSync(ZipEncoder().encode(Archive()));
+
+    expect(
+      () => AppFontArchiveExtractor.extract({
+        'archivePath': archivePath,
+        'entryName': 'missing.ttf',
+        'outputPath': '${directory.path}/font.ttf',
+        'licenseEntryName': null,
+        'licenseOutputPath': null,
+      }),
+      throwsStateError,
+    );
+  });
+}


### PR DESCRIPTION
## 变更说明

为 PiliPlus 新增应用界面字体修改功能。

目前 PiliPlus 无法在应用内调整界面字体。**本次修改在设置页面中增加 App 字体设置项**，用户可以按需下载并使用预设字体。

本功能修改了应用 UI 字体以及字幕、视频内容等字体，对弹幕字体无影响，同时未明显增大包体积。

## 修改内容

- 在设置页面新增 App 字体设置项
- 支持按需下载、选择和应用界面字体
- 支持显示字体下载进度和下载状态
- 支持应用重启后恢复已选择的字体
- 未在安装包内内置额外字体文件
- 未选择自定义字体时继续使用系统默认字体
- 不影响现有用户的默认显示效果

## 可选字体

目前提供以下选项：

- 系统默认
- 霞鹜文楷
- 霞鹜臻楷
- 霞鹜新晰黑
- 霞鹜朱雀仿宋
- 思源黑体
- 思源宋体
- MiSans
- HarmonyOS Sans
- 缝合像素字体

字体优先从官方站点或国内开源镜像下载，并在适用时保留官方 GitHub 地址作为备用来源。

## 测试情况

### Android

- 已完成实际设备测试
- 系统版本：Android 16
- PiliPlus 版本：基于提交时最新版本分支修改
- 字体下载、选择、应用及恢复默认字体功能正常
- 应用重启后字体设置正常保留

### Windows

- 已完成实际启动验证
- 系统版本：Windows 10
- PiliPlus 版本：基于提交时最新版本修改
- 字体选择、应用及恢复默认字体功能正常
- 应用重启后字体设置正常保留

### 自动化检查

- 字体元数据单元测试通过
- ZIP 字体提取及异常处理测试通过
- 本次修改涉及文件的静态分析通过
- Windows Release 构建通过

### iOS

目前没有可用于测试或构建 iOS 应用的 Mac 设备，因此未进行 iOS 真机测试和 iOS 编译验证。

本次实现使用 Flutter 提供的运行时字体加载能力，并未添加特定于 Android 或 Windows 的字体加载逻辑，但 iOS 平台的实际兼容性仍需在 macOS 环境中验证。

## 下载与完整性

字体下载采用临时文件保存，完成后执行文件大小和 SHA-256 校验。只有校验通过的字体才会写入正式存储位置。

对于提供多个下载来源的字体，首选来源失败、超时或校验不通过时，会自动尝试下一个来源。

字体压缩包在后台完成定点提取，仅保留实际使用的字体文件，不长期保存完整压缩包。

## 授权说明

- 霞鹜系列、思源系列和缝合像素字体按照各自开源字体许可证使用
- HarmonyOS Sans 使用前展示华为官方许可协议确认，并保留随字体提供的许可文件
- MiSans 使用前展示小米官方许可协议确认
- MiSans 仅从小米官方站点下载，不使用第三方重新分发的字体文件

## 包体积影响

本功能不会在项目中内置可选字体资源，字体仅在用户主动下载后保存到应用数据目录。

Windows Release 字体清单已检查，不包含上述可选字体。因此本次修改只会增加少量功能代码，不会因字体资源明显增加应用安装包体积。

需要注意的是，字体下载会占用网络流量和应用数据目录空间。其中部分官方字体以压缩包形式提供，实际下载量可能大于最终保留的字体文件大小。

## 兼容性说明

未设置自定义字体时，应用行为与修改前保持一致，继续使用原有字体配置。

如果已选择的字体文件丢失或不完整，应用会自动回退到系统默认字体，避免因字体文件异常影响正常启动。

本次修改已在 Android 和 Windows 平台完成实际验证；iOS 平台尚未完成构建和真机验证。

## 截图

<img width="1459" height="892" alt="3b340b362c126e3e788f9bf531c80fba" src="https://github.com/user-attachments/assets/a5a808fa-e509-4943-8840-031fcf0bcab1" />

<img width="1459" height="892" alt="dcb82a760643ef7662db19ff59acc10b" src="https://github.com/user-attachments/assets/8551f0e9-fd0f-41f2-9bd8-a07a0f65cc83" />

<img width="1459" height="892" alt="8a59f891413a83cf9aef60df524c9adc" src="https://github.com/user-attachments/assets/635b8716-7c62-41be-abc6-ffcc1fd8890b" />

<img width="1459" height="892" alt="02f791cd0d17d40cedf0a043c2dbfac4" src="https://github.com/user-attachments/assets/8f9194be-e924-4100-92aa-1b5ab6de46e5" />


