### PR TITLE
fix(macos): 🐛 restore opaque window background for title bar

### DIFF
--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -9,9 +9,9 @@ class MainFlutterWindow: NSWindow {
     self.contentViewController = flutterViewController
     self.setFrame(self.frame, display: true)
 
-    // 背景别用默认黑色
-    self.isOpaque = false
-    self.backgroundColor = .clear
+    // 使用系统窗口背景色，避免启动防闪时把标题栏/窗口背景透成透明
+    self.isOpaque = true
+    self.backgroundColor = .windowBackgroundColor
 
     RegisterGeneratedPlugins(registry: flutterViewController)
 


### PR DESCRIPTION
## Summary
- 修复 macOS 标题栏（交通灯按钮与窗口标题区域）呈透明的问题
- 保留 #1287 的“首帧后再显示窗口”防启动黑闪主流程
- 将启动时 `backgroundColor = .clear` / `isOpaque = false` 调整为系统不透明窗口背景色，避免原生标题栏被透掉

## Context
#1287 为消除启动黑闪，在 `MainFlutterWindow.swift` 中额外设置了：

```swift
self.isOpaque = false
self.backgroundColor = .clear
```

这会使 NSWindow 背景完全透明；在显示系统标题栏时，标题栏区域会透出背后内容。

本次仅调整启动窗口底色策略，不改动：
- `window_manager` 标题栏开关 / PiP 进出标题栏逻辑
- 桌面主题 `setBrightness` 同步