### PR TITLE
opt: 优化合并弹幕功能

### DIFF
--- a/lib/pages/danmaku/controller.dart
+++ b/lib/pages/danmaku/controller.dart
@@ -78,6 +78,10 @@ class PlDanmakuController {
       }
 
       if (!element.isSelf) {
+        // 被过滤的弹幕(文本/正则/按用户屏蔽)既不显示也不参与合并计数
+        if (shouldFilter && filters.remove(element)) {
+          continue;
+        }
         if (_mergeDanmaku) {
           final window = element.progress ~/ mergeWindow;
           final uniques = windowed.putIfAbsent(window, HashMap.new);
@@ -89,10 +93,6 @@ class PlDanmakuController {
             entry.$2.add(element.midHash);
             continue;
           }
-        }
-
-        if (shouldFilter && filters.remove(element)) {
-          continue;
         }
       }
 

--- a/lib/pages/danmaku/controller.dart
+++ b/lib/pages/danmaku/controller.dart
@@ -30,6 +30,8 @@ class PlDanmakuController {
   late final Set<int> _requestedSeg = HashSet();
 
   static const int segmentLength = 60 * 6 * 1000;
+  // 合并弹幕的时间窗口：相同内容仅在窗口内合并，避免跨时间段误合并
+  static const int mergeWindow = 15 * 1000;
 
   void dispose() {
     _dmSegMap.clear();
@@ -65,7 +67,8 @@ class PlDanmakuController {
 
   void handleDanmaku(List<DanmakuElem> elems) {
     if (elems.isEmpty) return;
-    final uniques = HashMap<String, DanmakuElem>();
+    // 按时间窗口分组：窗口 → 文本 → (首条弹幕, 该组出现过的不同用户集合)
+    final windowed = HashMap<int, HashMap<String, (DanmakuElem, Set<String>)>>();
 
     final filters = _plPlayerController.filters;
     final shouldFilter = filters.count != 0;
@@ -76,11 +79,14 @@ class PlDanmakuController {
 
       if (!element.isSelf) {
         if (_mergeDanmaku) {
-          final elem = uniques[element.content];
-          if (elem == null) {
-            uniques[element.content] = element..count = 1;
+          final window = element.progress ~/ mergeWindow;
+          final uniques = windowed.putIfAbsent(window, HashMap.new);
+          final entry = uniques[element.content];
+          if (entry == null) {
+            uniques[element.content] = (element, {element.midHash});
           } else {
-            elem.count++;
+            // 仅收集不同的用户(midHash)，条数不累加，最终计数=不同用户数
+            entry.$2.add(element.midHash);
             continue;
           }
         }
@@ -92,6 +98,15 @@ class PlDanmakuController {
 
       final int pos = element.progress ~/ 100; //每0.1秒存储一次
       (_dmSegMap[pos] ??= []).add(element);
+    }
+
+    // 合并结束后：count 设为该窗口内发送该文本的不同用户数
+    if (_mergeDanmaku) {
+      for (final uniques in windowed.values) {
+        for (final (element, users) in uniques.values) {
+          element.count = users.length;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## 变更说明

优化「合并弹幕」功能的合并范围与计数语义，并修复被屏蔽弹幕绕过合并计数的问题。

### 1. 合并范围：整个分片 → 15 秒窗口

原实现在整个 6 分钟分片内合并相同内容的弹幕，这样会导致不同场景的弹幕被合并到一处，改为按 15 秒固定窗口分组，相同内容仅在同一个窗口内合并，不过具体的数值还可以再考虑一下

### 2. 计数语义：总条数 → 不同用户数

原实现中 (N) 表示窗口内的总条数。现改为统计窗口内发送该文本的不同用户数（按 midHash 去重）：同一窗口内，同一用户因网络或刷屏重复发送的弹幕只合并不计数；该用户在不同窗口中发送的弹幕不受影响。

| 场景 | 原行为 | 新行为 |
|------|--------|--------|
| A 刷 49 条 + B 发 1 条 | `(50)` | `(2)` |
| 纯单人刷屏 50 条 | 显示计数 | count=1 不显示 |
| 5 个用户各发 1 条 | `(5)` | `(5)`（不变） |

### 3. 修复：被屏蔽弹幕绕过合并计数

原合并逻辑中，被合并的弹幕因 `continue` 跳过了 `filters.remove()` 检查，导致被屏蔽用户（按 midHash 屏蔽）的弹幕仍被计入合并计数。将过滤检查提前到合并逻辑之前，统一处理所有路径：

- 被屏蔽的弹幕既不显示，也不参与合并计数
- 合并组锚点被屏蔽时，自动让位给后续弹幕，不再连带屏蔽整组

## 修改文件

`lib/pages/danmaku/controller.dart`

## 兼容性

- 未开启「合并弹幕」时，行为与之前完全一致（所有新逻辑均在 `_mergeDanmaku` 条件内）
- 已有设置项不变，无需迁移
- 弹幕渲染、交互（点击悬停、点赞）、弹幕列表均不受影响