### PR TITLE
feat: 弹幕字体大小/不透明度支持1%精细调节

### DIFF
--- a/lib/pages/video/widgets/header_mixin.dart
+++ b/lib/pages/video/widgets/header_mixin.dart
@@ -329,7 +329,7 @@ mixin HeaderMixin<T extends StatefulWidget> on State<T> {
                         min: 0,
                         max: 1,
                         value: plPlayerController.danmakuOpacity.value,
-                        divisions: 10,
+                        divisions: 100,
                         label: '${plPlayerController.danmakuOpacity * 100}%',
                         onChanged: updateOpacity,
                       ),
@@ -412,7 +412,7 @@ mixin HeaderMixin<T extends StatefulWidget> on State<T> {
                         min: 0.5,
                         max: 2.5,
                         value: DanmakuOptions.danmakuFontScale,
-                        divisions: 20,
+                        divisions: 200,
                         label:
                             '${(DanmakuOptions.danmakuFontScale * 100).toStringAsFixed(1)}%',
                         onChanged: updateFontSize,
@@ -441,7 +441,7 @@ mixin HeaderMixin<T extends StatefulWidget> on State<T> {
                         min: 0.5,
                         max: 2.5,
                         value: DanmakuOptions.danmakuFontScaleFS,
-                        divisions: 20,
+                        divisions: 200,
                         label:
                             '${(DanmakuOptions.danmakuFontScaleFS * 100).toStringAsFixed(1)}%',
                         onChanged: updateFontSizeFS,


### PR DESCRIPTION
## 变更说明

弹幕字体大小、全屏字体大小、不透明度三个滑块，原来每档间隔10%，精度偏低。改为每档1%，与b站官方一致。

## 修改文件

`lib/pages/video/widgets/header_mixin.dart`

| 设置项 | 改前 | 改后 |
|------|-----|-----|
| 字体大小 | divisions: 20 | divisions: 200 |
| 全屏字体大小 | divisions: 20 | divisions: 200 |
| 不透明度 | divisions: 10 | divisions: 100 |

直播与视频共用同一面板，同时生效。