### PR TITLE
feat: 评论拉黑 + 评论/标题滑动选词屏蔽

### DIFF
--- a/lib/common/widgets/video_popup_menu.dart
+++ b/lib/common/widgets/video_popup_menu.dart
@@ -1,4 +1,5 @@
 import 'package:PiliPlus/common/widgets/custom_icon.dart';
+import 'package:PiliPlus/common/widgets/word_select_bar.dart';
 import 'package:PiliPlus/http/user.dart';
 import 'package:PiliPlus/http/video.dart';
 import 'package:PiliPlus/models/home/rcmd/result.dart';
@@ -9,6 +10,9 @@ import 'package:PiliPlus/pages/search/widgets/search_text.dart';
 import 'package:PiliPlus/pages/video/ai_conclusion/view.dart';
 import 'package:PiliPlus/pages/video/introduction/ugc/controller.dart';
 import 'package:PiliPlus/utils/accounts.dart';
+import 'package:PiliPlus/utils/recommend_filter.dart';
+import 'package:PiliPlus/utils/storage.dart';
+import 'package:PiliPlus/utils/storage_key.dart';
 import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:PiliPlus/utils/utils.dart';
 import 'package:flutter/material.dart';
@@ -264,44 +268,10 @@ class VideoPopupMenu extends StatelessWidget {
                   _VideoCustomAction(
                     '拉黑：${videoItem.owner.name}',
                     const Icon(MdiIcons.cancel, size: 16),
-                    () => showDialog(
+                    () => _showBlockVideoDialog(
                       context: context,
-                      builder: (context) {
-                        return AlertDialog(
-                          title: const Text('提示'),
-                          content: Text(
-                            '确定拉黑:${videoItem.owner.name}(${videoItem.owner.mid})?'
-                            '\n\n注：被拉黑的Up可以在隐私设置-黑名单管理中解除',
-                          ),
-                          actions: [
-                            TextButton(
-                              onPressed: Get.back,
-                              child: Text(
-                                '点错了',
-                                style: TextStyle(
-                                  color: ColorScheme.of(context).outline,
-                                ),
-                              ),
-                            ),
-                            TextButton(
-                              onPressed: () async {
-                                Get.back();
-                                final res = await VideoHttp.relationMod(
-                                  mid: videoItem.owner.mid!,
-                                  act: 5,
-                                  reSrc: 11,
-                                );
-                                if (res.isSuccess) {
-                                  onRemove?.call();
-                                } else {
-                                  res.toast();
-                                }
-                              },
-                              child: const Text('确认'),
-                            ),
-                          ],
-                        );
-                      },
+                      videoItem: videoItem,
+                      onRemove: onRemove,
                     ),
                   ),
                 ],
@@ -329,4 +299,97 @@ class VideoPopupMenu extends StatelessWidget {
               .toList(),
     );
   }
+}
+
+/// 视频卡片「拉黑」确认框：保留拉黑，同时提供标题关键词过滤，
+/// 滑动选择标题中的连续词加入标题过滤词库，选词后立即移除该视频。
+Future<void> _showBlockVideoDialog({
+  required BuildContext context,
+  required BaseSimpleVideoItemModel videoItem,
+  required VoidCallback? onRemove,
+}) async {
+  final selectedWords = <String>[];
+  await showDialog(
+    context: context,
+    builder: (context) => StatefulBuilder(
+      builder: (context, setState) => AlertDialog(
+        title: const Text('提示'),
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '确定拉黑:${videoItem.owner.name}(${videoItem.owner.mid})?'
+                '\n\n注：被拉黑的Up可以在隐私设置-黑名单管理中解除',
+              ),
+              const SizedBox(height: 12),
+              Text(
+                '标题关键词过滤（在标题上滑动选词加入屏蔽）：',
+                style: TextStyle(
+                  fontSize: 13,
+                  color: ColorScheme.of(context).outline,
+                ),
+              ),
+              const SizedBox(height: 8),
+              WordSelectBar(
+                text: videoItem.title,
+                onWordsChanged: (words) {
+                  selectedWords
+                    ..clear()
+                    ..addAll(words);
+                },
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: Get.back,
+            child: Text(
+              '点错了',
+              style: TextStyle(color: ColorScheme.of(context).outline),
+            ),
+          ),
+          TextButton(
+            onPressed: () async {
+              Get.back();
+              bool removed = false;
+              // 选词即入标题过滤词库，并立即移除该视频
+              if (selectedWords.isNotEmpty) {
+                var pattern = RecommendFilter.rcmdRegExp.pattern;
+                for (final w in selectedWords) {
+                  final esc = RegExp.escape(w);
+                  pattern = pattern.isEmpty ? esc : '$pattern|$esc';
+                }
+                RecommendFilter.rcmdRegExp = RegExp(
+                  pattern,
+                  caseSensitive: false,
+                );
+                RecommendFilter.enableFilter = pattern.isNotEmpty;
+                GStorage.setting.put(
+                  SettingBoxKey.banWordForRecommend,
+                  pattern,
+                );
+                onRemove?.call();
+                removed = true;
+              }
+              // 拉黑
+              final res = await VideoHttp.relationMod(
+                mid: videoItem.owner.mid!,
+                act: 5,
+                reSrc: 11,
+              );
+              if (res.isSuccess) {
+                if (!removed) onRemove?.call();
+              } else {
+                res.toast();
+              }
+            },
+            child: const Text('确认'),
+          ),
+        ],
+      ),
+    ),
+  );
 }

