### PR TITLE
Windows: support custom app fonts

### DIFF
--- a/lib/pages/setting/models/style_settings.dart
+++ b/lib/pages/setting/models/style_settings.dart
@@ -97,6 +97,21 @@ List<SettingsModel> get styleSettings => [
       onTap: _showFontWeightDialog,
     ),
   ),
+  if (Platform.isWindows)
+    NormalModel(
+      title: '应用字体',
+      leading: const Icon(Icons.text_format),
+      getSubtitle: () {
+        final fontFamily = Pref.appFontFamily;
+        return fontFamily.isEmpty ? '系统默认' : fontFamily;
+      },
+      onTap: (context, setState) async {
+        final result = await Get.toNamed('/fontFamilySetting');
+        if (result != null) {
+          setState();
+        }
+      },
+    ),
   NormalModel(
     title: '界面缩放',
     getSubtitle: () => '当前缩放比例：${Pref.uiScale.toStringAsFixed(2)}',

--- a/lib/pages/setting/pages/font_family_select.dart
+++ b/lib/pages/setting/pages/font_family_select.dart
@@ -1,0 +1,307 @@
+import 'package:PiliPlus/common/widgets/flutter/list_tile.dart';
+import 'package:PiliPlus/common/widgets/scaffold/simple_scaffold.dart';
+import 'package:PiliPlus/utils/extension/get_ext.dart';
+import 'package:PiliPlus/utils/storage.dart';
+import 'package:PiliPlus/utils/storage_key.dart';
+import 'package:PiliPlus/utils/storage_pref.dart';
+import 'package:PiliPlus/utils/windows_font_utils.dart';
+import 'package:flutter/material.dart' hide ListTile;
+import 'package:get/get.dart';
+
+class FontFamilySelectPage extends StatefulWidget {
+  const FontFamilySelectPage({super.key});
+
+  @override
+  State<FontFamilySelectPage> createState() => _FontFamilySelectPageState();
+}
+
+class _FontFamilySelectPageState extends State<FontFamilySelectPage> {
+  static const _previewText = 'Aa Bb 123 中文预览';
+  static const _systemDefaultFont = 'Segoe UI';
+  static const _twoColumnBreakpoint = 840.0;
+  static const _threeColumnBreakpoint = 1260.0;
+  final _searchController = TextEditingController();
+  final _scrollController = ScrollController();
+
+  late String _selectedFontFamily = Pref.appFontFamily;
+  List<String> _fontFamilies = const [];
+  Object? _loadError;
+  String _query = '';
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadFontFamilies();
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadFontFamilies() async {
+    if (!_isLoading) {
+      setState(() {
+        _isLoading = true;
+        _loadError = null;
+      });
+    }
+    try {
+      final fontFamilies = await WindowsFontUtils.getInstalledFontFamilies();
+      if (!mounted) return;
+      setState(() {
+        _fontFamilies = fontFamilies;
+        _isLoading = false;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _loadError = error;
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _saveFontFamily() async {
+    if (_selectedFontFamily.isEmpty) {
+      await GStorage.setting.delete(SettingBoxKey.appFontFamily);
+    } else {
+      await GStorage.setting.put(
+        SettingBoxKey.appFontFamily,
+        _selectedFontFamily,
+      );
+    }
+    Get
+      ..back(result: _selectedFontFamily)
+      ..updateMyAppTheme();
+  }
+
+  void _resetFontFamily() {
+    _selectedFontFamily = '';
+    _saveFontFamily();
+  }
+
+  void _clearSearch() {
+    _searchController.clear();
+    setState(() => _query = '');
+    _scrollToTop();
+  }
+
+  void _onSearchChanged(String value) {
+    setState(() => _query = value);
+    _scrollToTop();
+  }
+
+  void _scrollToTop() {
+    if (_scrollController.hasClients) {
+      _scrollController.jumpTo(0);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return SimpleScaffold(
+      appBar: AppBar(
+        title: const Text('应用字体'),
+        actions: [
+          IconButton(
+            tooltip: '刷新字体',
+            onPressed: _isLoading ? null : _loadFontFamilies,
+            icon: const Icon(Icons.refresh),
+          ),
+          TextButton(onPressed: _resetFontFamily, child: const Text('重置')),
+          TextButton(onPressed: _saveFontFamily, child: const Text('确定')),
+          const SizedBox(width: 12),
+        ],
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            _buildSearchField(theme),
+            Expanded(child: _buildFontList(theme)),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSearchField(ThemeData theme) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+      child: TextField(
+        controller: _searchController,
+        onChanged: _onSearchChanged,
+        decoration: InputDecoration(
+          visualDensity: .standard,
+          border: const OutlineInputBorder(
+            gapPadding: 0,
+            borderSide: BorderSide.none,
+            borderRadius: BorderRadius.all(Radius.circular(25)),
+          ),
+          isDense: true,
+          filled: true,
+          fillColor: theme.colorScheme.onInverseSurface,
+          hintText: '搜索字体',
+          prefixIcon: const Icon(Icons.search, size: 20),
+          suffixIcon: _query.isEmpty
+              ? null
+              : IconButton(
+                  tooltip: '清除',
+                  onPressed: _clearSearch,
+                  icon: const Icon(Icons.clear, size: 18),
+                ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFontList(ThemeData theme) {
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_loadError != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: .min,
+          spacing: 12,
+          children: [
+            Icon(
+              Icons.error_outline,
+              size: 36,
+              color: theme.colorScheme.outline,
+            ),
+            const Text('读取本机字体失败'),
+            TextButton.icon(
+              onPressed: _loadFontFamilies,
+              icon: const Icon(Icons.refresh),
+              label: const Text('重试'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final options = _visibleOptions;
+    if (options.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: .min,
+          spacing: 12,
+          children: [
+            Icon(
+              Icons.search_off,
+              size: 36,
+              color: theme.colorScheme.outline,
+            ),
+            const Text('未找到匹配字体'),
+          ],
+        ),
+      );
+    }
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final crossAxisCount = switch (constraints.maxWidth) {
+          >= _threeColumnBreakpoint => 3,
+          >= _twoColumnBreakpoint => 2,
+          _ => 1,
+        };
+        final scaledFontSize = MediaQuery.textScalerOf(context).scale(16);
+        final itemHeight = (80 + (scaledFontSize - 16).clamp(0, 16) * 2)
+            .toDouble();
+        return Scrollbar(
+          controller: _scrollController,
+          thumbVisibility: true,
+          interactive: true,
+          thickness: 10,
+          radius: const Radius.circular(5),
+          child: GridView.builder(
+            controller: _scrollController,
+            padding: const EdgeInsets.fromLTRB(8, 0, 18, 24),
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: crossAxisCount,
+              mainAxisExtent: itemHeight,
+              crossAxisSpacing: 4,
+              mainAxisSpacing: 2,
+            ),
+            itemCount: options.length,
+            itemBuilder: (context, index) => _buildFontItem(
+              theme,
+              options[index],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  List<_FontOption> get _visibleOptions {
+    final query = _query.trim().toLowerCase();
+    bool matches(String value) =>
+        query.isEmpty || value.toLowerCase().contains(query);
+
+    final options = <_FontOption>[];
+    final hasSelectedFont =
+        _selectedFontFamily.isEmpty ||
+        _fontFamilies.any(
+          (fontFamily) =>
+              fontFamily.toLowerCase() == _selectedFontFamily.toLowerCase(),
+        );
+    if (!hasSelectedFont && matches(_selectedFontFamily)) {
+      options.add(_FontOption(_selectedFontFamily, isUnavailable: true));
+    }
+    if (matches('系统默认')) {
+      options.add(const _FontOption(''));
+    }
+    options.addAll(
+      _fontFamilies.where(matches).map(_FontOption.new),
+    );
+    return options;
+  }
+
+  Widget _buildFontItem(ThemeData theme, _FontOption option) {
+    final fontFamily = option.fontFamily;
+    final isSelected =
+        fontFamily.toLowerCase() == _selectedFontFamily.toLowerCase();
+    final previewStyle = theme.textTheme.bodyLarge!.copyWith(
+      color: option.isUnavailable ? theme.colorScheme.error : null,
+      fontFamily: fontFamily.isEmpty ? _systemDefaultFont : fontFamily,
+    );
+    return ListTile(
+      selected: isSelected,
+      selectedTileColor: theme.colorScheme.primaryContainer.withValues(
+        alpha: 0.35,
+      ),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 4),
+      onTap: () => setState(() => _selectedFontFamily = fontFamily),
+      title: Text(
+        fontFamily.isEmpty ? '系统默认' : fontFamily,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        option.isUnavailable ? '当前字体不可用' : _previewText,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: previewStyle,
+      ),
+      trailing: SizedBox.square(
+        dimension: 24,
+        child: isSelected
+            ? Icon(Icons.check_rounded, color: theme.colorScheme.primary)
+            : null,
+      ),
+    );
+  }
+}
+
+class _FontOption {
+  const _FontOption(this.fontFamily, {this.isUnavailable = false});
+
+  final String fontFamily;
+  final bool isUnavailable;
+}

--- a/lib/router/app_pages.dart
+++ b/lib/router/app_pages.dart
@@ -55,6 +55,7 @@ import 'package:PiliPlus/pages/search_trending/view.dart';
 import 'package:PiliPlus/pages/setting/pages/bar_set.dart';
 import 'package:PiliPlus/pages/setting/pages/color_select.dart';
 import 'package:PiliPlus/pages/setting/pages/display_mode.dart';
+import 'package:PiliPlus/pages/setting/pages/font_family_select.dart';
 import 'package:PiliPlus/pages/setting/pages/font_size_select.dart';
 import 'package:PiliPlus/pages/setting/pages/logs.dart';
 import 'package:PiliPlus/pages/setting/pages/play_speed_set.dart';
@@ -111,6 +112,10 @@ class Routes {
     //
     GetPage(name: '/blackListPage', page: () => const BlackListPage()),
     GetPage(name: '/colorSetting', page: () => const ColorSelectPage()),
+    GetPage(
+      name: '/fontFamilySetting',
+      page: () => const FontFamilySelectPage(),
+    ),
     GetPage(name: '/fontSizeSetting', page: () => const FontSizeSelectPage()),
     // 屏幕帧率
     GetPage(name: '/displayModeSetting', page: () => const SetDisplayMode()),

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -127,6 +127,7 @@ abstract final class SettingBoxKey {
       retryDelay = 'retryDelay',
       liveQuality = 'liveQuality',
       liveQualityCellular = 'liveQualityCellular',
+      appFontFamily = 'appFontFamily',
       appFontWeight = 'appFontWeight',
       fastForBackwardDuration = 'fastForBackwardDuration',
       recordSearchHistory = 'recordSearchHistory',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -587,6 +587,9 @@ abstract final class Pref {
     defaultValue: LiveQuality.superHD.code,
   );
 
+  static String get appFontFamily =>
+      _setting.get(SettingBoxKey.appFontFamily, defaultValue: '');
+
   static int get appFontWeight =>
       _setting.get(SettingBoxKey.appFontWeight, defaultValue: -1);
 

--- a/lib/utils/theme_utils.dart
+++ b/lib/utils/theme_utils.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+
 import 'package:PiliPlus/common/style.dart';
 import 'package:PiliPlus/utils/extension/theme_ext.dart';
 import 'package:PiliPlus/utils/storage_pref.dart';
@@ -38,11 +40,20 @@ abstract final class ThemeUtils {
     final fontWeight = appFontWeight == -1
         ? null
         : FontWeight.values[appFontWeight];
-    late final textStyle = TextStyle(fontWeight: fontWeight);
+    final savedFontFamily = Pref.appFontFamily;
+    final fontFamily = Platform.isWindows && savedFontFamily.isNotEmpty
+        ? savedFontFamily
+        : null;
+    final hasCustomTextStyle = fontFamily != null || fontWeight != null;
+    late final textStyle = TextStyle(
+      fontFamily: fontFamily,
+      fontWeight: fontWeight,
+    );
     ThemeData themeData = ThemeData(
       colorScheme: colorScheme,
       useMaterial3: true,
-      textTheme: fontWeight == null
+      fontFamily: fontFamily,
+      textTheme: !hasCustomTextStyle
           ? null
           : TextTheme(
               displayLarge: textStyle,
@@ -61,7 +72,7 @@ abstract final class ThemeUtils {
               labelMedium: textStyle,
               labelSmall: textStyle,
             ),
-      tabBarTheme: fontWeight == null
+      tabBarTheme: !hasCustomTextStyle
           ? null
           : TabBarThemeData(labelStyle: textStyle),
       appBarTheme: AppBarTheme(
@@ -73,6 +84,7 @@ abstract final class ThemeUtils {
         titleTextStyle: TextStyle(
           fontSize: 16,
           color: colorScheme.onSurface,
+          fontFamily: fontFamily,
           fontWeight: fontWeight,
         ),
       ),
@@ -83,7 +95,10 @@ abstract final class ThemeUtils {
         actionTextColor: colorScheme.primary,
         backgroundColor: colorScheme.secondaryContainer,
         closeIconColor: colorScheme.secondary,
-        contentTextStyle: TextStyle(color: colorScheme.onSecondaryContainer),
+        contentTextStyle: TextStyle(
+          color: colorScheme.onSecondaryContainer,
+          fontFamily: fontFamily,
+        ),
         elevation: 20,
       ),
       popupMenuTheme: PopupMenuThemeData(
@@ -108,6 +123,7 @@ abstract final class ThemeUtils {
         titleTextStyle: TextStyle(
           fontSize: 18,
           color: colorScheme.onSurface,
+          fontFamily: fontFamily,
           fontWeight: fontWeight,
         ),
         backgroundColor: colorScheme.surface,
@@ -122,9 +138,10 @@ abstract final class ThemeUtils {
       // ignore: deprecated_member_use
       sliderTheme: const SliderThemeData(year2023: false),
       tooltipTheme: TooltipThemeData(
-        textStyle: const TextStyle(
+        textStyle: TextStyle(
           color: Colors.white,
           fontSize: 14,
+          fontFamily: fontFamily,
         ),
         decoration: BoxDecoration(
           color: Colors.grey[700]!.withValues(alpha: 0.9),

--- a/lib/utils/windows_font_utils.dart
+++ b/lib/utils/windows_font_utils.dart
@@ -1,0 +1,65 @@
+import 'dart:ffi';
+import 'dart:io' show Platform;
+import 'dart:isolate';
+
+import 'package:ffi/ffi.dart';
+import 'package:win32/win32.dart';
+
+abstract final class WindowsFontUtils {
+  static Future<List<String>> getInstalledFontFamilies() {
+    if (!Platform.isWindows) {
+      return Future.value(const <String>[]);
+    }
+    return Isolate.run(_enumerateInstalledFontFamilies);
+  }
+}
+
+List<String> _enumerateInstalledFontFamilies() {
+  final hdc = GetDC(null);
+  if (!hdc.isValid) {
+    throw StateError('Failed to acquire a Windows device context.');
+  }
+
+  final logFont = calloc<LOGFONT>();
+  final fontFamilies = <String, String>{};
+  final callback = NativeCallable<FONTENUMPROC>.isolateLocal(
+    (
+      Pointer<LOGFONT> logFont,
+      Pointer<TEXTMETRIC> _,
+      int _,
+      int _,
+    ) {
+      final fontFamily = logFont.ref.lfFaceName.trim();
+      // Symbol fonts replace ordinary text with pictograms and cannot serve as
+      // an application UI font.
+      if (logFont.ref.lfCharSet != SYMBOL_CHARSET &&
+          fontFamily.isNotEmpty &&
+          !fontFamily.startsWith('@')) {
+        fontFamilies.putIfAbsent(fontFamily.toLowerCase(), () => fontFamily);
+      }
+      return 1;
+    },
+    exceptionalReturn: 0,
+  );
+
+  try {
+    logFont.ref.lfCharSet = DEFAULT_CHARSET;
+    final result = EnumFontFamiliesEx(
+      hdc,
+      logFont,
+      callback.nativeFunction,
+      const LPARAM(0),
+      0,
+    );
+    if (result == 0 && fontFamilies.isEmpty) {
+      throw StateError('Windows did not return any installed fonts.');
+    }
+  } finally {
+    callback.close();
+    calloc.free(logFont);
+    ReleaseDC(null, hdc);
+  }
+
+  return fontFamilies.values.toList()
+    ..sort((a, b) => a.toLowerCase().compareTo(b.toLowerCase()));
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -490,7 +490,7 @@ packages:
     source: hosted
     version: "1.3.3"
   ffi:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: ffi
       sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -83,6 +83,7 @@ dependencies:
     git:
       url: https://github.com/bggRGjQaUbCoE/extended_nested_scroll_view.git
       ref: dev
+  ffi: ^2.1.4
   file_picker: ^12.0.0-beta.7
   fixnum: ^1.1.1
   fl_chart: ^1.0.0


### PR DESCRIPTION
Enumerate installed font families through Win32 GDI and filter fonts unsuitable for application UI.

Add a searchable responsive font preview with a draggable scrollbar and one-to-three-column layout.

Persist the selected family through existing settings backup and apply it with font weight and text scaling.

## 主要变更

- Windows 端支持选择本机已安装字体
- 提供字体搜索、实时预览、重置和刷新
- 根据窗口宽度动态显示 1–3 列
- 支持拖动字体列表滚动条
- 字体族与现有字体字重、字体大小共同生效
- 过滤 Wingdings、Webdings 等纯符号字体
- 保持现有设置导入、导出和 WebDAV 备份兼容

## 兼容性

- 字体选择入口仅在 Windows 显示
- 其他平台不会应用 Windows 字体设置
- 缺失或不可用字体会自动回退，不影响应用启动

## 验证

- `flutter analyze --no-fatal-infos`
- `flutter build windows --release`
- 验证字体枚举、搜索、选择、重置及主题更新
- 验证窗口缩放时 1–3 列响应式切换
- 验证滚动条拖动及纯符号字体过滤