### PR TITLE
fix orientation when horizontal screen enabled

### DIFF
--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -499,6 +499,8 @@ class PlPlayerController with BlockConfigMixin {
             orientation == .portraitDown)) {
       return;
     }
+    // 横屏适配且未全屏时保持系统自动旋转：若锁定到当前单一方向，
+    // 传感器事件延迟或丢失时，会导致旋转后界面居中留边（letterbox）。
     switch (orientation) {
       case .portraitUp:
         if (!_isVertical && controlsLock.value) return;
@@ -506,22 +508,32 @@ class PlPlayerController with BlockConfigMixin {
           if (!isManualFS) {
             triggerFullScreen(status: false, orientation: orientation);
           }
+        } else if (horizontalScreen && !isFullScreen) {
+          fullMode();
         } else {
           portraitUpMode();
         }
       case .portraitDown:
         if (!horizontalScreen) return;
         if (!_isVertical && controlsLock.value) return;
-        portraitDownMode();
+        if (isFullScreen) {
+          portraitDownMode();
+        } else {
+          fullMode();
+        }
       case .landscapeLeft:
         if (!horizontalScreen && !isFullScreen) {
           triggerFullScreen(orientation: orientation, isManualFS: false);
+        } else if (horizontalScreen && !isFullScreen) {
+          fullMode();
         } else {
           landscapeLeftMode();
         }
       case .landscapeRight:
         if (!horizontalScreen && !isFullScreen) {
           triggerFullScreen(orientation: orientation, isManualFS: false);
+        } else if (horizontalScreen && !isFullScreen) {
+          fullMode();
         } else {
           landscapeRightMode();
         }


### PR DESCRIPTION
### Problem
When "horizontal screen" mode (横屏适配) is enabled and the player is not in fullscreen, the device-orientation listener locks the app to the current single orientation (e.g. portraitUp). If the next sensor event is delayed or lost - which often happens right after entering the video detail page - the app stays locked to the old orientation. The OS then letterboxes the window, so the UI is shown centered with empty sides instead of switching to the landscape layout.

### Fix
In `_onOrientationChanged`, when `horizontalScreen` is enabled and the player is not fullscreen, keep the system in all-orientation mode (`fullMode()`) so rotation is handled natively by the OS and the page switches to the landscape layout via MediaQuery. Fullscreen orientation locking is unchanged.