### PR TITLE
feat: add MPV-style keyboard speed shortcuts

### DIFF
--- a/lib/pages/video/widgets/player_focus.dart
+++ b/lib/pages/video/widgets/player_focus.dart
@@ -5,12 +5,18 @@ import 'dart:math' as math;
 import 'package:PiliPlus/pages/common/common_intro_controller.dart';
 import 'package:PiliPlus/pages/video/introduction/ugc/controller.dart';
 import 'package:PiliPlus/plugin/pl_player/controller.dart';
+import 'package:PiliPlus/plugin/pl_player/models/mpv_speed_shortcut.dart';
 import 'package:PiliPlus/utils/platform_utils.dart';
 import 'package:PiliPlus/utils/storage.dart';
 import 'package:PiliPlus/utils/storage_key.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart'
-    show KeyDownEvent, KeyUpEvent, LogicalKeyboardKey, HardwareKeyboard;
+    show
+        HardwareKeyboard,
+        KeyDownEvent,
+        KeyRepeatEvent,
+        KeyUpEvent,
+        LogicalKeyboardKey;
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:get/get.dart';
 
@@ -42,11 +48,26 @@ class PlayerFocus extends StatelessWidget {
         logicalKey == LogicalKeyboardKey.arrowDown;
   }
 
+  static bool _hasEditableFocus() {
+    final context = FocusManager.instance.primaryFocus?.context;
+    if (context == null) return false;
+    return context.widget is EditableText ||
+        context.findAncestorWidgetOfExactType<EditableText>() != null;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Focus(
       autofocus: true,
+      onFocusChange: (hasFocus) {
+        if (!hasFocus) {
+          plPlayerController.releaseMpvSpeedShortcut();
+        }
+      },
       onKeyEvent: (node, event) {
+        if (_hasEditableFocus()) {
+          return KeyEventResult.ignored;
+        }
         final handled = _handleKey(event);
         if (handled || _shouldHandle(event.logicalKey)) {
           return KeyEventResult.handled;
@@ -88,6 +109,40 @@ class PlayerFocus extends StatelessWidget {
 
   bool _handleKey(KeyEvent event) {
     final key = event.logicalKey;
+    final hardwareKeyboard = HardwareKeyboard.instance;
+    final hasCommandModifier =
+        hardwareKeyboard.isControlPressed ||
+        hardwareKeyboard.isAltPressed ||
+        hardwareKeyboard.isMetaPressed;
+    final isShiftPressed = hardwareKeyboard.isShiftPressed;
+
+    final isKeyK = key == LogicalKeyboardKey.keyK;
+    final isKeyL = key == LogicalKeyboardKey.keyL;
+    if (!hasCommandModifier && !isShiftPressed && (isKeyK || isKeyL)) {
+      final slot = isKeyK ? MpvSpeedSlot.k : MpvSpeedSlot.l;
+      if (event is KeyDownEvent) {
+        plPlayerController.onMpvSpeedKeyDown(slot, event.timeStamp);
+      } else if (event is KeyRepeatEvent) {
+        plPlayerController.onMpvSpeedKeyDown(
+          slot,
+          event.timeStamp,
+          repeat: true,
+        );
+      } else if (event is KeyUpEvent) {
+        plPlayerController.onMpvSpeedKeyUp(slot, event.timeStamp);
+      }
+      return true;
+    }
+
+    final isMinus = key == LogicalKeyboardKey.minus;
+    if (!hasCommandModifier &&
+        !isShiftPressed &&
+        (isMinus || key == LogicalKeyboardKey.equal)) {
+      if (event is KeyDownEvent || event is KeyRepeatEvent) {
+        plPlayerController.adjustMpvSpeed(isMinus ? -1 : 1);
+      }
+      return true;
+    }
 
     final isKeyQ = key == LogicalKeyboardKey.keyQ;
     if (isKeyQ || key == LogicalKeyboardKey.keyR) {
@@ -223,7 +278,8 @@ class PlayerFocus extends StatelessWidget {
           return true;
 
         case LogicalKeyboardKey.keyL:
-          if (isFullScreen || plPlayerController.isDesktopPip) {
+          if (HardwareKeyboard.instance.isShiftPressed &&
+              (isFullScreen || plPlayerController.isDesktopPip)) {
             plPlayerController.onLockControl(
               !plPlayerController.controlsLock.value,
             );

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -26,6 +26,7 @@ import 'package:PiliPlus/plugin/pl_player/models/double_tap_type.dart';
 import 'package:PiliPlus/plugin/pl_player/models/duration.dart';
 import 'package:PiliPlus/plugin/pl_player/models/fullscreen_mode.dart';
 import 'package:PiliPlus/plugin/pl_player/models/heart_beat_type.dart';
+import 'package:PiliPlus/plugin/pl_player/models/mpv_speed_shortcut.dart';
 import 'package:PiliPlus/plugin/pl_player/models/play_repeat.dart';
 import 'package:PiliPlus/plugin/pl_player/models/play_status.dart';
 import 'package:PiliPlus/plugin/pl_player/models/video_fit_type.dart';
@@ -103,6 +104,12 @@ class PlPlayerController with BlockConfigMixin {
   late double lastPlaybackSpeed = 1.0;
   final RxDouble _playbackSpeed = Pref.playSpeedDefault.obs;
   late final RxDouble _longPressSpeed = Pref.longPressSpeedDefault.obs;
+  late final MpvSpeedShortcutMachine mpvSpeedShortcut = MpvSpeedShortcutMachine(
+    kTarget: Pref.mpvKeyKSpeed,
+    lTarget: Pref.mpvKeyLSpeed,
+  );
+  Future<void> _mpvSpeedQueue = Future<void>.value();
+  double? _mpvPendingSpeed;
 
   final RxDouble volume = RxDouble(
     PlatformUtils.isDesktop ? Pref.desktopVolume : 1.0,
@@ -1126,6 +1133,67 @@ class PlPlayerController with BlockConfigMixin {
     }
   }
 
+  void _dispatchMpvSpeedAction(MpvSpeedAction action) {
+    if (!action.handled) return;
+
+    final persistSlot = action.persistSlot;
+    final persistTarget = action.persistTarget;
+    if (persistSlot != null && persistTarget != null) {
+      final key = persistSlot == MpvSpeedSlot.k
+          ? VideoBoxKey.mpvKeyKSpeed
+          : VideoBoxKey.mpvKeyLSpeed;
+      GStorage.video.put(key, persistTarget);
+    }
+
+    final speed = action.playbackSpeed;
+    if (speed != null) {
+      _mpvPendingSpeed = speed;
+      _mpvSpeedQueue = _mpvSpeedQueue.catchError((_) {}).then((_) async {
+        await setPlaybackSpeed(speed);
+        if (_mpvPendingSpeed == speed) {
+          _mpvPendingSpeed = null;
+        }
+      });
+    }
+  }
+
+  void onMpvSpeedKeyDown(
+    MpvSpeedSlot slot,
+    Duration timeStamp, {
+    bool repeat = false,
+  }) {
+    if (isLive || videoPlayerController == null) return;
+    _dispatchMpvSpeedAction(
+      mpvSpeedShortcut.keyDown(
+        slot,
+        currentSpeed: _mpvPendingSpeed ?? playbackSpeed,
+        timeStamp: timeStamp,
+        repeat: repeat,
+      ),
+    );
+  }
+
+  void onMpvSpeedKeyUp(MpvSpeedSlot slot, Duration timeStamp) {
+    if (isLive) return;
+    _dispatchMpvSpeedAction(
+      mpvSpeedShortcut.keyUp(slot, timeStamp: timeStamp),
+    );
+  }
+
+  void adjustMpvSpeed(int deltaTenths) {
+    if (isLive || videoPlayerController == null) return;
+    _dispatchMpvSpeedAction(
+      mpvSpeedShortcut.adjust(
+        currentSpeed: _mpvPendingSpeed ?? playbackSpeed,
+        deltaTenths: deltaTenths,
+      ),
+    );
+  }
+
+  void releaseMpvSpeedShortcut() {
+    _dispatchMpvSpeedAction(mpvSpeedShortcut.releaseAll());
+  }
+
   // 还原默认速度
   double playSpeedDefault = Pref.playSpeedDefault;
   Future<void> setDefaultSpeed() async {
@@ -1557,6 +1625,8 @@ class PlPlayerController with BlockConfigMixin {
     }
 
     _playerCount = 0;
+    mpvSpeedShortcut.releaseAll();
+    _mpvPendingSpeed = null;
     if (removeSafeArea) {
       showSystemBar();
     }

--- a/lib/plugin/pl_player/models/mpv_speed_shortcut.dart
+++ b/lib/plugin/pl_player/models/mpv_speed_shortcut.dart
@@ -1,0 +1,176 @@
+enum MpvSpeedSlot { k, l }
+
+final class MpvSpeedAction {
+  const MpvSpeedAction({
+    this.handled = true,
+    this.playbackSpeed,
+    this.persistSlot,
+    this.persistTarget,
+  });
+
+  const MpvSpeedAction.ignored()
+    : handled = false,
+      playbackSpeed = null,
+      persistSlot = null,
+      persistTarget = null;
+
+  final bool handled;
+  final double? playbackSpeed;
+  final MpvSpeedSlot? persistSlot;
+  final double? persistTarget;
+}
+
+final class MpvSpeedShortcutMachine {
+  MpvSpeedShortcutMachine({
+    required double kTarget,
+    required double lTarget,
+  }) : _kTarget = _normalize(kTarget),
+       _lTarget = _normalize(lTarget);
+
+  static const holdThreshold = Duration(milliseconds: 250);
+
+  double _kTarget;
+  double _lTarget;
+  MpvSpeedSlot? _pressedSlot;
+  MpvSpeedSlot? _latchedSlot;
+  MpvSpeedSlot? _learningSlot;
+  Duration? _pressedAt;
+  double? _pressedRestoreSpeed;
+  double? _latchedRestoreSpeed;
+  bool _disablePress = false;
+
+  bool get isLatched => _latchedSlot != null;
+
+  MpvSpeedAction keyDown(
+    MpvSpeedSlot slot, {
+    required double currentSpeed,
+    required Duration timeStamp,
+    bool repeat = false,
+  }) {
+    if (repeat || _pressedSlot != null) {
+      return const MpvSpeedAction.ignored();
+    }
+
+    _pressedSlot = slot;
+    _pressedAt = timeStamp;
+    _disablePress = false;
+
+    if (_latchedSlot == slot && _latchedRestoreSpeed != null) {
+      final restoreSpeed = _latchedRestoreSpeed!;
+      _pressedRestoreSpeed = restoreSpeed;
+      _disablePress = true;
+      _learningSlot = null;
+      _clearLatched();
+      return MpvSpeedAction(playbackSpeed: restoreSpeed);
+    }
+
+    _pressedRestoreSpeed = _latchedRestoreSpeed ?? currentSpeed;
+    _clearLatched();
+    _learningSlot = slot;
+    return MpvSpeedAction(playbackSpeed: _targetFor(slot));
+  }
+
+  MpvSpeedAction keyUp(
+    MpvSpeedSlot slot, {
+    required Duration timeStamp,
+  }) {
+    if (_pressedSlot != slot ||
+        _pressedAt == null ||
+        _pressedRestoreSpeed == null) {
+      return const MpvSpeedAction.ignored();
+    }
+
+    final pressedAt = _pressedAt!;
+    final restoreSpeed = _pressedRestoreSpeed!;
+    final disablePress = _disablePress;
+    _clearPressed();
+
+    if (disablePress) {
+      return const MpvSpeedAction();
+    }
+
+    if (timeStamp - pressedAt >= holdThreshold) {
+      _learningSlot = null;
+      return MpvSpeedAction(playbackSpeed: restoreSpeed);
+    }
+
+    _latchedSlot = slot;
+    _latchedRestoreSpeed = restoreSpeed;
+    _learningSlot = slot;
+    return const MpvSpeedAction();
+  }
+
+  MpvSpeedAction adjust({
+    required double currentSpeed,
+    required int deltaTenths,
+  }) {
+    final learningSlot = _learningSlot;
+    if (learningSlot == null) {
+      return MpvSpeedAction(
+        playbackSpeed: _step(currentSpeed, deltaTenths),
+      );
+    }
+
+    final target = _step(_targetFor(learningSlot), deltaTenths);
+    _setTarget(learningSlot, target);
+    return MpvSpeedAction(
+      playbackSpeed: target,
+      persistSlot: learningSlot,
+      persistTarget: target,
+    );
+  }
+
+  MpvSpeedAction releaseAll() {
+    double? restoreSpeed;
+    if (!_disablePress) {
+      restoreSpeed = _pressedRestoreSpeed ?? _latchedRestoreSpeed;
+    }
+
+    _clearPressed();
+    _clearLatched();
+    _learningSlot = null;
+
+    if (restoreSpeed == null) {
+      return const MpvSpeedAction.ignored();
+    }
+    return MpvSpeedAction(playbackSpeed: restoreSpeed);
+  }
+
+  double _targetFor(MpvSpeedSlot slot) {
+    return switch (slot) {
+      MpvSpeedSlot.k => _kTarget,
+      MpvSpeedSlot.l => _lTarget,
+    };
+  }
+
+  void _setTarget(MpvSpeedSlot slot, double value) {
+    switch (slot) {
+      case MpvSpeedSlot.k:
+        _kTarget = value;
+      case MpvSpeedSlot.l:
+        _lTarget = value;
+    }
+  }
+
+  void _clearPressed() {
+    _pressedSlot = null;
+    _pressedAt = null;
+    _pressedRestoreSpeed = null;
+    _disablePress = false;
+  }
+
+  void _clearLatched() {
+    _latchedSlot = null;
+    _latchedRestoreSpeed = null;
+  }
+
+  static double _normalize(double speed) {
+    final tenths = (speed * 10).round();
+    return (tenths < 1 ? 1 : tenths) / 10;
+  }
+
+  static double _step(double speed, int deltaTenths) {
+    final tenths = (speed * 10).round() + deltaTenths;
+    return (tenths < 1 ? 1 : tenths) / 10;
+  }
+}

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -251,6 +251,8 @@ abstract final class VideoBoxKey {
   static const String playRepeat = 'playRepeat',
       playSpeedDefault = 'playSpeedDefault',
       longPressSpeedDefault = 'longPressSpeedDefault',
+      mpvKeyKSpeed = 'mpvKeyKSpeed',
+      mpvKeyLSpeed = 'mpvKeyLSpeed',
       speedsList = 'speedsList',
       cacheVideoFit = 'cacheVideoFit';
 }

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -862,6 +862,12 @@ abstract final class Pref {
   static double get longPressSpeedDefault =>
       _video.get(VideoBoxKey.longPressSpeedDefault, defaultValue: 3.0);
 
+  static double get mpvKeyKSpeed =>
+      _video.get(VideoBoxKey.mpvKeyKSpeed, defaultValue: 2.0);
+
+  static double get mpvKeyLSpeed =>
+      _video.get(VideoBoxKey.mpvKeyLSpeed, defaultValue: 3.0);
+
   static bool get defaultShowComment =>
       _setting.get(SettingBoxKey.defaultShowComment, defaultValue: false);
 

--- a/test/plugin/pl_player/models/mpv_speed_shortcut_test.dart
+++ b/test/plugin/pl_player/models/mpv_speed_shortcut_test.dart
@@ -1,0 +1,217 @@
+import 'package:PiliPlus/plugin/pl_player/models/mpv_speed_shortcut.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  MpvSpeedShortcutMachine createMachine() {
+    return MpvSpeedShortcutMachine(kTarget: 2.0, lTarget: 3.0);
+  }
+
+  void latch(
+    MpvSpeedShortcutMachine machine,
+    MpvSpeedSlot slot, {
+    double currentSpeed = 1.0,
+  }) {
+    machine.keyDown(
+      slot,
+      currentSpeed: currentSpeed,
+      timeStamp: Duration.zero,
+    );
+    machine.keyUp(
+      slot,
+      timeStamp: const Duration(milliseconds: 100),
+    );
+  }
+
+  test('K applies 2.00x and release at 249ms latches', () {
+    final machine = createMachine();
+
+    final down = machine.keyDown(
+      MpvSpeedSlot.k,
+      currentSpeed: 1.0,
+      timeStamp: Duration.zero,
+    );
+    final up = machine.keyUp(
+      MpvSpeedSlot.k,
+      timeStamp: const Duration(milliseconds: 249),
+    );
+
+    expect(down.playbackSpeed, 2.0);
+    expect(up.playbackSpeed, isNull);
+    expect(machine.isLatched, isTrue);
+  });
+
+  test('release at 250ms restores the original speed', () {
+    final machine = createMachine();
+
+    machine.keyDown(
+      MpvSpeedSlot.l,
+      currentSpeed: 1.25,
+      timeStamp: Duration.zero,
+    );
+    final up = machine.keyUp(
+      MpvSpeedSlot.l,
+      timeStamp: const Duration(milliseconds: 250),
+    );
+
+    expect(up.playbackSpeed, 1.25);
+    expect(machine.isLatched, isFalse);
+  });
+
+  test('pressing the latched slot again restores the original speed', () {
+    final machine = createMachine();
+    latch(machine, MpvSpeedSlot.k, currentSpeed: 1.25);
+
+    final down = machine.keyDown(
+      MpvSpeedSlot.k,
+      currentSpeed: 2.0,
+      timeStamp: const Duration(seconds: 1),
+    );
+    final up = machine.keyUp(
+      MpvSpeedSlot.k,
+      timeStamp: const Duration(milliseconds: 1100),
+    );
+
+    expect(down.playbackSpeed, 1.25);
+    expect(up.playbackSpeed, isNull);
+    expect(machine.isLatched, isFalse);
+  });
+
+  test('switching from K to L preserves the original restore speed', () {
+    final machine = createMachine();
+    latch(machine, MpvSpeedSlot.k, currentSpeed: 1.25);
+
+    final down = machine.keyDown(
+      MpvSpeedSlot.l,
+      currentSpeed: 2.0,
+      timeStamp: const Duration(seconds: 1),
+    );
+    machine.keyUp(
+      MpvSpeedSlot.l,
+      timeStamp: const Duration(milliseconds: 1100),
+    );
+    final restore = machine.keyDown(
+      MpvSpeedSlot.l,
+      currentSpeed: 3.0,
+      timeStamp: const Duration(seconds: 2),
+    );
+
+    expect(down.playbackSpeed, 3.0);
+    expect(restore.playbackSpeed, 1.25);
+  });
+
+  test('active K adjustment applies and persists only the K target', () {
+    final machine = createMachine();
+    latch(machine, MpvSpeedSlot.k);
+
+    final action = machine.adjust(currentSpeed: 2.0, deltaTenths: 1);
+
+    expect(action.playbackSpeed, 2.1);
+    expect(action.persistSlot, MpvSpeedSlot.k);
+    expect(action.persistTarget, 2.1);
+  });
+
+  test('active L adjustment applies and persists only the L target', () {
+    final machine = createMachine();
+    latch(machine, MpvSpeedSlot.l);
+
+    final action = machine.adjust(currentSpeed: 3.0, deltaTenths: -1);
+
+    expect(action.playbackSpeed, 2.9);
+    expect(action.persistSlot, MpvSpeedSlot.l);
+    expect(action.persistTarget, 2.9);
+  });
+
+  test('idle adjustment does not persist a target', () {
+    final machine = createMachine();
+
+    final action = machine.adjust(currentSpeed: 1.0, deltaTenths: 1);
+
+    expect(action.playbackSpeed, 1.1);
+    expect(action.persistSlot, isNull);
+    expect(action.persistTarget, isNull);
+  });
+
+  test('repeat key-down is ignored without restarting hold duration', () {
+    final machine = createMachine();
+    machine.keyDown(
+      MpvSpeedSlot.k,
+      currentSpeed: 1.0,
+      timeStamp: Duration.zero,
+    );
+
+    final repeat = machine.keyDown(
+      MpvSpeedSlot.k,
+      currentSpeed: 2.0,
+      timeStamp: const Duration(milliseconds: 200),
+      repeat: true,
+    );
+    final up = machine.keyUp(
+      MpvSpeedSlot.k,
+      timeStamp: const Duration(milliseconds: 250),
+    );
+
+    expect(repeat.handled, isFalse);
+    expect(up.playbackSpeed, 1.0);
+  });
+
+  test('mismatched key-up is ignored', () {
+    final machine = createMachine();
+    machine.keyDown(
+      MpvSpeedSlot.k,
+      currentSpeed: 1.0,
+      timeStamp: Duration.zero,
+    );
+
+    final action = machine.keyUp(
+      MpvSpeedSlot.l,
+      timeStamp: const Duration(milliseconds: 100),
+    );
+
+    expect(action.handled, isFalse);
+  });
+
+  test('releaseAll restores a held speed and clears state', () {
+    final machine = createMachine();
+    machine.keyDown(
+      MpvSpeedSlot.l,
+      currentSpeed: 1.5,
+      timeStamp: Duration.zero,
+    );
+
+    final action = machine.releaseAll();
+
+    expect(action.playbackSpeed, 1.5);
+    expect(machine.isLatched, isFalse);
+  });
+
+  test('releaseAll restores a latched speed and clears state', () {
+    final machine = createMachine();
+    latch(machine, MpvSpeedSlot.k, currentSpeed: 1.5);
+
+    final action = machine.releaseAll();
+
+    expect(action.playbackSpeed, 1.5);
+    expect(machine.isLatched, isFalse);
+  });
+
+  test('decimal steps do not accumulate floating-point drift', () {
+    final machine = createMachine();
+    var speed = 1.0;
+
+    for (var index = 0; index < 10; index += 1) {
+      speed = machine
+          .adjust(currentSpeed: speed, deltaTenths: 1)
+          .playbackSpeed!;
+    }
+
+    expect(speed, 2.0);
+  });
+
+  test('speed never drops below 0.10x', () {
+    final machine = createMachine();
+
+    final action = machine.adjust(currentSpeed: 0.1, deltaTenths: -1);
+
+    expect(action.playbackSpeed, 0.1);
+  });
+}


### PR DESCRIPTION
## Summary
- add MPV-style Bluetooth hardware-keyboard speed shortcuts
- map `-` / `=` to 0.10x speed steps
- map K/L to remembered 2.0x/3.0x tap-or-hold slots
- move the existing player lock shortcut from L to Shift+L
- restore speed when player focus is lost

## Behavior
- quick K/L press latches the configured target speed
- pressing the active slot again restores the original speed
- holding K/L for at least 250 ms restores on release
- active `-` / `=` adjustments update and persist the active slot target
- live playback and editable text focus are excluded

## Tests
- `flutter test`: 13 tests passed
- changed production files pass targeted Dart analysis
- formatting and `git diff --check` pass

The repository-wide analyzer still reports the existing private-Flutter-API diagnostics that are handled by the project's platform patch step during CI.