### PR TITLE
fix: auto-recover from stream corruption errors

### DIFF
--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -731,6 +731,7 @@ class PlPlayerController with BlockConfigMixin {
     final opt = {
       'video-sync': Pref.videoSync,
       if (Platform.isAndroid) 'ao': Pref.audioOutput,
+      'stream-lavf-o': 'reconnect=1',
       'volume':
           (PlatformUtils.isMobile ? Pref.playerVolume : volume.value * 100)
               .toString(),
@@ -1029,6 +1030,15 @@ class PlPlayerController with BlockConfigMixin {
               });
             },
           );
+        } else if (event.contains('Invalid NAL unit size') ||
+            event.contains('Error splitting the input into NAL') ||
+            event.contains('Stream ends prematurely')) {
+          EasyThrottle.throttle(
+            'controllerStream.nal.error',
+            const Duration(milliseconds: 5000),
+            refreshPlayer,
+          );
+          Utils.reportError(event);
         } else if (event.startsWith('Could not open codec')) {
           SmartDialog.showToast('无法加载解码器, $event，可能会切换至软解');
         } else if (!onlyPlayAudio.value) {


### PR DESCRIPTION
## Summary

- Add `stream-lavf-o=reconnect=1` to PlayerConfiguration options to enable HTTP stream reconnection on connection drops
- Auto-refresh player when NAL corruption errors occur (Invalid NAL unit size, Error splitting NAL, Stream ends prematurely), with 5s throttle to prevent loops

## Context

On certain devices (tested on HONOR MBH-N49, Android 16, Qualcomm), bilibili CDN connections are intermittently reset, causing corrupted data to reach the H.264 decoder. This results in a flood of `Invalid NAL unit size` errors and permanent playback stall (video freezes while audio may continue, or vice versa).

Previously, users had to manually seek or reload the video to recover. With this fix, the player automatically calls `refreshPlayer()` on NAL corruption errors, restoring playback from the current position.

## Test plan

- [x] Verified on HONOR MBH-N49 (Android 16) — player auto-recovers instead of freezing
- [x] Verify no regression on other Android devices
- [x] Verify no regression on iOS/desktop platforms
- [x] Verify `stream-lavf-o=reconnect=1` doesn't cause startup errors (it's a valid lavf protocol option)