### PR TITLE
feat: support quick reply by long pressing comment button in dynamics list

### DIFF
--- a/lib/pages/dynamics/widgets/action_panel.dart
+++ b/lib/pages/dynamics/widgets/action_panel.dart
@@ -1,9 +1,19 @@
+import 'package:PiliPlus/grpc/bilibili/main/community/reply/v1.pb.dart'
+    show ReplyInfo;
+import 'package:PiliPlus/http/dynamics.dart';
+import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/models/dynamics/result.dart';
+import 'package:PiliPlus/pages/common/publish/publish_route.dart';
 import 'package:PiliPlus/pages/dynamics_repost/view.dart';
+import 'package:PiliPlus/pages/video/reply_new/view.dart';
+import 'package:PiliPlus/utils/feed_back.dart';
 import 'package:PiliPlus/utils/num_utils.dart';
 import 'package:PiliPlus/utils/page_utils.dart';
 import 'package:PiliPlus/utils/request_utils.dart';
+import 'package:PiliPlus/utils/storage_pref.dart';
+import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:get/get.dart';
 import 'package:material_ui/material_ui.dart';
 
 class ActionPanel extends StatelessWidget {
@@ -12,6 +22,67 @@ class ActionPanel extends StatelessWidget {
     required this.item,
   });
   final DynamicItemModel item;
+
+  void _onQuickReply(VoidCallback onUpdateUi) {
+    feedBack();
+    final commentType = item.basic?.commentType;
+    final commentIdStr = item.basic?.commentIdStr;
+    if (commentType != null &&
+        commentType != 0 &&
+        commentIdStr != null &&
+        commentIdStr.isNotEmpty) {
+      _showReplyPage(int.parse(commentIdStr), commentType, onUpdateUi);
+    } else {
+      SmartDialog.showLoading(msg: '加载中...');
+      DynamicsHttp.dynamicDetail(id: item.idStr)
+          .then((res) {
+            SmartDialog.dismiss(status: SmartStatus.loading);
+            if (res case Success(:final response)) {
+              final bCommentId = response.basic?.commentIdStr;
+              final bCommentType = response.basic?.commentType;
+              if (bCommentId != null &&
+                  bCommentId.isNotEmpty &&
+                  bCommentType != null &&
+                  bCommentType != 0) {
+                _showReplyPage(int.parse(bCommentId), bCommentType, onUpdateUi);
+              } else {
+                SmartDialog.showToast('该动态不支持快速评论');
+              }
+            } else {
+              res.toast();
+            }
+          })
+          .catchError((e) {
+            SmartDialog.dismiss(status: SmartStatus.loading);
+            SmartDialog.showToast(e.toString());
+          });
+    }
+  }
+
+  void _showReplyPage(int oid, int replyType, VoidCallback onUpdateUi) {
+    Get.key.currentState!
+        .push(
+          PublishRoute(
+            pageBuilder: (buildContext, animation, secondaryAnimation) {
+              return ReplyPage(
+                oid: oid,
+                root: 0,
+                parent: 0,
+                replyType: replyType,
+              );
+            },
+          ),
+        )
+        .then((replyInfo) {
+          if (replyInfo is ReplyInfo) {
+            final comment = item.modules.moduleStat?.comment;
+            if (comment != null) {
+              comment.count = (comment.count ?? 0) + 1;
+              onUpdateUi();
+            }
+          }
+        });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -66,22 +137,35 @@ class ActionPanel extends StatelessWidget {
           ),
         ),
         Expanded(
-          child: TextButton.icon(
-            onPressed: () => PageUtils.pushDynDetail(
-              item,
-              isPush: true,
-              viewComment: true,
-            ),
-            icon: Icon(
-              FontAwesomeIcons.comment,
-              size: 16,
-              color: outline,
-              semanticLabel: "评论",
-            ),
-            style: btnStyle,
-            label: Text(
-              comment.count != null ? NumUtils.numFormat(comment.count) : '评论',
-            ),
+          child: Builder(
+            builder: (context) {
+              return TextButton.icon(
+                onPressed: () => PageUtils.pushDynDetail(
+                  item,
+                  isPush: true,
+                  viewComment: true,
+                ),
+                onLongPress: Pref.enableQuickReplyDyn
+                    ? () => _onQuickReply(() {
+                        if (context.mounted) {
+                          (context as Element?)?.markNeedsBuild();
+                        }
+                      })
+                    : null,
+                icon: Icon(
+                  FontAwesomeIcons.comment,
+                  size: 16,
+                  color: outline,
+                  semanticLabel: "评论",
+                ),
+                style: btnStyle,
+                label: Text(
+                  comment.count != null
+                      ? NumUtils.numFormat(comment.count)
+                      : '评论',
+                ),
+              );
+            },
           ),
         ),
         Expanded(

--- a/lib/pages/setting/models/extra_settings.dart
+++ b/lib/pages/setting/models/extra_settings.dart
@@ -567,6 +567,13 @@ List<SettingsModel> get extraSettings => [
     defaultVal: true,
     onChanged: (val) => ItemModulesModel.showDynInteraction = val,
   ),
+  const SwitchModel(
+    title: '长按动态评论直接回复',
+    subtitle: '在动态列表中长按评论按钮直接呼出回复框，无需进入详情页',
+    leading: Icon(Icons.mode_comment_outlined),
+    setKey: SettingBoxKey.enableQuickReplyDyn,
+    defaultVal: true,
+  ),
   NormalModel(
     title: '用户页默认展示TAB',
     leading: const Icon(Icons.tab),

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -60,6 +60,7 @@ abstract final class SettingBoxKey {
       replySortType = 'replySortType',
       defaultDynamicType = 'defaultDynamicType',
       showDynInteraction = 'showDynInteraction',
+      enableQuickReplyDyn = 'enableQuickReplyDyn',
       enableHotKey = 'enableHotKey',
       enableSearchRcmd = 'enableSearchRcmd',
       enableQuickFav = 'enableQuickFav',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -324,6 +324,9 @@ abstract final class Pref {
   static bool get showDynInteraction =>
       _setting.get(SettingBoxKey.showDynInteraction, defaultValue: true);
 
+  static bool get enableQuickReplyDyn =>
+      _setting.get(SettingBoxKey.enableQuickReplyDyn, defaultValue: true);
+
   static double get blockLimit =>
       _setting.get(SettingBoxKey.blockLimit, defaultValue: 0.0);
 


### PR DESCRIPTION
## 描述
在动态列表中，支持长按评论按钮快速弹出评论输入弹窗，无需跳转进动态详情页即可快速发送评论。

## 更改说明

1. **动态列表长按评论直接回复**：
   - 在动态卡片底部的“评论”按钮上支持长按（`onLongPress`），触发触感震动反馈并直接拉起 `ReplyPage` 评论弹窗，无需进入详情页。
   - 自动解析动态评论参数（`oid` 与 `replyType`），未携带时自动异步拉取详情后弹出。
   - 评论发布成功后，本地即时递增动态卡片上的评论计数并局部刷新当前卡片。
2. **设置项开关**：
   - 在 **设置 -> 其他设置 -> 动态** 中新增「长按动态评论直接回复」开关（默认开启）。

## [测试构建](https://github.com/qpst4/PiliPlus/actions/runs/32447420281)

- Android 与 Windows 实机测试通过
- 动态长按快评、评论数即时刷新与设置开关测试通过
- 全平台构建通过

## 关联 Issue

Closes #991