### PR TITLE
feat: add advanced setting to query watch-later status on video page

### DIFF
--- a/lib/models/common/setting_type.dart
+++ b/lib/models/common/setting_type.dart
@@ -1,3 +1,4 @@
+import 'package:PiliPlus/pages/setting/models/advanced_settings.dart';
 import 'package:PiliPlus/pages/setting/models/extra_settings.dart';
 import 'package:PiliPlus/pages/setting/models/model.dart';
 import 'package:PiliPlus/pages/setting/models/play_settings.dart';
@@ -13,6 +14,7 @@ enum SettingType {
   playSetting('播放器设置'),
   styleSetting('外观设置'),
   extraSetting('其它设置'),
+  advancedSetting('高级设置'),
   webdavSetting('WebDAV 设置'),
   about('关于'),
   ;
@@ -27,6 +29,7 @@ enum SettingType {
     .playSetting => playSettings,
     .styleSetting => styleSettings,
     .extraSetting => extraSettings,
+    .advancedSetting => advancedSettings,
     _ => throw UnimplementedError(),
   };
 }

--- a/lib/pages/common/common_intro_controller.dart
+++ b/lib/pages/common/common_intro_controller.dart
@@ -4,7 +4,8 @@ import 'package:PiliPlus/http/fav.dart';
 import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/http/user.dart';
 import 'package:PiliPlus/http/video.dart';
-import 'package:PiliPlus/models/common/video/source_type.dart';
+import 'package:PiliPlus/models/common/video/source_type.dart'
+    show SourceType;
 import 'package:PiliPlus/models_new/fav/fav_folder/data.dart';
 import 'package:PiliPlus/models_new/video/video_detail/data.dart';
 import 'package:PiliPlus/models_new/video/video_detail/stat_detail.dart';
