### PR TITLE
fix(webview): inApp 模式下拦截非 http(s) scheme，避免 ERR_UNKNOWN_URL_SCHEME

### DIFF
--- a/lib/pages/webview/view.dart
+++ b/lib/pages/webview/view.dart
@@ -317,9 +317,8 @@ class _WebviewPageState extends State<WebviewPage> {
             return null;
           },
           shouldOverrideUrlLoading: (controller, navigationAction) async {
-            late String url = navigationAction.request.url.toString();
             if (!_inApp) {
-              bool hasMatch = await PiliScheme.routePush(
+              final hasMatch = await PiliScheme.routePush(
                 navigationAction.request.url?.uriValue ?? Uri(),
                 selfHandle: true,
                 off: _off,
@@ -327,15 +326,16 @@ class _WebviewPageState extends State<WebviewPage> {
               // if (kDebugMode) debugPrint('webview: [$url], [$hasMatch]');
               if (hasMatch) {
                 progress.value = 1;
-                return NavigationActionPolicy.CANCEL;
+                return .CANCEL;
               }
             }
+            final url = navigationAction.request.url.toString();
             if (_prefixRegex.hasMatch(url)) {
               if (context.mounted) {
-                SnackBar snackBar = SnackBar(
-                  content: const Text('当前网页将要打开外部链接，是否打开'),
-                  showCloseIcon: true,
+                final snackBar = SnackBar(
                   persist: false,
+                  showCloseIcon: true,
+                  content: const Text('当前网页将要打开外部链接，是否打开'),
                   action: SnackBarAction(
                     label: '打开',
                     onPressed: () => PageUtils.launchURL(url),
@@ -344,10 +344,10 @@ class _WebviewPageState extends State<WebviewPage> {
                 ScaffoldMessenger.of(context).showSnackBar(snackBar);
               }
               progress.value = 1;
-              return NavigationActionPolicy.CANCEL;
+              return .CANCEL;
             }
 
-            return NavigationActionPolicy.ALLOW;
+            return .ALLOW;
           },
         ),
       ),

--- a/lib/pages/webview/view.dart
+++ b/lib/pages/webview/view.dart
@@ -317,20 +317,20 @@ class _WebviewPageState extends State<WebviewPage> {
             return null;
           },
           shouldOverrideUrlLoading: (controller, navigationAction) async {
-            if (_inApp) {
-              return NavigationActionPolicy.ALLOW;
-            }
             late String url = navigationAction.request.url.toString();
-            bool hasMatch = await PiliScheme.routePush(
-              navigationAction.request.url?.uriValue ?? Uri(),
-              selfHandle: true,
-              off: _off,
-            );
-            // if (kDebugMode) debugPrint('webview: [$url], [$hasMatch]');
-            if (hasMatch) {
-              progress.value = 1;
-              return NavigationActionPolicy.CANCEL;
-            } else if (_prefixRegex.hasMatch(url)) {
+            if (!_inApp) {
+              bool hasMatch = await PiliScheme.routePush(
+                navigationAction.request.url?.uriValue ?? Uri(),
+                selfHandle: true,
+                off: _off,
+              );
+              // if (kDebugMode) debugPrint('webview: [$url], [$hasMatch]');
+              if (hasMatch) {
+                progress.value = 1;
+                return NavigationActionPolicy.CANCEL;
+              }
+            }
+            if (_prefixRegex.hasMatch(url)) {
               if (context.mounted) {
                 SnackBar snackBar = SnackBar(
                   content: const Text('当前网页将要打开外部链接，是否打开'),


### PR DESCRIPTION
## 问题

目前在专栏页中点击“浏览器打开”时，加载一段时间后WebView 会报错：
```
ERR_UNKNOWN_URL_SCHEME
```
如图：
<img width="480" height="1066" alt="image" src="https://github.com/user-attachments/assets/2cc35227-5ea1-4ae7-9b94-554bd4bce63e" />

## 原因分析

原因是 B站在移动端会尝试打开bilibili://开头的链接尝试调用本地的客户端进行打开，而目前软件WebView 的默认拦截逻辑本身是正常的  
（`bilibili://` 会被 `PiliScheme.routePush` 处理，其他未知 scheme 会弹出“是否打开外部链接”的 SnackBar）。  
对应代码：  
- [https://github.com/bggRGjQaUbCoE/PiliPlus/blob/f6035628d3f8db26b7b3ecd317b74becc748db68/lib/pages/webview/view.dart#L319-L351](https://github.com/bggRGjQaUbCoE/PiliPlus/blob/f6035628d3f8db26b7b3ecd317b74becc748db68/lib/pages/webview/view.dart#L319-L351)

但专栏页的“浏览器打开”使用了 `PageUtils.inAppWebview`，它传入了 `inApp: true`：  
- [https://github.com/bggRGjQaUbCoE/PiliPlus/blob/f6035628d3f8db26b7b3ecd317b74becc748db68/lib/utils/page_utils.dart#L436-L453](https://github.com/bggRGjQaUbCoE/PiliPlus/blob/f6035628d3f8db26b7b3ecd317b74becc748db68/lib/utils/page_utils.dart#L436-L453)

在这种情况下，WebView 会在 `_inApp` 分支中直接对所有导航返回 `NavigationActionPolicy.ALLOW`：  
- [https://github.com/bggRGjQaUbCoE/PiliPlus/blob/f6035628d3f8db26b7b3ecd317b74becc748db68/lib/pages/webview/view.dart#L320-L322](https://github.com/bggRGjQaUbCoE/PiliPlus/blob/f6035628d3f8db26b7b3ecd317b74becc748db68/lib/pages/webview/view.dart#L320-L322)

包括 `bilibili://`。由于 WebView 无法识别该 scheme，最终报 `ERR_UNKNOWN_URL_SCHEME`。

`inApp: true` 的本意是避免跳回目前软件的原生页面，让用户停留在网页环境中。但现有实现把“非 http(s) 的兜底处理”也跳过了，导致 WebView 无法渲染的 scheme 被强制放行，失去了原本在浏览器打开专栏的意义

## 复现步骤

1. 打开任意专栏页  
2. 点击右上角“浏览器打开”  
3. WebView 内部跳转到 `bilibili://`  
4. WebView 报 `ERR_UNKNOWN_URL_SCHEME`


## 修复方案（最小修复，推荐）

仅在 `_inApp` 分支中对 `http/https` 放行；  
非 http(s) 的情况继续走现有 `_prefixRegex` 的 SnackBar 逻辑（提示“是否打开外部链接”→ 用户选择留在网页或通过系统 intent 打开），取消用户既可以留在网页继续查看，跳转就跳转到官方客户端进行查看。

麻烦佬看下了，目前在安卓端测试没有明显问题，可以正常唤出外部打开选择。

感谢佬

