### PR TITLE
桌面端滚轮体验修复：1.修改还原屏幕触发逻辑 2.修复悬停播放器时滚轮连带滚动页面

### DIFF
--- a/lib/common/widgets/gesture/mouse_interactive_viewer.dart
+++ b/lib/common/widgets/gesture/mouse_interactive_viewer.dart
@@ -491,29 +491,17 @@ class _MouseInteractiveViewerState extends State<MouseInteractiveViewer>
 
   void _receivedPointerSignal(PointerSignalEvent event) {
     final Offset local = event.localPosition;
-    final Offset global = event.position;
     final double scaleChange;
     if (event is PointerScrollEvent) {
-      if (event.kind == PointerDeviceKind.trackpad) {
-        final Offset localDelta = PointerEvent.transformDeltaViaPositions(
-          untransformedEndPosition: global + event.scrollDelta,
-          untransformedDelta: event.scrollDelta,
-          transform: event.transform,
-        );
-
-        final Offset focalPointScene = _transformer.toScene(local);
-        final Offset newFocalPointScene = _transformer.toScene(
-          local - localDelta,
-        );
-
-        _transformer.value = _matrixTranslate(
-          _transformer.value,
-          newFocalPointScene - focalPointScene,
-        );
-
+      if (event.kind != PointerDeviceKind.trackpad &&
+          !_gestureIsSupported(_GestureType.scale)) {
         return;
       }
-      _handlePointerScrollEvent(event);
+      // 注册仲裁，阻止外层滚动视图同时响应滚轮
+      GestureBinding.instance.pointerSignalResolver.register(
+        event,
+        _onPointerScroll,
+      );
       return;
     } else if (event is PointerScaleEvent) {
       scaleChange = event.scale;
@@ -535,6 +523,32 @@ class _MouseInteractiveViewerState extends State<MouseInteractiveViewer>
       _transformer.value,
       focalPointSceneScaled - focalPointScene,
     );
+  }
+
+  void _onPointerScroll(PointerSignalEvent event) {
+    final scrollEvent = event as PointerScrollEvent;
+    if (scrollEvent.kind == PointerDeviceKind.trackpad) {
+      final Offset local = scrollEvent.localPosition;
+      final Offset global = scrollEvent.position;
+      final Offset localDelta = PointerEvent.transformDeltaViaPositions(
+        untransformedEndPosition: global + scrollEvent.scrollDelta,
+        untransformedDelta: scrollEvent.scrollDelta,
+        transform: scrollEvent.transform,
+      );
+
+      final Offset focalPointScene = _transformer.toScene(local);
+      final Offset newFocalPointScene = _transformer.toScene(
+        local - localDelta,
+      );
+
+      _transformer.value = _matrixTranslate(
+        _transformer.value,
+        newFocalPointScene - focalPointScene,
+      );
+
+      return;
+    }
+    _handlePointerScrollEvent(scrollEvent);
   }
 
   void _handlePointerScrollEvent(PointerScrollEvent event) {

--- a/lib/plugin/pl_player/view/view.dart
+++ b/lib/plugin/pl_player/view/view.dart
@@ -258,7 +258,8 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
       _onControlChanged,
     );
 
-    _transformationController = TransformationController();
+    _transformationController = TransformationController()
+      ..addListener(_onTransformChanged);
 
     _animationController = AnimationController(
       vsync: this,
@@ -379,7 +380,9 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
     _brightnessListener?.cancel();
     _controlsListener?.cancel();
     _animationController.dispose();
-    _transformationController.dispose();
+    _transformationController
+      ..removeListener(_onTransformChanged)
+      ..dispose();
     _removeDmAction();
     if (PlatformUtils.isMobile) {
       FlutterVolumeController.removeListener();
@@ -956,8 +959,17 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
     _initialFocalPoint = details.localFocalPoint;
   }
 
-  void _onScaleUpdate(double scale) {
-    showRestoreScaleBtn.value = scale != 1.0;
+  // 显隐由 _onTransformChanged 统一驱动
+  void _onScaleUpdate(double scale) {}
+
+  // 浮点残差，不与 identity 精确比较
+  void _onTransformChanged() {
+    final matrix = _transformationController.value;
+    final translation = matrix.getTranslation();
+    showRestoreScaleBtn.value =
+        translation.x.abs() > 0.5 ||
+        translation.y.abs() > 0.5 ||
+        (matrix.getMaxScaleOnAxis() - 1).abs() > 1e-3;
   }
 
   void _onHorizontalDragStart() {
@@ -1664,7 +1676,6 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
                         ),
                       ),
                       onPressed: () async {
-                        showRestoreScaleBtn.value = false;
                         final animController = AnimationController(
                           vsync: this,
                           duration: const Duration(milliseconds: 255),
@@ -1684,6 +1695,10 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
                         animController
                           ..removeListener(listener)
                           ..dispose();
+                        // Tween 终值可能有残差，显式归位
+                        if (mounted) {
+                          _transformationController.value = Matrix4.identity();
+                        }
                       },
                       child: const Text('还原屏幕'),
                     ),


### PR DESCRIPTION
## 小改进目前桌面端播放的操控体验

### 问题

1. 按住 Shift/Alt 滚动滚轮会平移视频画面(Alt+Tab 切窗导致的修饰键粘滞也会误触发)。此时「还原屏幕」按钮不会出现——它只在缩放≠1 时显示,纯平移没有恢复入口,部分情况下会完全移出屏幕，只能重进页面。
如图（调整后）：
<img width="1284" height="853" alt="image" src="https://github.com/user-attachments/assets/02277c25-ee97-4af0-ad01-942bddaab9f2" />

2. 桌面端下竖形窗口下播放器位于页面滚动容器内,滚轮事件被播放器和外层滚动视图同时响应，导致想调整音量，页面却滚走、视频被收起


### 复现

1. 播放中光标悬停画面,按住 Alt(纵向)或 Shift(横向)滚动滚轮 → 画面滑出画框,控制栏/弹幕正常,无还原按钮。
2. 桌面端调整为竖屏窗口（即宽小于高，在播放器内滚动鼠标滚轮）

### 修复方式

1. 改为监听 `TransformationController`:变换矩阵偏离原位(平移或缩放,按容差过滤浮点残差)即显示还原按钮,覆盖所有变换路径
2. 播放器滚轮处理接入 PointerSignalResolver 仲裁,悬停播放器时滚轮归播放器独占,页面不再滚动;光标在内容区时页面滚动不受影响。

### 测试

已在我的Win和Android环境下测试，无发现明显问题。

麻烦佬看下这个PR有没有必要，感谢佬了。