### PR TITLE
fix(android): 修复从视频页切换到听视频后音量变大的问题

### DIFF
--- a/lib/models/common/audio_normalization.dart
+++ b/lib/models/common/audio_normalization.dart
@@ -1,3 +1,6 @@
+import 'package:PiliPlus/models/video/play/url.dart' show Volume;
+import 'package:PiliPlus/utils/storage_pref.dart';
+
 enum AudioNormalization {
   disable('禁用'),
   // ref https://github.com/KRTirtho/spotube/commit/da10ab2e291d4ba4d3082b9a6ae535639fb8f1b7
@@ -23,4 +26,28 @@ enum AudioNormalization {
     '2' => loudnorm.param,
     _ => config,
   };
+
+  static final _loudnormRegExp = RegExp('loudnorm=([^,]+)');
+
+  static String parse(Volume? volume, String param) {
+    if (volume != null && volume.isNotEmpty) {
+      return param.replaceFirstMapped(
+        _loudnormRegExp,
+        (i) =>
+            'loudnorm=${volume.format(
+              Map.fromEntries(
+                i.group(1)!.split(':').map((item) {
+                  final parts = item.split('=');
+                  return MapEntry(parts[0].toLowerCase(), num.parse(parts[1]));
+                }),
+              ),
+            )}',
+      );
+    } else {
+      return param.replaceFirst(
+        _loudnormRegExp,
+        AudioNormalization.getParamFromConfig(Pref.fallbackNormalization),
+      );
+    }
+  }
 }

--- a/lib/models/common/audio_normalization.dart
+++ b/lib/models/common/audio_normalization.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+
 import 'package:PiliPlus/models/video/play/url.dart' show Volume;
 import 'package:PiliPlus/utils/storage_pref.dart';
 
@@ -49,5 +51,31 @@ enum AudioNormalization {
         AudioNormalization.getParamFromConfig(Pref.fallbackNormalization),
       );
     }
+  }
+}
+
+mixin AudioNormalizationMixin {
+  late final _audioNormalization = Pref.audioNormalization;
+  late final enableAudioNormalization =
+      Platform.isAndroid && _audioNormalization != '0';
+  late final _param = AudioNormalization.getParamFromConfig(
+    _audioNormalization,
+  );
+
+  static const _kNormalizationKey = 'lavfi-complex';
+
+  Map<String, String>? audioFilterExtras(
+    Volume? volume, {
+    Map<String, String>? map,
+  }) {
+    if (!enableAudioNormalization) return map;
+    var audioNormalization = AudioNormalization.parse(volume, _param);
+    if (audioNormalization.isEmpty) return map;
+    audioNormalization = '"[aid1] $audioNormalization [ao]"';
+    if (map != null) {
+      map[_kNormalizationKey] = audioNormalization;
+      return map;
+    }
+    return {_kNormalizationKey: audioNormalization};
   }
 }

--- a/lib/pages/audio/controller.dart
+++ b/lib/pages/audio/controller.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io' show Platform;
 
 import 'package:PiliPlus/common/constants.dart';
 import 'package:PiliPlus/common/widgets/dialog/simple_dialog_option.dart';
@@ -16,6 +17,7 @@ import 'package:PiliPlus/grpc/bilibili/app/listener/v1.pb.dart'
 import 'package:PiliPlus/http/browser_ua.dart';
 import 'package:PiliPlus/http/constants.dart';
 import 'package:PiliPlus/http/loading_state.dart';
+import 'package:PiliPlus/models/common/audio_normalization.dart';
 import 'package:PiliPlus/pages/common/common_intro_controller.dart'
     show FavMixin;
 import 'package:PiliPlus/pages/dynamics_repost/view.dart';
@@ -310,19 +312,56 @@ class AudioController extends GetxController
     }
   }
 
