### PR TITLE
feat(macos): refresh recommendations with Command+R

### DIFF
--- a/lib/pages/home/view.dart
+++ b/lib/pages/home/view.dart
@@ -1,7 +1,11 @@
+import 'dart:io';
+
 import 'package:PiliPlus/common/style.dart';
 import 'package:PiliPlus/common/widgets/custom_height_widget.dart';
 import 'package:PiliPlus/common/widgets/image/network_img_layer.dart';
 import 'package:PiliPlus/common/widgets/scroll_physics.dart' show tabBarView;
+import 'package:PiliPlus/models/common/home_tab_type.dart';
+import 'package:PiliPlus/models/common/nav_bar_config.dart';
 import 'package:PiliPlus/pages/common/common_page.dart';
 import 'package:PiliPlus/pages/home/controller.dart';
 import 'package:PiliPlus/pages/main/controller.dart';
@@ -10,6 +14,7 @@ import 'package:PiliPlus/utils/extension/get_ext.dart';
 import 'package:PiliPlus/utils/extension/size_ext.dart';
 import 'package:PiliPlus/utils/feed_back.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show HardwareKeyboard, KeyDownEvent;
 import 'package:get/get.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
@@ -75,7 +80,7 @@ class _HomePageState extends CommonPageState<HomePage>
     } else {
       tabBar = const SizedBox(height: 6);
     }
-    return Column(
+    Widget child = Column(
       children: [
         if (!_mainController.useSideBar &&
             MediaQuery.sizeOf(context).isPortrait)
@@ -91,6 +96,30 @@ class _HomePageState extends CommonPageState<HomePage>
         ),
       ],
     );
+
+    if (Platform.isMacOS) {
+      child = Focus(
+        autofocus: true,
+        onKeyEvent: (_, event) {
+          if (event is KeyDownEvent &&
+              event.logicalKey == .keyR &&
+              HardwareKeyboard.instance.isMetaPressed &&
+              _mainController.navigationBars[_mainController
+                      .selectedIndex
+                      .value] ==
+                  NavigationBarType.home &&
+              _homeController.tabs[_homeController.tabController.index] ==
+                  HomeTabType.rcmd) {
+            _homeController.onRefresh();
+            return .handled;
+          }
+          return .ignored;
+        },
+        child: child,
+      );
+    }
+
+    return child;
   }
 
   Widget customAppBar() {

--- a/lib/pages/home/view.dart
+++ b/lib/pages/home/view.dart
@@ -1,11 +1,7 @@
-import 'dart:io';
-
 import 'package:PiliPlus/common/style.dart';
 import 'package:PiliPlus/common/widgets/custom_height_widget.dart';
 import 'package:PiliPlus/common/widgets/image/network_img_layer.dart';
 import 'package:PiliPlus/common/widgets/scroll_physics.dart' show tabBarView;
-import 'package:PiliPlus/models/common/home_tab_type.dart';
-import 'package:PiliPlus/models/common/nav_bar_config.dart';
 import 'package:PiliPlus/pages/common/common_page.dart';
 import 'package:PiliPlus/pages/home/controller.dart';
 import 'package:PiliPlus/pages/main/controller.dart';
@@ -14,7 +10,6 @@ import 'package:PiliPlus/utils/extension/get_ext.dart';
 import 'package:PiliPlus/utils/extension/size_ext.dart';
 import 'package:PiliPlus/utils/feed_back.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show HardwareKeyboard, KeyDownEvent;
 import 'package:get/get.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 
@@ -80,7 +75,7 @@ class _HomePageState extends CommonPageState<HomePage>
     } else {
       tabBar = const SizedBox(height: 6);
     }
-    Widget child = Column(
+    return Column(
       children: [
         if (!_mainController.useSideBar &&
             MediaQuery.sizeOf(context).isPortrait)
@@ -96,30 +91,6 @@ class _HomePageState extends CommonPageState<HomePage>
         ),
       ],
     );
