### PR TITLE
fix: 无痕模式下 CC 字幕消失

### DIFF
--- a/lib/pages/video/controller.dart
+++ b/lib/pages/video/controller.dart
@@ -1149,7 +1149,7 @@ class VideoDetailController extends GetxController
 
       if (response.subtitle?.subtitles case final sub? when (sub.isNotEmpty)) {
         _setSubtitle(sub);
-      } else if (!Accounts.main.isLogin) {
+      } else if (!Accounts.heartbeat.isLogin) {
         final res = await DmGrpc.dmView(aid, cid.value);
         if (res case Success(:final response)) {
           if (response.hasSubtitle() &&


### PR DESCRIPTION
 问题：开启无痕模式后点进视频，CC 字幕按钮消失。

 根因：字幕主路径走 playInfo（/x/player/wbi/v2），该接口按路由表归属 heartbeat 账号槽位。无痕模式会把 heartbeat 换成匿名账号，导致 playInfo 请求不携带登录
 凭据，B 站接口不返回字幕列表。此时本应触发 dmView gRPC 兜底（该接口无需登录也能拿到字幕），但兜底条件写的是 !Accounts.main.isLogin——无痕模式下 main 仍是登
 录态，条件为 false，兜底被跳过。于是两条路径都拿不到字幕，subtitles 为空，字幕按钮随之隐藏。

 修复：把兜底条件从 !Accounts.main.isLogin 改为 !Accounts.heartbeat.isLogin，即判断实际发起 playInfo 请求所用的账号，而不是全局登录旗标。改动仅一行。

 大概寻思了一下，应该没有什么负面影响。麻烦大佬看一下，感谢。