+  Map<String, String>? _audioFilterExtras() {
+    if (!Platform.isAndroid) {
+      return null;
+    }
+    final config = Pref.audioNormalization;
+    if (config == '0') {
+      return null;
+    }
+    final param = AudioNormalization.getParamFromConfig(config);
+    final volume = _videoDetailController?.volume;
+    final String audioNormalization;
+    if (volume != null && volume.isNotEmpty) {
+      audioNormalization = param.replaceFirstMapped(
+        PlPlayerController.loudnormRegExp,
+        (i) =>
+            'loudnorm=${volume.format(
+              Map.fromEntries(
+                i.group(1)!.split(':').map((item) {
+                  final parts = item.split('=');
+                  return MapEntry(parts[0].toLowerCase(), num.parse(parts[1]));
+                }),
+              ),
+            )}',
+      );
+    } else {
+      audioNormalization = param.replaceFirst(
+        PlPlayerController.loudnormRegExp,
+        AudioNormalization.getParamFromConfig(Pref.fallbackNormalization),
+      );
+    }
+    if (audioNormalization.isEmpty) {
+      return null;
+    }
+    return {'lavfi-complex': '"[aid1] $audioNormalization [ao]"'};
+  }
+
   Future<void> _onOpenMedia(
     String url, {
     String ua = Constants.userAgentApp,
     String? referer,
   }) async {
     await _initPlayerIfNeeded();
+    final extras = _audioFilterExtras();
     player
       ?..setMediaHeader(
         userAgent: ua,
         // mpv cannot clear referer option
         headers: {'Referer': ?referer},
       )
-      ..open(Media(url, start: _start));
+      ..open(Media(url, start: _start, extras: extras));
     _start = null;
   }
 