-
-    if (Platform.isMacOS) {
-      child = Focus(
-        autofocus: true,
-        onKeyEvent: (_, event) {
-          if (event is KeyDownEvent &&
-              event.logicalKey == .keyR &&
-              HardwareKeyboard.instance.isMetaPressed &&
-              _mainController.navigationBars[_mainController
-                      .selectedIndex
-                      .value] ==
-                  NavigationBarType.home &&
-              _homeController.tabs[_homeController.tabController.index] ==
-                  HomeTabType.rcmd) {
-            _homeController.onRefresh();
-            return .handled;
-          }
-          return .ignored;
-        },
-        child: child,
-      );
-    }
-
-    return child;
   }
 
   Widget customAppBar() {

--- a/lib/pages/main/controller.dart
+++ b/lib/pages/main/controller.dart
@@ -5,6 +5,7 @@ import 'package:PiliPlus/grpc/dyn.dart';
 import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/http/msg.dart';
 import 'package:PiliPlus/models/common/dynamic/dynamic_badge_mode.dart';
+import 'package:PiliPlus/models/common/home_tab_type.dart';
 import 'package:PiliPlus/models/common/msg/msg_unread_type.dart';
 import 'package:PiliPlus/models/common/nav_bar_config.dart';
 import 'package:PiliPlus/pages/dynamics/controller.dart';
@@ -330,6 +331,16 @@ class MainController extends GetxController
     if (hasHome) {
       homeController.showTopBar?.value = true;
     }
+  }
+
+  bool refreshRecommendations() {
+    if (navigationBars[selectedIndex.value] == NavigationBarType.home &&
+        homeController.tabs[homeController.tabController.index] ==
+            HomeTabType.rcmd) {
+      homeController.onRefresh();
+      return true;
+    }
+    return false;
   }
 
   @override

--- a/lib/pages/main/view.dart
+++ b/lib/pages/main/view.dart
@@ -56,6 +56,9 @@ class _MainAppState extends PopScopeState<MainApp>
   void initState() {
     super.initState();
     addObserverMobile(this);
+    if (Platform.isMacOS) {
+      HardwareKeyboard.instance.addHandler(_handleKeyEvent);
+    }
     if (PlatformUtils.isDesktop) {
       windowManager
         ..addListener(this)
@@ -117,6 +120,9 @@ class _MainAppState extends PopScopeState<MainApp>
 
   @override
   void dispose() {
+    if (Platform.isMacOS) {
+      HardwareKeyboard.instance.removeHandler(_handleKeyEvent);
+    }
     if (PlatformUtils.isDesktop) {
       trayManager.removeListener(this);
       windowManager.removeListener(this);
@@ -125,6 +131,13 @@ class _MainAppState extends PopScopeState<MainApp>
     PiliScheme.listener?.cancel();
     GStorage.close();
     super.dispose();
+  }
+
+  bool _handleKeyEvent(KeyEvent event) {
+    return event is KeyDownEvent &&
+        event.logicalKey == LogicalKeyboardKey.keyR &&
+        HardwareKeyboard.instance.isMetaPressed &&
+        _mainController.refreshRecommendations();
   }
 
   @override


### PR DESCRIPTION
## Changes

- Add a macOS-only `Command + R` keyboard shortcut for refreshing recommendations
- Register the shortcut at the main app level so it works regardless of the current focus node
- Only refresh when the Home navigation and Recommendation tab are active
- Reuse the existing recommendation refresh flow

## Why

Provide the standard macOS refresh shortcut for quickly reloading recommendation content.

## Validation

- `fvm flutter analyze lib/pages/home/view.dart lib/pages/main/controller.dart lib/pages/main/view.dart`
- `fvm flutter build macos --debug` with the repository-required Flutter patches applied
- Launched the generated macOS debug app locally
- Pressed `Command + R` on the Recommendation page and confirmed that new recommendation cards loaded
- `git diff --check`

All checks passed.