--- a/lib/common/widgets/word_select_bar.dart
+++ b/lib/common/widgets/word_select_bar.dart
@@ -1,0 +1,221 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+/// 一次选中的一个连续词及其在原文中的字符区间。
+class _SelectedWord {
+  final String word;
+  final int start;
+  final int end;
+  const _SelectedWord({required this.word, required this.start, required this.end});
+}
+
+/// 滑动选词组件：把一段文字拆成一个个圆角方块，在方块上滑动/点击选中连续字符，
+/// 一次连续的字符串作为一个词，通过 [onWordsChanged] 把当前所有已选词回调给父级。
+///
+/// 组件只维护「本次会话」的选中状态，不直接写任何存储。
+class WordSelectBar extends StatefulWidget {
+  final String text;
+  final ValueChanged<List<String>> onWordsChanged;
+
+  const WordSelectBar({
+    super.key,
+    required this.text,
+    required this.onWordsChanged,
+  });
+
+  @override
+  State<WordSelectBar> createState() => _WordSelectBarState();
+}
+
+class _WordSelectBarState extends State<WordSelectBar> {
+  late final List<String> _chars;
+  late final List<GlobalKey> _charKeys;
+
+  final List<_SelectedWord> _selectedWords = [];
+  final Set<int> _committedIndices = {};
+
+  int? _dragStart;
+  int? _dragCurrent;
+
+  @override
+  void initState() {
+    super.initState();
+    _chars = widget.text.characters.toList();
+    _charKeys = List.generate(_chars.length, (_) => GlobalKey());
+  }
+
+  void _notify() {
+    widget.onWordsChanged(_selectedWords.map((e) => e.word).toList());
+  }
+
+  /// 根据全局坐标命中字符方块，返回其 index，未命中返回 null。
+  int? _hitTest(Offset globalPos) {
+    for (int i = 0; i < _charKeys.length; i++) {
+      final ctx = _charKeys[i].currentContext;
+      if (ctx == null) continue;
+      final box = ctx.findRenderObject() as RenderBox?;
+      if (box == null || !box.hasSize) continue;
+      final topLeft = box.localToGlobal(Offset.zero);
+      if ((topLeft & box.size).contains(globalPos)) return i;
+    }
+    return null;
+  }
+
+  void _onPointerDown(PointerDownEvent e) {
+    final idx = _hitTest(e.position);
+    if (idx != null) {
+      setState(() {
+        _dragStart = idx;
+        _dragCurrent = idx;
+      });
+    }
+  }
+
+  void _onPointerMove(PointerMoveEvent e) {
+    if (_dragStart == null) return;
+    final idx = _hitTest(e.position);
+    if (idx != null && idx != _dragCurrent) {
+      setState(() => _dragCurrent = idx);
+    }
+  }
+
+  void _onPointerUp(PointerUpEvent e) {
+    final start = _dragStart;
+    final end = _dragCurrent;
+    _dragStart = null;
+    _dragCurrent = null;
+    if (start == null) return;
+
+    final lo = math.min(start, end ?? start);
+    final hi = math.max(start, end ?? start);
+    final word = _chars.sublist(lo, hi + 1).join();
+    if (word.trim().isEmpty) return;
+
+    setState(() {
+      _selectedWords.add(_SelectedWord(word: word, start: lo, end: hi));
+      _recomputeCommitted();
+    });
+    _notify();
+  }
+
+  void _recomputeCommitted() {
+    _committedIndices.clear();
+    for (final sw in _selectedWords) {
+      for (int i = sw.start; i <= sw.end; i++) {
+        _committedIndices.add(i);
+      }
+    }
+  }
+
+  void _removeWord(_SelectedWord sw) {
+    setState(() {
+      _selectedWords.remove(sw);
+      _recomputeCommitted();
+    });
+    _notify();
+  }
+
+  bool _isInDragRange(int index) {
+    final start = _dragStart;
+    final current = _dragCurrent;
+    if (start == null || current == null) return false;
+    final lo = math.min(start, current);
+    final hi = math.max(start, current);
+    return index >= lo && index <= hi;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    if (_chars.isEmpty) {
+      return Text(
+        '无可用文字',
+        style: TextStyle(color: colorScheme.outline, fontSize: 14),
+      );
+    }
+
+    final chip = _selectedWords.isEmpty
+        ? const SizedBox.shrink()
+        : Padding(
+            padding: const EdgeInsets.only(bottom: 10),
+            child: Wrap(
+              spacing: 6,
+              runSpacing: 4,
+              children: [
+                for (final sw in _selectedWords)
+                  InputChip(
+                    label: Text(sw.word),
+                    visualDensity: VisualDensity.compact,
+                    onDeleted: () => _removeWord(sw),
+                  ),
+              ],
+            ),
+          );
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        chip,
+        Listener(
+          behavior: HitTestBehavior.opaque,
+          onPointerDown: _onPointerDown,
+          onPointerMove: _onPointerMove,
+          onPointerUp: _onPointerUp,
+          onPointerCancel: (_) {
+            _dragStart = null;
+            _dragCurrent = null;
+          },
+          child: Wrap(
+            spacing: 1,
+            runSpacing: 1,
+            children: [
+              for (int i = 0; i < _chars.length; i++) _buildChar(i, colorScheme),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildChar(int index, ColorScheme colorScheme) {
+    final ch = _chars[index];
+    final committed = _committedIndices.contains(index);
+    final dragging = _isInDragRange(index);
+
+    Color bg;
+    Color fg;
+    Border? border;
+    if (committed) {
+      bg = colorScheme.primary.withValues(alpha: 0.16);
+      fg = colorScheme.primary;
+      border = Border.all(color: colorScheme.primary.withValues(alpha: 0.5));
+    } else if (dragging) {
+      bg = colorScheme.primary.withValues(alpha: 0.28);
+      fg = colorScheme.primary;
+    } else {
+      bg = colorScheme.surfaceContainerHighest;
+      fg = colorScheme.onSurface;
+    }
+
+    return Container(
+      key: _charKeys[index],
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 8),
+      decoration: BoxDecoration(
+        color: bg,
+        borderRadius: BorderRadius.circular(6),
+        border: border,
+      ),
+      child: Text(
+        ch,
+        style: TextStyle(
+          fontSize: 15,
+          color: fg,
+          height: 1,
+          fontWeight: committed || dragging ? FontWeight.w600 : FontWeight.w400,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/video/reply/widgets/reply_item_grpc.dart
+++ b/lib/pages/video/reply/widgets/reply_item_grpc.dart
@@ -14,6 +14,7 @@ import 'package:PiliPlus/common/widgets/pendant_avatar.dart';
 import 'package:PiliPlus/common/widgets/text_ellipsis/text_ellipsis.dart';
 import 'package:PiliPlus/common/widgets/text_more/text_more.dart';
 import 'package:PiliPlus/common/widgets/translucent_row.dart';
+import 'package:PiliPlus/common/widgets/word_select_bar.dart';
 import 'package:PiliPlus/grpc/bilibili/main/community/reply/v1.pb.dart'
     show ReplyInfo, ReplyControl, Content, Url, ReplyControl_VoteOption, Emote;
 import 'package:PiliPlus/grpc/reply.dart';
@@ -1070,6 +1071,21 @@ class ReplyItemGrpc extends StatelessWidget {
               ),
             ),
           ],
+          if (ownerMid != Int64.ZERO && item.mid != ownerMid)
+            ListTile(
+              onTap: () {
+                Get.back();
+                _showBlockReplyDialog(
+                  context: context,
+                  message: message,
+                  mid: item.mid,
+                  onDelete: onDelete,
+                );
+              },
+              minLeadingWidth: 0,
+              leading: Icon(Icons.block, color: errorColor, size: 19),
+              title: Text('拉黑', style: style.copyWith(color: errorColor)),
+            ),
           if (ownerMid == upMid || ownerMid == item.member.mid)
             ListTile(
               onTap: () async {
@@ -1215,5 +1231,114 @@ class ReplyItemGrpc extends StatelessWidget {
         ],
       ),
     );
+  }
+}
+
+/// 长按评论弹出的「拉黑」确认框：可独立勾选「拉黑该用户」和「新增评论区屏蔽词」，
+/// 屏蔽词用滑动选词从评论文字里划选，确认后拉黑并移除这条评论。
+Future<void> _showBlockReplyDialog({
+  required BuildContext context,
+  required String message,
+  required Int64 mid,
+  required VoidCallback onDelete,
+}) async {
+  bool banUser = false;
+  bool addWord = false;
+  final selectedWords = <String>[];
+
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) => StatefulBuilder(
+      builder: (context, setState) => AlertDialog(
+        title: const Text('拉黑'),
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              CheckBoxText(
+                text: '拉黑该用户',
+                onChanged: (v) => banUser = v,
+              ),
+              CheckBoxText(
+                text: '新增评论区屏蔽词',
+                onChanged: (v) {
+                  addWord = v;
+                  setState(() {});
+                },
+              ),
+              if (addWord) ...[
+                const SizedBox(height: 4),
+                Text(
+                  '在评论上滑动选择要屏蔽的词：',
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: ColorScheme.of(context).outline,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                WordSelectBar(
+                  text: message,
+                  onWordsChanged: (words) {
+                    selectedWords
+                      ..clear()
+                      ..addAll(words);
+                  },
+                ),
+              ],
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Get.back(result: false),
+            child: Text(
+              '取消',
+              style: TextStyle(color: ColorScheme.of(context).outline),
+            ),
+          ),
+          TextButton(
+            onPressed: () => Get.back(result: true),
+            child: const Text('确认'),
+          ),
+        ],
+      ),
+    ),
+  );
+
+  if (confirmed != true) return;
+
+  // 追加评论区屏蔽词
+  if (addWord && selectedWords.isNotEmpty) {
+    var pattern = ReplyGrpc.replyRegExp.pattern;
+    for (final w in selectedWords) {
+      final esc = RegExp.escape(w);
+      pattern = pattern.isEmpty ? esc : '$pattern|$esc';
+    }
+    ReplyGrpc.replyRegExp = RegExp(pattern, caseSensitive: false);
+    ReplyGrpc.enableFilter = pattern.isNotEmpty;
+    GStorage.setting.put(SettingBoxKey.banWordForReply, pattern);
+  }
+
+  // 只加屏蔽词不拉黑时，评论已命中屏蔽词，直接移除
+  if (!banUser) {
+    if (addWord && selectedWords.isNotEmpty) {
+      onDelete();
+    }
+    return;
+  }
+
+  SmartDialog.showLoading(msg: '拉黑中...');
+  final res = await VideoHttp.relationMod(
+    mid: mid.toInt(),
+    act: 5,
+    reSrc: 11,
+  );
+  SmartDialog.dismiss();
+  if (res.isSuccess) {
+    SmartDialog.showToast('拉黑成功');
+    onDelete();
+  } else {
+    res.toast();
   }
 }


### PR DESCRIPTION
## 功能

1. **评论区长按拉黑**：长按评论弹出的菜单顶部新增「拉黑」，点击后弹确认框，可独立勾选「拉黑该用户」和「新增评论区屏蔽词」，确认后拉黑并移除该评论。

2. **评论屏蔽词滑动选词**：勾选「新增评论区屏蔽词」后，评论区文字展开为一个个圆角方块，滑动/点击即可选中连续字符作为一个屏蔽词。

3. **首页标题关键词过滤**：视频卡片「拉黑：{up主}」确认框内新增「标题关键词过滤」，在标题上滑动选词，选中的词立即加入标题过滤词库，完成后移除该视频。

## 实现

- 新增通用组件 `WordSelectBar`（`lib/common/widgets/word_select_bar.dart`）：把文字按字素拆成圆角方块，用 Listener + GlobalKey 命中检测，支持滑动连续选词、已选词 chips 展示与删除。
- 复用已有屏蔽词存储机制：
  - 评论：`ReplyGrpc.replyRegExp` + `SettingBoxKey.banWordForReply`
  - 标题：`RecommendFilter.rcmdRegExp` + `SettingBoxKey.banWordForRecommend`
- 拉黑复用 `VideoHttp.relationMod(mid, act: 5, reSrc: 11)`。

## 验证

- `flutter analyze` 通过。
- 真机/模拟器安装验证：长按评论菜单顶部出现「拉黑」，滑动选词能选中连续字符；首页视频卡片「拉黑」框内可滑动选标题词过滤。

## 备注

- 屏蔽词追加格式与现有「加入过滤」逻辑一致（`word1|word2`，`RegExp.escape`，`caseSensitive: false`）。
