### PR TITLE
feat: 支持控制桌面画中画窗口是否默认置顶

### DIFF
--- a/lib/pages/live_room/widgets/header_control.dart
+++ b/lib/pages/live_room/widgets/header_control.dart
@@ -133,7 +133,7 @@ class _LiveHeaderControlState extends State<LiveHeaderControl>
           child,
           ...?timeBatteryWidgets,
           const SizedBox(width: 10),
-          if (PlatformUtils.isDesktop && !plPlayerController.isDesktopPip)
+          if (PlatformUtils.isDesktop)
             Obx(() {
               final isAlwaysOnTop = plPlayerController.isAlwaysOnTop.value;
               return ComBtn(

--- a/lib/pages/setting/models/play_settings.dart
+++ b/lib/pages/setting/models/play_settings.dart
@@ -232,6 +232,14 @@ List<SettingsModel> get playSettings => [
       defaultVal: false,
     ),
   ],
+  if (PlatformUtils.isDesktop)
+    const SwitchModel(
+      title: '桌面画中画窗口置顶',
+      subtitle: '进入桌面画中画时窗口默认置顶显示',
+      leading: Icon(Icons.push_pin_outlined),
+      setKey: SettingBoxKey.pipAlwaysOnTop,
+      defaultVal: true,
+    ),
   const SwitchModel(
     title: '全屏手势反向',
     subtitle: '默认播放器中部向上滑动进入全屏，向下退出\n开启后向下全屏，向上退出',

--- a/lib/pages/video/widgets/header_control.dart
+++ b/lib/pages/video/widgets/header_control.dart
@@ -1806,7 +1806,7 @@ class HeaderControlState extends State<HeaderControl>
               title,
               // show current datetime
               ...?timeBatteryWidgets,
-              if (PlatformUtils.isDesktop && !plPlayerController.isDesktopPip)
+              if (PlatformUtils.isDesktop)
                 Obx(() {
                   final isAlwaysOnTop = plPlayerController.isAlwaysOnTop.value;
                   return SizedBox(

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -248,7 +248,7 @@ class PlPlayerController with BlockConfigMixin {
     }
 
     await windowManager.setMinimumSize(size);
-    setAlwaysOnTop(true);
+    setAlwaysOnTop(Pref.pipAlwaysOnTop);
     windowManager
       ..setSize(size)
       ..setAspectRatio(width / height);

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -192,6 +192,7 @@ abstract final class SettingBoxKey {
   static const String enableShowDanmaku = 'enableShowDanmaku',
       enableShowLiveDanmaku = 'enableShowLiveDanmaku',
       pipNoDanmaku = 'pipNoDanmaku',
+      pipAlwaysOnTop = 'pipAlwaysOnTop',
       showVipDanmaku = 'showVipDanmaku',
       mergeDanmaku = 'mergeDanmaku',
       danmakuWeight = 'danmakuWeight',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -770,6 +770,10 @@ abstract final class Pref {
   static bool get autoPiP =>
       _setting.get(SettingBoxKey.autoPiP, defaultValue: false);
 
+  /// 桌面端画中画窗口是否默认置顶
+  static bool get pipAlwaysOnTop =>
+      _setting.get(SettingBoxKey.pipAlwaysOnTop, defaultValue: true);
+
   static bool get enableSponsorBlock =>
       _setting.get(SettingBoxKey.enableSponsorBlock, defaultValue: false);
 


### PR DESCRIPTION
### 改动说明

当前桌面端进入画中画时，窗口会强制置顶在最上层（`enterDesktopPip()` 中 `setAlwaysOnTop(true)` 硬编码）。本 PR 增加了一个设置项，让用户自由控制此行为：
- **新增设置项「桌面画中画窗口置顶」**：位于 设置 → 播放设置，默认开启（保持现有行为），关闭后进入 PiP 时窗口不再自动置顶。
- **PiP 模式下显示置顶按钮**：此前播放器顶栏的置顶（图钉）按钮在 PiP 模式下被隐藏（`!isDesktopPip` 条件），现在改为始终显示，方便用户在 PiP 中随时动态切换置顶状态。

### 修改文件
| 文件 | 改动 |
|---|---|
| `lib/utils/storage_key.dart` | 新增 `pipAlwaysOnTop` 存储键 |
| `lib/utils/storage_pref.dart` | 新增 `pipAlwaysOnTop` getter，默认 `true` |
| `lib/pages/setting/models/play_settings.dart` | 新增桌面端设置开关（仅 `PlatformUtils.isDesktop` 可见） |
| `lib/plugin/pl_player/controller.dart` | `enterDesktopPip()` 中改为读取设置项而非硬编码 `true` |
| `lib/pages/video/widgets/header_control.dart` | 移除 PiP 模式下的置顶按钮隐藏条件 |
| `lib/pages/live_room/widgets/header_control.dart` | 同上 |

### 行为对照

| 场景 | 改动前 | 改动后 |
|---|---|---|
| 进入桌面 PiP | 窗口始终置顶 | 由设置项控制（默认置顶） |
| PiP 模式下的置顶按钮 | 隐藏 | 始终可见，可动态切换 |