### PR TITLE
fix: 修复不透明度的浮点误差以及滑动优化

### DIFF
--- a/lib/pages/video/widgets/header_mixin.dart
+++ b/lib/pages/video/widgets/header_mixin.dart
@@ -108,7 +108,7 @@ mixin HeaderMixin<T extends StatefulWidget> on State<T> {
         }
 
         void updateFontSizeFS(double val) {
-          DanmakuOptions.danmakuFontScaleFS = val;
+          DanmakuOptions.danmakuFontScaleFS = val.toPrecision(2);
           setState(() {});
           if (isFullScreen) {
             setOptions();
@@ -116,7 +116,7 @@ mixin HeaderMixin<T extends StatefulWidget> on State<T> {
         }
 
         void updateFontSize(double val) {
-          DanmakuOptions.danmakuFontScale = val;
+          DanmakuOptions.danmakuFontScale = val.toPrecision(2);
           setState(() {});
           if (!isFullScreen) {
             setOptions();
@@ -136,7 +136,7 @@ mixin HeaderMixin<T extends StatefulWidget> on State<T> {
         }
 
         void updateOpacity(double val) {
-          plPlayerController.danmakuOpacity.value = val;
+          plPlayerController.danmakuOpacity.value = val.toPrecision(2);
           setState(() {});
         }
 
@@ -312,7 +312,7 @@ mixin HeaderMixin<T extends StatefulWidget> on State<T> {
                   Row(
                     mainAxisAlignment: MainAxisAlignment.spaceBetween,
                     children: [
-                      Text('不透明度 ${plPlayerController.danmakuOpacity * 100}%'),
+                      Text('不透明度 ${(plPlayerController.danmakuOpacity * 100).toStringAsFixed(1)}%'),
                       resetBtn(theme, '100.0%', () => updateOpacity(1.0)),
                     ],
                   ),
@@ -329,8 +329,7 @@ mixin HeaderMixin<T extends StatefulWidget> on State<T> {
                         min: 0,
                         max: 1,
                         value: plPlayerController.danmakuOpacity.value,
-                        divisions: 100,
-                        label: '${plPlayerController.danmakuOpacity * 100}%',
+                        label: '${(plPlayerController.danmakuOpacity * 100).toStringAsFixed(1)}%',
                         onChanged: updateOpacity,
                       ),
                     ),
@@ -412,7 +411,6 @@ mixin HeaderMixin<T extends StatefulWidget> on State<T> {
                         min: 0.5,
                         max: 2.5,
                         value: DanmakuOptions.danmakuFontScale,
-                        divisions: 200,
                         label:
                             '${(DanmakuOptions.danmakuFontScale * 100).toStringAsFixed(1)}%',
                         onChanged: updateFontSize,
@@ -441,7 +439,6 @@ mixin HeaderMixin<T extends StatefulWidget> on State<T> {
                         min: 0.5,
                         max: 2.5,
                         value: DanmakuOptions.danmakuFontScaleFS,
-                        divisions: 200,
                         label:
                             '${(DanmakuOptions.danmakuFontScaleFS * 100).toStringAsFixed(1)}%',
                         onChanged: updateFontSizeFS,


### PR DESCRIPTION
对于上一个pr重新测试了一下，修复 #2452 带来的问题以及滑动优化

## 变更说明

### 1. 不透明度 label 浮点误差修复
不透明度文字和滑块label使用`toStringAsFixed(1)`格式化，防止出现显示格式错误。

### 2. 回调值取整到 0.01 精度
三个回调使用`val.toPrecision(2)`取整，避免连续模式下跨session的值漂移。

### 3. 滑块改为连续模式
去掉三处`divisions`参数（不透明度、字体大小、全屏字体大小），拖动更加顺滑。

## 修改文件

`lib/pages/video/widgets/header_mixin.dart`

| 改动 | 说明 |
|------|------|
| `updateFontSizeFS` | 加 `toPrecision(2)` |
| `updateFontSize` | 加 `toPrecision(2)` |
| `updateOpacity` | 加 `toPrecision(2)` |
| 不透明度文字 | 加 `toStringAsFixed(1)` |
| 不透明度滑块 | 删 `divisions: 100`，label 加 `toStringAsFixed(1)` |
| 字体大小滑块 | 删 `divisions: 200` |
| 全屏字体大小滑块 | 删 `divisions: 200` |

## 兼容性
已有设置不受影响，存盘值格式不变。