@@ -333,6 +372,7 @@ class AudioController extends GetxController
     player = await Player.create(
       configuration: PlayerConfiguration(
         options: {
+          if (Platform.isAndroid) 'ao': Pref.audioOutput,
           'volume': PlatformUtils.isDesktop
               ? (desktopVolume.value * 100).toString()
               : Pref.playerVolume.toString(),

--- a/lib/pages/audio/controller.dart
+++ b/lib/pages/audio/controller.dart
@@ -18,7 +18,7 @@ import 'package:PiliPlus/http/browser_ua.dart';
 import 'package:PiliPlus/http/constants.dart';
 import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/models/common/audio_normalization.dart';
-import 'package:PiliPlus/models/video/play/url.dart' show Volume;
+import 'package:PiliPlus/models/video/play/url.dart' as http_model show Volume;
 import 'package:PiliPlus/pages/common/common_intro_controller.dart'
     show FavMixin;
 import 'package:PiliPlus/pages/dynamics_repost/view.dart';
@@ -293,17 +293,19 @@ class AudioController extends GetxController
   void _onPlay(PlayURLResp data) {
     final PlayInfo? playInfo = data.playerInfo.values.firstOrNull;
     if (playInfo != null) {
-      final Volume? volume = playInfo.hasVolume()
-          ? Volume(
-              measuredI: playInfo.volume.measuredI,
-              measuredLra: playInfo.volume.measuredLra,
-              measuredTp: playInfo.volume.measuredTp,
-              measuredThreshold: playInfo.volume.measuredThreshold,
-              targetOffset: playInfo.volume.targetOffset,
-              targetI: playInfo.volume.targetI,
-              targetTp: playInfo.volume.targetTp,
-            )
-          : null;
+      http_model.Volume? volume;
+      if (playInfo.hasVolume()) {
+        final volumeInfo = playInfo.volume;
+        volume = http_model.Volume(
+          measuredI: volumeInfo.measuredI,
+          measuredLra: volumeInfo.measuredLra,
+          measuredTp: volumeInfo.measuredTp,
+          measuredThreshold: volumeInfo.measuredThreshold,
+          targetOffset: volumeInfo.targetOffset,
+          targetI: volumeInfo.targetI,
+          targetTp: volumeInfo.targetTp,
+        );
+      }
       if (playInfo.hasPlayDash()) {
         final playDash = playInfo.playDash;
         final audios = playDash.audio;
@@ -329,22 +331,20 @@ class AudioController extends GetxController
     }
   }
 
-  Map<String, String>? _audioFilterExtras(Volume? volume) {
-    if (!Platform.isAndroid) {
-      return null;
-    }
-    final config = Pref.audioNormalization;
-    if (config == '0') {
-      return null;
-    }
-    final param = AudioNormalization.getParamFromConfig(config);
-    final effectiveVolume = volume;
+  late final _audioNormalization = Pref.audioNormalization;
+  late final enableAudioNormalization =
+      Platform.isAndroid && _audioNormalization != '0';
+  late final String _audioNormalizationParam =
+      AudioNormalization.getParamFromConfig(_audioNormalization);
+
+  Map<String, String>? _audioFilterExtras(http_model.Volume? volume) {
+    if (!enableAudioNormalization) return null;
     final String audioNormalization;
-    if (effectiveVolume != null && effectiveVolume.isNotEmpty) {
-      audioNormalization = param.replaceFirstMapped(
+    if (volume != null && volume.isNotEmpty) {
+      audioNormalization = _audioNormalizationParam.replaceFirstMapped(
         PlPlayerController.loudnormRegExp,
         (i) =>
-            'loudnorm=${effectiveVolume.format(
+            'loudnorm=${volume.format(
               Map.fromEntries(
                 i.group(1)!.split(':').map((item) {
                   final parts = item.split('=');
@@ -354,7 +354,7 @@ class AudioController extends GetxController
             )}',
       );
     } else {
-      audioNormalization = param.replaceFirst(
+      audioNormalization = _audioNormalizationParam.replaceFirst(
         PlPlayerController.loudnormRegExp,
         AudioNormalization.getParamFromConfig(Pref.fallbackNormalization),
       );
@@ -369,7 +369,7 @@ class AudioController extends GetxController
     String url, {
     String ua = Constants.userAgentApp,
     String? referer,
-    Volume? volume,
+    http_model.Volume? volume,
   }) async {
     await _initPlayerIfNeeded();
     final extras = _audioFilterExtras(volume);

--- a/lib/pages/audio/controller.dart
+++ b/lib/pages/audio/controller.dart
@@ -339,26 +339,10 @@ class AudioController extends GetxController
 
   Map<String, String>? _audioFilterExtras(http_model.Volume? volume) {
     if (!enableAudioNormalization) return null;
-    final String audioNormalization;
-    if (volume != null && volume.isNotEmpty) {
-      audioNormalization = _audioNormalizationParam.replaceFirstMapped(
-        PlPlayerController.loudnormRegExp,
-        (i) =>
-            'loudnorm=${volume.format(
-              Map.fromEntries(
-                i.group(1)!.split(':').map((item) {
-                  final parts = item.split('=');
-                  return MapEntry(parts[0].toLowerCase(), num.parse(parts[1]));
-                }),
-              ),
-            )}',
-      );
-    } else {
-      audioNormalization = _audioNormalizationParam.replaceFirst(
-        PlPlayerController.loudnormRegExp,
-        AudioNormalization.getParamFromConfig(Pref.fallbackNormalization),
-      );
-    }
+    final String audioNormalization = AudioNormalization.parse(
+      volume,
+      _audioNormalizationParam,
+    );
     if (audioNormalization.isEmpty) {
       return null;
     }

--- a/lib/pages/audio/controller.dart
+++ b/lib/pages/audio/controller.dart
@@ -158,7 +158,12 @@ class AudioController extends GetxController
     final hasAudioUrl = audioUrl != null;
     if (hasAudioUrl) {
       _querySponsorBlock();
-      _onOpenMedia(audioUrl, ua: BrowserUa.pc, referer: HttpString.baseUrl);
+      _onOpenMedia(
+        audioUrl,
+        ua: BrowserUa.pc,
+        referer: HttpString.baseUrl,
+        volume: _videoDetailController?.volume,
+      );
     }
     ConnectivityUtils.isWiFi.then((isWiFi) {
       cacheAudioQa = isWiFi ? Pref.defaultAudioQa : Pref.defaultAudioQaCellular;
@@ -333,13 +338,13 @@ class AudioController extends GetxController
       return null;
     }
     final param = AudioNormalization.getParamFromConfig(config);
-    volume ??= _videoDetailController?.volume;
+    final effectiveVolume = volume;
     final String audioNormalization;
-    if (volume != null && volume.isNotEmpty) {
+    if (effectiveVolume != null && effectiveVolume.isNotEmpty) {
       audioNormalization = param.replaceFirstMapped(
         PlPlayerController.loudnormRegExp,
         (i) =>
-            'loudnorm=${volume.format(
+            'loudnorm=${effectiveVolume.format(
               Map.fromEntries(
                 i.group(1)!.split(':').map((item) {
                   final parts = item.split('=');

--- a/lib/pages/audio/controller.dart
+++ b/lib/pages/audio/controller.dart
@@ -59,7 +59,8 @@ class AudioController extends GetxController
         TripleMixin,
         FavMixin,
         BlockConfigMixin,
-        BlockMixin {
+        BlockMixin,
+        AudioNormalizationMixin {
   late Int64 id;
   late Int64 oid;
   late List<Int64> subId;
@@ -331,24 +332,6 @@ class AudioController extends GetxController
     }
   }
 
-  late final _audioNormalization = Pref.audioNormalization;
-  late final enableAudioNormalization =
-      Platform.isAndroid && _audioNormalization != '0';
-  late final String _audioNormalizationParam =
-      AudioNormalization.getParamFromConfig(_audioNormalization);
-
-  Map<String, String>? _audioFilterExtras(http_model.Volume? volume) {
-    if (!enableAudioNormalization) return null;
-    final String audioNormalization = AudioNormalization.parse(
-      volume,
-      _audioNormalizationParam,
-    );
-    if (audioNormalization.isEmpty) {
-      return null;
-    }
-    return {'lavfi-complex': '"[aid1] $audioNormalization [ao]"'};
-  }
-
   Future<void> _onOpenMedia(
     String url, {
     String ua = Constants.userAgentApp,
@@ -356,7 +339,7 @@ class AudioController extends GetxController
     http_model.Volume? volume,
   }) async {
     await _initPlayerIfNeeded();
-    final extras = _audioFilterExtras(volume);
+    final extras = audioFilterExtras(volume);
     player
       ?..setMediaHeader(
         userAgent: ua,

--- a/lib/pages/audio/controller.dart
+++ b/lib/pages/audio/controller.dart
@@ -18,6 +18,7 @@ import 'package:PiliPlus/http/browser_ua.dart';
 import 'package:PiliPlus/http/constants.dart';
 import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/models/common/audio_normalization.dart';
+import 'package:PiliPlus/models/video/play/url.dart' show Volume;
 import 'package:PiliPlus/pages/common/common_intro_controller.dart'
     show FavMixin;
 import 'package:PiliPlus/pages/dynamics_repost/view.dart';
@@ -287,6 +288,17 @@ class AudioController extends GetxController
   void _onPlay(PlayURLResp data) {
     final PlayInfo? playInfo = data.playerInfo.values.firstOrNull;
     if (playInfo != null) {
+      final Volume? volume = playInfo.hasVolume()
+          ? Volume(
+              measuredI: playInfo.volume.measuredI,
+              measuredLra: playInfo.volume.measuredLra,
+              measuredTp: playInfo.volume.measuredTp,
+              measuredThreshold: playInfo.volume.measuredThreshold,
+              targetOffset: playInfo.volume.targetOffset,
+              targetI: playInfo.volume.targetI,
+              targetTp: playInfo.volume.targetTp,
+            )
+          : null;
       if (playInfo.hasPlayDash()) {
         final playDash = playInfo.playDash;
         final audios = playDash.audio;
@@ -298,7 +310,7 @@ class AudioController extends GetxController
           (e) => e.id <= cacheAudioQa,
           (a, b) => a.id > b.id ? a : b,
         );
-        _onOpenMedia(VideoUtils.getCdnUrl(audio.playUrls));
+        _onOpenMedia(VideoUtils.getCdnUrl(audio.playUrls), volume: volume);
       } else if (playInfo.hasPlayUrl()) {
         final playUrl = playInfo.playUrl;
         final durls = playUrl.durl;
@@ -307,12 +319,12 @@ class AudioController extends GetxController
         }
         final durl = durls.first;
         position.value = 0;
-        _onOpenMedia(VideoUtils.getCdnUrl(durl.playUrls));
+        _onOpenMedia(VideoUtils.getCdnUrl(durl.playUrls), volume: volume);
       }
     }
   }
 
-  Map<String, String>? _audioFilterExtras() {
+  Map<String, String>? _audioFilterExtras(Volume? volume) {
     if (!Platform.isAndroid) {
       return null;
     }
@@ -321,7 +333,7 @@ class AudioController extends GetxController
       return null;
     }
     final param = AudioNormalization.getParamFromConfig(config);
-    final volume = _videoDetailController?.volume;
+    volume ??= _videoDetailController?.volume;
     final String audioNormalization;
     if (volume != null && volume.isNotEmpty) {
       audioNormalization = param.replaceFirstMapped(
@@ -352,9 +364,10 @@ class AudioController extends GetxController
     String url, {
     String ua = Constants.userAgentApp,
     String? referer,
+    Volume? volume,
   }) async {
     await _initPlayerIfNeeded();
-    final extras = _audioFilterExtras();
+    final extras = _audioFilterExtras(volume);
     player
       ?..setMediaHeader(
         userAgent: ua,

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -68,7 +68,7 @@ import 'package:window_manager/window_manager.dart';
 
 typedef PlayCallback = Future<void>? Function();
 
-class PlPlayerController with BlockConfigMixin {
+class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
   Player? _videoPlayerController;
   VideoController? _videoController;
 
@@ -574,12 +574,6 @@ class PlPlayerController with BlockConfigMixin {
   // offline
   bool get isFileSource => dataSource is FileSource;
 
-  late final _audioNormalization = Pref.audioNormalization;
-  late final enableAudioNormalization =
-      Platform.isAndroid && _audioNormalization != '0';
-  late final String _audioNormalizationParam =
-      AudioNormalization.getParamFromConfig(_audioNormalization);
-
   // 初始化资源
   Future<void> setDataSource(
     DataSource dataSource, {
@@ -824,15 +818,7 @@ class PlPlayerController with BlockConfigMixin {
             // '!delay_open,media_type=audio;'
             '%${isFileSource ? utf8.encode(audio).length : audio.length}%$audio');
       }
-      if (enableAudioNormalization) {
-        final String audioNormalization = AudioNormalization.parse(
-          volume,
-          _audioNormalizationParam,
-        );
-        if (audioNormalization.isNotEmpty) {
-          extras['lavfi-complex'] = '"[aid1] $audioNormalization [ao]"';
-        }
-      }
+      audioFilterExtras(volume, map: extras);
     }
 
     await player.open(

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -724,8 +724,6 @@ class PlPlayerController with BlockConfigMixin {
     }
   }
 
-  static final loudnormRegExp = RegExp('loudnorm=([^,]+)');
-
   Future<Player> _initPlayer() async {
     assert(_videoPlayerController == null);
     final opt = {
@@ -827,26 +825,10 @@ class PlPlayerController with BlockConfigMixin {
             '%${isFileSource ? utf8.encode(audio).length : audio.length}%$audio');
       }
       if (enableAudioNormalization) {
-        final String audioNormalization;
-        if (volume != null && volume.isNotEmpty) {
-          audioNormalization = _audioNormalizationParam.replaceFirstMapped(
-            loudnormRegExp,
-            (i) =>
-                'loudnorm=${volume.format(
-                  Map.fromEntries(
-                    i.group(1)!.split(':').map((item) {
-                      final parts = item.split('=');
-                      return MapEntry(parts[0].toLowerCase(), num.parse(parts[1]));
-                    }),
-                  ),
-                )}',
-          );
-        } else {
-          audioNormalization = _audioNormalizationParam.replaceFirst(
-            loudnormRegExp,
-            AudioNormalization.getParamFromConfig(Pref.fallbackNormalization),
-          );
-        }
+        final String audioNormalization = AudioNormalization.parse(
+          volume,
+          _audioNormalizationParam,
+        );
         if (audioNormalization.isNotEmpty) {
           extras['lavfi-complex'] = '"[aid1] $audioNormalization [ao]"';
         }


### PR DESCRIPTION
## 问题背景

平时在 Android 上看视频时，我发现从视频播放页切换到“听视频”后，即使没有调整系统音量，同一个视频的声音也会明显变大。

切换前后播放的是同一条音频流，因此最初怀疑是视频页和听视频页使用的播放器配置不一致。

## 原因

从视频页进入独立的“听视频”页面时，应用会创建一个新的音频播放器。

Android 视频播放器初始化时会：

- 根据设置传入 `Pref.audioOutput`，选择 `OpenSL ES`、`AAudio` 或 `AudioTrack` 等音频输出设备。
- 开启音量均衡后，根据视频的响度信息添加 `loudnorm` 滤镜；没有响度信息时使用备用均衡参数。

听视频页此前创建播放器时没有带上这两项配置。

这导致同一条音频流从视频页切换到听视频页后，实际使用的音频输出通路和音量均衡链路发生变化，所以在系统音量没有改变的情况下，仍会出现明显的音量听感差异。

## 修改内容

让 Android 听视频播放器与视频播放器使用相同的音频配置：

- 创建听视频播放器时传入 `Pref.audioOutput`。
- 打开媒体时应用与视频播放器一致的音量均衡逻辑：
  - 有视频响度信息时，根据响度信息生成 `loudnorm` 参数。
  - 没有响度信息时，使用 `Pref.fallbackNormalization`。
  - 音量均衡关闭时不添加额外滤镜。

项目的自定义音频输出和音量均衡目前仅在 Android 启用，因此本次修改也保持相同的平台范围。iOS 等其他平台继续沿用原有的默认音频配置。

## 修复效果

从视频播放页切换到听视频页后，两边会使用一致的 Android 音频输出和音量均衡配置，避免因为播放链路不同造成音量突然变大的问题。

## 验证

已在 Android 上进行实际播放验证：

1. 打开视频并正常播放。
2. 从视频播放页切换到“听视频”。
3. 切换前后不调整系统音量。
4. 修复后两边的音量听感保持一致。