### PR TITLE
fix(scaffold): SimpleScaffold 绘制顺序与命中测试顺序不一致

### DIFF
--- a/lib/common/widgets/scaffold/simple_scaffold.dart
+++ b/lib/common/widgets/scaffold/simple_scaffold.dart
@@ -126,8 +126,8 @@ class _RenderScaffoldLayout extends RenderBox
       }
     }
 
-    doPaint(appBar);
     doPaint(body);
+    doPaint(appBar);
     doPaint(fab);
   }
 


### PR DESCRIPTION
`_RenderScaffoldLayout` 目前 `paint()` 按 appBar → body → fab 绘制（body 覆盖 appBar），
而 `hitTestChildren` 目前是按照定义的 `ScaffoldType.values`（fab → appBar → body）从前到后命中测试，
即命中测试认为 appBar 在 body 之上——我们的绘制函数跟验证函数没有按照flutter规范做完整的逆序。

本 PR 将绘制顺序改为 body → appBar → fab，使其与命中测试序互为逆序；
同时这也与 Material Scaffold 的层叠语义一致（`Scaffold.build` 中 body 先于
appBar 加入 children，按序绘制后 appBar 覆盖 body）。

因为一个小问题发现的，对实际渲染应该没有影响，效果已经在实机上进行测试。

不在某些特殊情况下，目前的顺序没有什么问题。但是不知道是否是佬的特殊设计，我看着跟底下的测试函数体现的顺序不太一致，就提了这个PR，麻烦佬抽空看一下。


