### PR TITLE
fix: resume history from the recording account progress

### DIFF
--- a/lib/models_new/history/list.dart
+++ b/lib/models_new/history/list.dart
@@ -21,6 +21,18 @@ class HistoryItemModel with MultiSelectData {
   String? tagName;
   int? liveStatus;
 
+  /// The history API uses seconds as the progress unit
+  /// while the player expects milliseconds.
+  ///
+  /// The history API uses `-1` to indicate that the video has been fully watched.
+  /// When reopened, playback should start from the beginning to avoid resuming from
+  /// the last playback position associated with the video streaming account.
+  int? get playbackProgress {
+    final progress = this.progress;
+    if (progress == null) return null;
+    return progress == -1 ? 0 : progress * Duration.millisecondsPerSecond;
+  }
+
   HistoryItemModel({
     this.title,
     this.cover,

--- a/lib/pages/history/widgets/item.dart
+++ b/lib/pages/history/widgets/item.dart
@@ -69,13 +69,17 @@ class HistoryItem extends StatelessWidget {
                     SmartDialog.showToast('直播未开播');
                   }
                 } else if (business == 'pgc') {
-                  PageUtils.viewPgc(epId: item.history.epid);
+                  PageUtils.viewPgc(
+                    epId: item.history.epid,
+                    progress: item.playbackProgress,
+                  );
                 } else if (business == 'cheese') {
                   if (item.uri?.isNotEmpty == true) {
                     PageUtils.viewPgcFromUri(
                       item.uri!,
                       isPgc: false,
                       aid: item.history.oid,
+                      progress: item.playbackProgress,
                     );
                   }
                 } else {
@@ -101,6 +105,7 @@ class HistoryItem extends StatelessWidget {
                       cover: item.cover,
                       title: item.title,
                       dimension: dimension,
+                      progress: item.playbackProgress,
                     );
                   }
                 }

--- a/lib/utils/page_utils.dart
+++ b/lib/utils/page_utils.dart
@@ -624,6 +624,7 @@ abstract final class PageUtils {
           seasonId: isSeason ? id : null,
           epId: isSeason ? null : id,
           aid: aid,
+          progress: progress,
           off: off,
         );
       }
@@ -752,6 +753,7 @@ abstract final class PageUtils {
     dynamic seasonId,
     dynamic epId,
     int? aid,
+    int? progress, // milliseconds
     bool off = false,
   }) async {
     try {
@@ -777,6 +779,7 @@ abstract final class PageUtils {
             seasonId: response.seasonId,
             epId: episode.id,
             cover: episode.cover,
+            progress: progress,
             extraArguments: {
               'pgcItem': response,
             },


### PR DESCRIPTION
## Description

Fix history playback progress when the **video streaming account** and **watch history account** are different.

Videos opened from watch history now resume using the progress recorded by the watch history account, instead of the `lastPlayTime` returned for the video streaming account.

This applies to regular videos, PGC content, and courses. Completed videos restart from the beginning.

## 说明

当前版本从观看历史记录进入某个视频后，若记录历史记录的账号与视频取流的账号不一致，则会出现无法从上次观看记录继续播放、从视频取流账号的观看记录继续播放的问题。

改动新增`progress`字段传入以匹配历史记录的观看时间。

已云端编译并本地测试（Android端），修复后的复现结果与预期一致。