### PR TITLE
feat(reply): filter mention-dominated replies

### DIFF
--- a/lib/grpc/reply.dart
+++ b/lib/grpc/reply.dart
@@ -8,7 +8,11 @@ import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:fixnum/fixnum.dart';
 
 abstract final class ReplyGrpc {
+  static final RegExp _whitespaceRegExp = RegExp(r'\s+');
+
   static bool antiGoodsReply = Pref.antiGoodsReply;
+  static bool filterMentionDominatedReply = Pref.filterMentionDominatedReply;
+  static int mentionFilterThreshold = Pref.mentionFilterThreshold;
   static RegExp replyRegExp = RegExp(
     Pref.banWordForReply,
     caseSensitive: false,
@@ -36,8 +40,59 @@ abstract final class ReplyGrpc {
         reply.content.message.contains(Constants.goodsUrlPrefix);
   }
 
-  static bool needRemoveGrpc(ReplyInfo reply) {
+  static bool needRemoveMentionGrpc(ReplyInfo reply) {
+    final content = reply.content;
+    if (content.pictures.isNotEmpty) {
+      return false;
+    }
+
+    String message = content.message;
+    for (final emote in content.emotes.keys) {
+      message = message.replaceAll(emote, '\uFFFC');
+    }
+    message = message.replaceAll(_whitespaceRegExp, '');
+    if (message.isEmpty || content.atNameToMid.isEmpty) {
+      return false;
+    }
+
+    final mentionTokens =
+        content.atNameToMid.keys
+            .map((name) => '@${name.replaceAll(_whitespaceRegExp, '')}')
+            .toList()
+          ..sort((a, b) => b.length.compareTo(a.length));
+
+    for (final mention in mentionTokens) {
+      final prefix = '回复$mention';
+      if (message.startsWith(prefix)) {
+        final remaining = message.substring(prefix.length);
+        if (remaining.startsWith(':') || remaining.startsWith('：')) {
+          message = remaining.substring(1);
+          break;
+        }
+      }
+    }
+    if (message.isEmpty) {
+      return false;
+    }
+
+    String remaining = message;
+    int mentionLength = 0;
+    for (final mention in mentionTokens) {
+      final prevLength = remaining.length;
+      remaining = remaining.replaceAll(mention, '');
+      mentionLength += prevLength - remaining.length;
+    }
+    return mentionLength * 100 >= message.length * mentionFilterThreshold;
+  }
+
+  static bool needRemoveGrpc(
+    ReplyInfo reply, {
+    bool applyMentionFilter = true,
+  }) {
     return (enableFilter && replyRegExp.hasMatch(reply.content.message)) ||
+        (applyMentionFilter &&
+            filterMentionDominatedReply &&
+            needRemoveMentionGrpc(reply)) ||
         (antiGoodsReply && needRemoveGoodGrpc(reply));
   }
 
@@ -124,7 +179,10 @@ abstract final class ReplyGrpc {
       ),
       DialogListReply.fromBuffer,
     );
-    return res..dataOrNull?.replies.removeWhere(needRemoveGrpc);
+    return res
+      ..dataOrNull?.replies.removeWhere(
+        (reply) => needRemoveGrpc(reply, applyMentionFilter: false),
+      );
   }
 
   static Future<LoadingState<SearchItemReply>> searchItem({

--- a/lib/pages/setting/models/extra_settings.dart
+++ b/lib/pages/setting/models/extra_settings.dart
@@ -222,6 +222,18 @@ List<SettingsModel> get extraSettings => [
       ReplyGrpc.enableFilter = value.pattern.isNotEmpty;
     },
   ),
+  SplitModel(
+    normalModel: const NormalModel.split(
+      title: '过滤以 @ 用户为主的评论',
+      subtitle: '点击设置过滤阈值（默认 90%）',
+      leading: Icon(Icons.alternate_email),
+    ),
+    switchModel: SwitchModel.split(
+      setKey: SettingBoxKey.filterMentionDominatedReply,
+      onChanged: (value) => ReplyGrpc.filterMentionDominatedReply = value,
+      onTap: _showMentionFilterThresholdDialog,
+    ),
+  ),
   getBanWordModel(
     title: '动态关键词过滤',
     key: SettingBoxKey.banWordForDyn,
@@ -616,6 +628,26 @@ List<SettingsModel> get extraSettings => [
     },
   ),
 ];
+
+Future<void> _showMentionFilterThresholdDialog(BuildContext context) async {
+  final res = await showDialog<double>(
+    context: context,
+    builder: (context) => SliderDialog(
+      title: Text('@ 用户内容占比阈值（${Pref.mentionFilterThreshold}%）'),
+      min: 50,
+      max: 100,
+      divisions: 50,
+      precise: 0,
+      suffix: '%',
+      value: Pref.mentionFilterThreshold.toDouble(),
+    ),
+  );
+  if (res != null) {
+    final threshold = res.toInt();
+    ReplyGrpc.mentionFilterThreshold = threshold;
+    await GStorage.setting.put(SettingBoxKey.mentionFilterThreshold, threshold);
+  }
+}
 
 Future<void> audioNormalization(
   BuildContext context,

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -89,6 +89,8 @@ abstract final class SettingBoxKey {
       cdnSpeedTest = 'cdnSpeedTest',
       horizontalPreview = 'horizontalPreview',
       banWordForReply = 'banWordForReply',
+      filterMentionDominatedReply = 'filterMentionDominatedReply',
+      mentionFilterThreshold = 'mentionFilterThreshold',
       banWordForZone = 'banWordForZone',
       savedRcmdTip = 'savedRcmdTip',
       openInBrowser = 'openInBrowser',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -301,6 +301,14 @@ abstract final class Pref {
   static String get banWordForReply =>
       _setting.get(SettingBoxKey.banWordForReply, defaultValue: '');
 
+  static bool get filterMentionDominatedReply => _setting.get(
+    SettingBoxKey.filterMentionDominatedReply,
+    defaultValue: false,
+  );
+
+  static int get mentionFilterThreshold =>
+      _setting.get(SettingBoxKey.mentionFilterThreshold, defaultValue: 90);
+
   static String get banWordForZone =>
       _setting.get(SettingBoxKey.banWordForZone, defaultValue: '');
 


### PR DESCRIPTION
新增可选的“过滤以 @ 用户为主的评论”设置。功能默认关闭，过滤阈值默认 90%，支持在 50%～100% 之间调整。

| 入口位置 | 阈值弹窗 |
| :---: | :---: |
| <img width="769" height="260" alt="屏幕截图 2026-07-16 100232" src="https://github.com/user-attachments/assets/7b382b64-c2b6-4d4b-8d5b-15c4c1ce36bc" /> | <img width="461" height="288" alt="屏幕截图 2026-07-16 100302" src="https://github.com/user-attachments/assets/974cc75b-0368-4bce-9ffe-f9b287caa8c8" /> |

### 处理规则

- 使用 gRPC 返回的 `atNameToMid` 识别 @ 用户
- 带图片的评论保留
- 每个表情按一个字符计算
- 二级回复不统计 `回复 @用户：` 前缀
- “查看对话”显示完整上下文，不应用此过滤

### 验证

- `dart analyze` 通过，修改文件无诊断
- Android debug APK 构建通过
- 已模拟器手动验证纯 @、普通文本、图片、表情、二级回复及对话列表