@@ -147,6 +148,32 @@ abstract class CommonIntroController extends GetxController
   Future<void> queryVideoTags() async {
     final result = await UserHttp.videoTags(bvid: bvid, cid: cid.value);
     videoTags.value = result.dataOrNull;
+  }
+
+  // 查询当前视频是否在稍后再看列表中
+  Future<void> queryLaterStatus() async {
+    if (!isLogin) {
+      return;
+    }
+    final aid = IdUtils.bv2av(bvid);
+    var page = 1;
+    while (true) {
+      final res = await UserHttp.seeYouLater(page: page, viewed: 0);
+      if (res case Success(:final response)) {
+        if (response.list?.any((item) => item.aid == aid) == true) {
+          hasLater.value = true;
+          return;
+        }
+        final count = response.count ?? 0;
+        if (page * 20 >= count || (response.list?.isEmpty ?? true)) {
+          break;
+        }
+        page++;
+      } else {
+        return; // 查询失败时保留原值，不误改状态
+      }
+    }
+    hasLater.value = false;
   }
 
   Future<void> viewLater() async {

--- a/lib/pages/common/common_intro_controller.dart
+++ b/lib/pages/common/common_intro_controller.dart
@@ -152,6 +152,11 @@ abstract class CommonIntroController extends GetxController
 
   // 查询当前视频是否在稍后再看列表中
   Future<void> queryLaterStatus() async {
+    if (!Pref.queryLaterStatus) {
+      // 高级设置关闭时使用原逻辑：根据页面来源(sourceType)推断
+      hasLater.value = videoDetailCtr.sourceType == SourceType.watchLater;
+      return;
+    }
     if (!isLogin) {
       return;
     }

--- a/lib/pages/setting/models/advanced_settings.dart
+++ b/lib/pages/setting/models/advanced_settings.dart
@@ -1,0 +1,14 @@
+import 'package:PiliPlus/pages/setting/models/model.dart';
+import 'package:PiliPlus/utils/storage_key.dart';
+import 'package:flutter/material.dart';
+
+List<SettingsModel> get advancedSettings => [
+  const SwitchModel(
+    title: '进入视频页时查询稍后再看状态',
+    subtitle: '开启：进入视频页时查询该视频是否已加入稍后再看，'
+        '“再看”按钮状态更准确\n关闭：按页面来源推断（原逻辑）',
+    leading: Icon(Icons.watch_later_outlined),
+    setKey: SettingBoxKey.queryLaterStatus,
+    defaultVal: false,
+  ),
+];

--- a/lib/pages/setting/view.dart
+++ b/lib/pages/setting/view.dart
@@ -73,6 +73,11 @@ class _SettingPageState extends State<SettingPage> {
       icon: Icon(Icons.extension_outlined),
     ),
     _SettingsModel(
+      type: SettingType.advancedSetting,
+      subtitle: '实验性选项',
+      icon: Icon(Icons.tune),
+    ),
+    _SettingsModel(
       type: SettingType.webdavSetting,
       icon: Icon(MdiIcons.databaseCogOutline),
     ),
@@ -118,7 +123,8 @@ class _SettingPageState extends State<SettingPage> {
                       .videoSetting ||
                       .playSetting ||
                       .styleSetting ||
-                      .extraSetting => CommonSetting(
+                      .extraSetting ||
+                      .advancedSetting => CommonSetting(
                         settingType: _type,
                         showAppBar: false,
                       ),
@@ -149,7 +155,8 @@ class _SettingPageState extends State<SettingPage> {
           .videoSetting ||
           .playSetting ||
           .styleSetting ||
-          .extraSetting => CommonSetting(settingType: type),
+          .extraSetting ||
+          .advancedSetting => CommonSetting(settingType: type),
           .webdavSetting => const WebDavSettingPage(),
           .about => const AboutPage(),
         },

--- a/lib/pages/video/introduction/pgc/controller.dart
+++ b/lib/pages/video/introduction/pgc/controller.dart
@@ -8,7 +8,6 @@ import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/http/pgc.dart';
 import 'package:PiliPlus/http/search.dart';
 import 'package:PiliPlus/http/video.dart';
-import 'package:PiliPlus/models/common/video/source_type.dart';
 import 'package:PiliPlus/models/common/video/video_type.dart';
 import 'package:PiliPlus/models_new/pgc/pgc_info_model/episode.dart';
 import 'package:PiliPlus/models_new/pgc/pgc_info_model/result.dart';
@@ -70,6 +69,7 @@ class PgcIntroController extends CommonIntroController {
         if (epId != null) {
           queryPgcLikeCoinFav();
         }
+        queryLaterStatus();
       }
       queryVideoTags();
     }
@@ -286,7 +286,7 @@ class PgcIntroController extends CommonIntroController {
         queryPgcLikeCoinFav();
       }
 
-      hasLater.value = videoDetailCtr.sourceType == SourceType.watchLater;
+      queryLaterStatus();
       this.cid.value = cid;
       queryOnlineTotal();
       queryVideoIntro(episode as EpisodeItem);

--- a/lib/pages/video/introduction/ugc/controller.dart
+++ b/lib/pages/video/introduction/ugc/controller.dart
@@ -11,7 +11,6 @@ import 'package:PiliPlus/http/member.dart';
 import 'package:PiliPlus/http/search.dart';
 import 'package:PiliPlus/http/user.dart';
 import 'package:PiliPlus/http/video.dart';
-import 'package:PiliPlus/models/common/video/source_type.dart';
 import 'package:PiliPlus/models_new/member_card_info/data.dart';
 import 'package:PiliPlus/models_new/relation/data.dart';
 import 'package:PiliPlus/models_new/video/video_ai_conclusion/model_result.dart';
@@ -138,6 +137,7 @@ class UgcIntroController extends CommonIntroController with ReloadMixin {
     if (isLogin) {
       queryAllStatus();
       queryFollowStatus();
+      queryLaterStatus();
     }
   }
 
@@ -528,8 +528,8 @@ class UgcIntroController extends CommonIntroController with ReloadMixin {
           } catch (_) {}
         }
 
-        hasLater.value = videoDetailCtr.sourceType == SourceType.watchLater;
         this.bvid = bvid;
+        queryLaterStatus();
         queryVideoIntro();
       } else {
         if (episode is Part) {

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -235,7 +235,8 @@ abstract final class SettingBoxKey {
       tempPlayerConf = 'tempPlayerConf',
       reduceLuxColor = 'reduceLuxColor',
       liveCdnUrl = 'liveCdnUrl',
-      saveReply = 'saveReply';
+      saveReply = 'saveReply',
+      queryLaterStatus = 'queryLaterStatus';
 }
 
 abstract final class LocalCacheKey {

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -482,6 +482,9 @@ abstract final class Pref {
   static bool get showHotRcmd =>
       _setting.get(SettingBoxKey.showHotRcmd, defaultValue: false);
 
+  static bool get queryLaterStatus =>
+      _setting.get(SettingBoxKey.queryLaterStatus, defaultValue: false);
+
   static String get audioNormalization =>
       _setting.get(SettingBoxKey.audioNormalization, defaultValue: '0');
 


### PR DESCRIPTION
### 概述

新增”高级设置“分区，内含一个开关，控制进入视频详情页时是否查询稍后再看列表，以刷新「再看」按钮的选中状态。

- 默认关闭：沿用原逻辑——按钮状态按页面来源（sourceType）推断
- 开启后：进入视频页、切换分P/剧集时查询稍后再看列表，按钮状态与服务端真实数据一致
- 查询失败时：保留原值，不覆盖正确的初始状态

### 原因

原实现只按页面来源推断按钮状态，从首页等入口点进”已在稍后再看列表中的视频“时，按钮显示为未选中。服务端查询修复了这个问题；开关则让不需要的用户可以关闭，避免每次进入视频页都多发请求。

### 改动文件

| 文件                                                             | 改动                                                                 |
|------------------------------------------------------------------|----------------------------------------------------------------------|
| lib/pages/common/common_intro_controller.dart                    | queryLaterStatus()——开关关闭时回退到来源推断；开启时查询稍后再看列表 |
| lib/pages/video/introduction/ugc/controller.dart                 | 初始化与切换分P时调用 queryLaterStatus()                             |
| lib/pages/video/introduction/pgc/controller.dart                 | 初始化与切换剧集时调用 queryLaterStatus()                            |
| lib/pages/setting/models/advanced_settings.dart                  | 新增——「高级设置」分区与开关                                         |
| lib/pages/setting/view.dart、lib/models/common/setting_type.dart | 注册新分区到设置页                                                   |