### PR TITLE
feat: 支持播放页旋转至横屏时自动全屏

### DIFF
--- a/lib/pages/setting/models/play_settings.dart
+++ b/lib/pages/setting/models/play_settings.dart
@@ -189,6 +189,14 @@ List<SettingsModel> get playSettings => [
     setKey: SettingBoxKey.enableAutoEnter,
     defaultVal: false,
   ),
+  if (PlatformUtils.isMobile)
+    const SwitchModel(
+      title: '旋转至横屏时自动全屏',
+      subtitle: '仅在播放页内由竖屏旋转至横屏时进入全屏，横屏进入播放页时保持横屏布局',
+      leading: Icon(Icons.screen_rotation_outlined),
+      setKey: SettingBoxKey.autoFullScreenOnLandscape,
+      defaultVal: false,
+    ),
   const SwitchModel(
     title: '自动退出全屏',
     subtitle: '视频结束播放时退出全屏',

--- a/lib/pages/video/view.dart
+++ b/lib/pages/video/view.dart
@@ -110,6 +110,9 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
   bool get enableVerticalExpand =>
       videoDetailController.plPlayerController.enableVerticalExpand;
 
+  bool get autoFullScreenOnLandscape =>
+      videoDetailController.plPlayerController.autoFullScreenOnLandscape;
+
   bool get pipNoDanmaku =>
       videoDetailController.plPlayerController.pipNoDanmaku;
 
@@ -457,6 +460,24 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
     final size = MediaQuery.sizeOf(context);
     maxWidth = size.width;
     maxHeight = size.height;
+    final nextIsPortrait = maxHeight >= maxWidth;
+    final previousIsPortrait = _lastPageIsPortrait;
+    _lastPageIsPortrait = nextIsPortrait;
+    if (autoFullScreenOnLandscape &&
+        previousIsPortrait != null &&
+        previousIsPortrait != nextIsPortrait) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || _lastPageIsPortrait != nextIsPortrait) return;
+        final controller = videoDetailController.plPlayerController;
+        if (previousIsPortrait && !controller.isFullScreen.value) {
+          controller.triggerFullScreen(isManualFS: false);
+        } else if (nextIsPortrait &&
+            controller.isFullScreen.value &&
+            !controller.isManualFS) {
+          controller.triggerFullScreen(status: false);
+        }
+      });
+    }
     isWindowMode = MaxScreenSize.isWindowMode(
       width: maxWidth * videoDetailController.uiScale,
       height: maxHeight * videoDetailController.uiScale,
@@ -467,7 +488,7 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
     final minVideoHeight = shortestSide / Style.aspectRatio16x9;
     final maxVideoHeight = max(size.longestSide * 0.65, shortestSide);
     videoDetailController
-      ..isPortrait = isPortrait = maxHeight >= maxWidth
+      ..isPortrait = isPortrait = nextIsPortrait
       ..minVideoHeight = minVideoHeight
       ..maxVideoHeight = maxVideoHeight
       ..videoHeight = videoDetailController.isVertical.value
@@ -1246,6 +1267,7 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
   late ThemeData theme;
   ColorScheme get colorScheme => theme.colorScheme;
   late bool isPortrait;
+  bool? _lastPageIsPortrait;
   late double maxWidth;
   late double maxHeight;
   bool isWindowMode = false;

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -487,14 +487,10 @@ class PlPlayerController with BlockConfigMixin {
   }
 
   void _onOrientationChanged(OrientationParams param) {
-    final previousOrientation = _orientation;
     _orientation = param.orientation;
     if (Platform.isIOS && !visible) return;
     final orientation = param.orientation;
     final isFullScreen = this.isFullScreen.value;
-    final rotatedFromPortrait =
-        previousOrientation == .portraitUp ||
-        previousOrientation == .portraitDown;
     if (checkIsAutoRotate &&
         param.isAutoRotate != true &&
         (!isFullScreen ||
@@ -506,9 +502,7 @@ class PlPlayerController with BlockConfigMixin {
     switch (orientation) {
       case .portraitUp:
         if (!_isVertical && controlsLock.value) return;
-        if (((!horizontalScreen && !_isVertical) ||
-                autoFullScreenOnLandscape) &&
-            isFullScreen) {
+        if (!horizontalScreen && !_isVertical && isFullScreen) {
           if (!isManualFS) {
             triggerFullScreen(status: false, orientation: orientation);
           }
@@ -518,23 +512,15 @@ class PlPlayerController with BlockConfigMixin {
       case .portraitDown:
         if (!horizontalScreen) return;
         if (!_isVertical && controlsLock.value) return;
-        if (autoFullScreenOnLandscape && isFullScreen && !isManualFS) {
-          triggerFullScreen(status: false, orientation: orientation);
-        } else {
-          portraitDownMode();
-        }
+        portraitDownMode();
       case .landscapeLeft:
-        if ((!horizontalScreen ||
-                (autoFullScreenOnLandscape && rotatedFromPortrait)) &&
-            !isFullScreen) {
+        if (!horizontalScreen && !isFullScreen) {
           triggerFullScreen(orientation: orientation, isManualFS: false);
         } else {
           landscapeLeftMode();
         }
       case .landscapeRight:
-        if ((!horizontalScreen ||
-                (autoFullScreenOnLandscape && rotatedFromPortrait)) &&
-            !isFullScreen) {
+        if (!horizontalScreen && !isFullScreen) {
           triggerFullScreen(orientation: orientation, isManualFS: false);
         } else {
           landscapeRightMode();

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -487,10 +487,14 @@ class PlPlayerController with BlockConfigMixin {
   }
 
   void _onOrientationChanged(OrientationParams param) {
+    final previousOrientation = _orientation;
     _orientation = param.orientation;
     if (Platform.isIOS && !visible) return;
     final orientation = param.orientation;
     final isFullScreen = this.isFullScreen.value;
+    final rotatedFromPortrait =
+        previousOrientation == .portraitUp ||
+        previousOrientation == .portraitDown;
     if (checkIsAutoRotate &&
         param.isAutoRotate != true &&
         (!isFullScreen ||
@@ -502,7 +506,9 @@ class PlPlayerController with BlockConfigMixin {
     switch (orientation) {
       case .portraitUp:
         if (!_isVertical && controlsLock.value) return;
-        if (!horizontalScreen && !_isVertical && isFullScreen) {
+        if (((!horizontalScreen && !_isVertical) ||
+                autoFullScreenOnLandscape) &&
+            isFullScreen) {
           if (!isManualFS) {
             triggerFullScreen(status: false, orientation: orientation);
           }
@@ -512,15 +518,23 @@ class PlPlayerController with BlockConfigMixin {
       case .portraitDown:
         if (!horizontalScreen) return;
         if (!_isVertical && controlsLock.value) return;
-        portraitDownMode();
+        if (autoFullScreenOnLandscape && isFullScreen && !isManualFS) {
+          triggerFullScreen(status: false, orientation: orientation);
+        } else {
+          portraitDownMode();
+        }
       case .landscapeLeft:
-        if (!horizontalScreen && !isFullScreen) {
+        if ((!horizontalScreen ||
+                (autoFullScreenOnLandscape && rotatedFromPortrait)) &&
+            !isFullScreen) {
           triggerFullScreen(orientation: orientation, isManualFS: false);
         } else {
           landscapeLeftMode();
         }
       case .landscapeRight:
-        if (!horizontalScreen && !isFullScreen) {
+        if ((!horizontalScreen ||
+                (autoFullScreenOnLandscape && rotatedFromPortrait)) &&
+            !isFullScreen) {
           triggerFullScreen(orientation: orientation, isManualFS: false);
         } else {
           landscapeRightMode();
@@ -1364,6 +1378,7 @@ class PlPlayerController with BlockConfigMixin {
   bool isManualFS = true;
   late final FullScreenMode mode = Pref.fullScreenMode;
   late final horizontalScreen = Pref.horizontalScreen;
+  late final autoFullScreenOnLandscape = Pref.autoFullScreenOnLandscape;
   late final removeSafeArea = Pref.removeSafeArea;
 
   Future<void>? changeOrientation({

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -8,6 +8,7 @@ abstract final class SettingBoxKey {
       defaultAudioQaCellular = 'defaultAudioQaCellular',
       autoPlayEnable = 'autoPlayEnable',
       fullScreenMode = 'fullScreenMode',
+      autoFullScreenOnLandscape = 'autoFullScreenOnLandscape',
       preferCodecs = 'preferCodecs',
       defaultToastOp = 'defaultToastOp',
       defaultPicQa = 'defaultPicQa',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -207,6 +207,11 @@ abstract final class Pref {
     return FullScreenMode.values[index];
   }
 
+  static bool get autoFullScreenOnLandscape => _setting.get(
+    SettingBoxKey.autoFullScreenOnLandscape,
+    defaultValue: false,
+  );
+
   static BtmProgressBehavior get btmProgressBehavior =>
       BtmProgressBehavior.values[_setting.get(
         SettingBoxKey.btmProgressBehavior,


### PR DESCRIPTION
## 功能

- 新增“旋转至横屏时自动全屏”设置，默认关闭，不改变现有用户行为。
- 已处于横屏时进入视频页，继续使用横屏布局，不自动进入全屏。
- 在播放页内从竖屏旋转到横屏时自动进入全屏；转回竖屏时退出此次自动触发的全屏。
- 手动进入全屏的行为保持不变。

## 主要改动

- `play_settings.dart`：增加移动端设置项。
- `controller.dart`：区分初始方向与进入播放页后的方向变化。
- `storage_key.dart`、`storage_pref.dart`：保存并读取设置。

## 验证

- 已在 Android 平板真机验证横屏进入视频页、播放页内竖屏转横屏、转回竖屏和手动全屏等场景。