### PR TITLE
feat: 新增 Windows 端 Z/X/C 快捷键快速调节播放倍速

### DIFF
--- a/lib/pages/video/widgets/player_focus.dart
+++ b/lib/pages/video/widgets/player_focus.dart
@@ -86,6 +86,41 @@ class PlayerFocus extends StatelessWidget {
     }
   }
 
+  /// 单次倍速步进（0.1x），使用整数十份位运算避免浮点精度累积误差
+  void _changeSpeed({required bool isIncrease}) {
+    final tenths = (plPlayerController.playbackSpeed * 10).round();
+    final newTenths = isIncrease
+        ? (tenths + 1).clamp(1, 60)
+        : (tenths - 1).clamp(1, 60);
+    final newSpeed = newTenths / 10.0;
+    plPlayerController
+      ..setPlaybackSpeed(newSpeed)
+      ..showKeyboardSpeedToast(newSpeed);
+  }
+
+  /// X/C 长按：按下步进一次，300ms 延迟后持续步进（每 100ms），松开取消
+  void _updateSpeed(KeyEvent event, {required bool isIncrease}) {
+    if (event is KeyDownEvent) {
+      if (hasPlayer) {
+        _changeSpeed(isIncrease: isIncrease);
+        // 300ms 防误触阈值，过后才开始连续步进
+        plPlayerController
+          ..longPressTimer?.cancel()
+          ..longPressTimer = Timer(
+            const Duration(milliseconds: 300),
+            () => plPlayerController
+              ..cancelLongPressTimer()
+              ..longPressTimer = Timer.periodic(
+                const Duration(milliseconds: 100),
+                (_) => _changeSpeed(isIncrease: isIncrease),
+              ),
+          );
+      }
+    } else if (event is KeyUpEvent) {
+      plPlayerController.cancelLongPressTimer();
+    }
+  }
+
   bool _handleKey(KeyEvent event) {
     final key = event.logicalKey;
 
@@ -116,6 +151,25 @@ class PlayerFocus extends StatelessWidget {
     final isArrowUp = key == LogicalKeyboardKey.arrowUp;
     if (isArrowUp || key == LogicalKeyboardKey.arrowDown) {
       _updateVolume(event, isIncrease: isArrowUp);
+      return true;
+    }
+
+    // Z：恢复 1.0x 倍速（同时取消 X/C 长按定时器，防止后续 tick 改回去）
+    if (key == LogicalKeyboardKey.keyZ) {
+      if (event is KeyDownEvent && !plPlayerController.isLive && hasPlayer) {
+        plPlayerController
+          ..cancelLongPressTimer()
+          ..setPlaybackSpeed(1.0)
+          ..showKeyboardSpeedToast(1.0);
+      }
+      return true;
+    }
+
+    // X/C 倍速加减（X 减速、C 加速），支持长按持续调节（每 100ms 步进 0.1x）
+    if (key == LogicalKeyboardKey.keyX || key == LogicalKeyboardKey.keyC) {
+      if (!plPlayerController.isLive && hasPlayer) {
+        _updateSpeed(event, isIncrease: key == LogicalKeyboardKey.keyC);
+      }
       return true;
     }
 

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -104,6 +104,17 @@ class PlPlayerController with BlockConfigMixin {
   final RxDouble _playbackSpeed = Pref.playSpeedDefault.obs;
   late final RxDouble _longPressSpeed = Pref.longPressSpeedDefault.obs;
 
+  /// 键盘快捷键倍速提示（Z/X/C），显示于播放器内中下部
+  final RxDouble keyboardSpeedToast = RxDouble(0.0);
+  Timer? _keyboardSpeedTimer;
+  void showKeyboardSpeedToast(double speed) {
+    keyboardSpeedToast.value = speed;
+    _keyboardSpeedTimer?.cancel();
+    _keyboardSpeedTimer = Timer(const Duration(seconds: 1), () {
+      keyboardSpeedToast.value = 0.0;
+    });
+  }
+
   final RxDouble volume = RxDouble(
     PlatformUtils.isDesktop ? Pref.desktopVolume : 1.0,
   );
@@ -1573,6 +1584,7 @@ class PlPlayerController with BlockConfigMixin {
       AndroidHelper$ToDart.onUserLeaveHint = null;
     }
     _timer?.cancel();
+    _keyboardSpeedTimer?.cancel();
     // _position.close();
     // _playerEventSubs?.cancel();
     // _sliderPosition.close();

--- a/lib/plugin/pl_player/view/view.dart
+++ b/lib/plugin/pl_player/view/view.dart
@@ -1428,6 +1428,37 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
             ),
           ),
 
+        /// 键盘快捷键（Z/X/C）倍速提示，显示于播放器内中下部
+        Obx(
+          () => AnimatedOpacity(
+            curve: Curves.easeInOut,
+            opacity: plPlayerController.keyboardSpeedToast.value > 0 ? 1.0 : 0.0,
+            duration: const Duration(milliseconds: 150),
+            child: Align(
+              alignment: const Alignment(0, 0.65),
+              child: IgnorePointer(
+                ignoring: true,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 14,
+                    vertical: 8,
+                  ),
+                  decoration: const BoxDecoration(
+                    color: Color(0x88000000),
+                    borderRadius: BorderRadius.all(Radius.circular(16)),
+                  ),
+                  child: Text(
+                    plPlayerController.keyboardSpeedToast.value > 0
+                        ? '${plPlayerController.keyboardSpeedToast.value.toStringAsFixed(1)}x'
+                        : '',
+                    style: const TextStyle(color: Colors.white, fontSize: 20),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+
         /// 时间进度 toast
         if (!isLive)
           IgnorePointer(


### PR DESCRIPTION
## 新增 Windows 端 Z/X/C 快捷键快速调整视频播放倍速

### 快捷键映射

| 按键 | 功能 |
|------|------|
| **Z** | 恢复 1.0x 倍速 |
| **X** | 减速，每按一次减少 0.1x，长按 300ms 后连续减速（每 100ms 步进一次） |
| **C** | 加速，每按一次增加 0.1x，长按 300ms 后连续加速（每 100ms 步进一次） |

- 速度范围：0.1x ~ 6.0x（实测 8x 及以上音画不同步/无声）
- 直播画面自动禁用
- 受设置中「启用键盘控制」开关控制

### 倍速提示显示

- 倍速信息显示在播放器画面内部中下部（半透明黑底圆角标签，字号 20）
- 操作后 1 秒自动淡出，显示格式如 `1.5x`

### 实现细节

- 整数十份位运算（`tenths = (speed * 10).round()`），避免浮点累加精度误差
- 300ms 防误触阈值，过后启动 `Timer.periodic(100ms)` 连续步进，松开即停
- 所有代码仅新增，未修改播放器原有任何逻辑

### 涉及修改

| 文件 | 改动 |
|------|------|
| `lib/pages/video/widgets/player_focus.dart` | 新增 Z/X/C 快捷键处理逻辑 |
| `lib/plugin/pl_player/controller.dart` | 新增倍速提示响应式字段，dispose 清理定时器 |
| `lib/plugin/pl_player/view/view.dart` | 新增播放器内倍速提示叠加层 |