### PR TITLE
feat: enable MPV warn-level logging in Release mode

### DIFF
--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -743,7 +743,7 @@ class PlPlayerController with BlockConfigMixin {
 
     final player = await Player.create(
       configuration: PlayerConfiguration(
-        logLevel: kDebugMode ? .warn : .error,
+        logLevel: (kDebugMode || Pref.enableLog) ? .warn : .error,
         options: opt,
       ),
     );
@@ -982,14 +982,15 @@ class PlPlayerController with BlockConfigMixin {
           isLive,
         );
       }),
-      if (kDebugMode)
-        stream.log.listen(((PlayerLog log) {
-          if (log.level == 'error' || log.level == 'fatal') {
-            Utils.reportError('${log.level}: ${log.prefix}: ${log.text}', null);
-          } else {
-            debugPrint(log.toString());
-          }
-        })),
+      stream.log.listen(((PlayerLog log) {
+        if (log.level == 'error' || log.level == 'fatal') {
+          Utils.reportError('${log.level}: ${log.prefix}: ${log.text}', null);
+        } else if (kDebugMode) {
+          debugPrint(log.toString());
+        } else if (log.level == 'warn' && Pref.enableLog) {
+          Utils.reportError('${log.level}: ${log.prefix}: ${log.text}', null);
+        }
+      })),
       stream.error.listen((String event) {
         if (dataSource is FileSource &&
             event.startsWith("Failed to open file")) {


### PR DESCRIPTION
## Summary

- When user has logging enabled (`Pref.enableLog`), set MPV log level to `warn` instead of `error`
- Always attach `stream.log` listener (not gated by `kDebugMode`), so error/fatal messages are captured in the in-app log viewer in Release builds
- In Release mode with logging enabled, also record `warn`-level MPV messages (e.g. stream reconnection attempts, codec fallbacks)

## Motivation

When diagnosing playback issues on user devices (e.g. stream corruption, CDN disconnects), the current `error`-only logging misses important context like `tls: mbedtls_ssl_read reported connection reset by peer` or `vd: Attempting next decoding method after failure`. These are logged at `warn` level by MPV and are invisible in Release builds.

This change respects the existing in-app log toggle — no extra disk/CPU cost when logging is disabled.

## Test plan

- [x] Verify no performance regression with logging disabled (default path unchanged)
- [x] Verify warn-level logs appear in the in-app log page when logging is enabled
- [x] Verify no impact on iOS/desktop platforms