### PR TITLE
fix: iOS 暂停或从播放页返回时的音频爆音

### DIFF
--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -1152,15 +1152,46 @@ class PlPlayerController with BlockConfigMixin {
     // screenManager.setOverlays(false);
   }
 
-  /// 暂停播放
+  /// iOS 上暂停时音频输出被直接截断，会产生爆音，
+  /// 暂停前后对音量做淡出、恢复处理。
   Future<void> pause({bool notify = true, bool isInterrupt = false}) async {
-    await _videoPlayerController?.pause();
+    final player = _videoPlayerController;
+    final needFade =
+        Platform.isIOS && playerStatus.isPlaying && player != null;
+    if (needFade) {
+      await _fadeOutVolume(player);
+    }
+    await player?.pause();
     playerStatus.value = PlayerStatus.paused;
+
+    if (needFade) {
+      await _restoreVolumeAfterPause(player);
+    }
 
     // 主动暂停时让出音频焦点
     if (!isInterrupt) {
       audioSessionHandler?.setActive(false);
     }
+  }
+
+  /// 淡出时长需要覆盖音频输出缓冲（iOS 上通常几十毫秒），
+  /// 让缓冲里的声音也一起淡出到零；步长足够小，单步音量变化不可感知。
+  Future<void> _fadeOutVolume(Player player) async {
+    const steps = 5;
+    const stepDuration = Duration(milliseconds: 25);
+    for (var i = steps - 1; i >= 0; i--) {
+      await player.setVolume(Pref.playerVolume * i / steps);
+      if (i > 0) {
+        await Future.delayed(stepDuration);
+      }
+    }
+  }
+
+  /// 等暂停生效、缓冲排空后再恢复音量，暂停状态下不会产生声音
+  Future<void> _restoreVolumeAfterPause(Player player) async {
+    const restoreDelay = Duration(milliseconds: 100);
+    await Future.delayed(restoreDelay);
+    await player.setVolume(Pref.playerVolume);
   }
 
   bool tripling = false;


### PR DESCRIPTION
### 现象

iOS 上视频播放中点暂停，或者不暂停直接从播放页返回，会出现爆音。与 #2406 描述的现象一致。

### 原因

mpv 在暂停时直接截断音频输出。如果截断瞬间波形处在非零幅度，扬声器振膜被迫从振动状态骤停，爆音就是这么来的。[IINA #3617](https://github.com/iina/iina/issues/3617) 里做过波形对比：QuickTime 暂停时波形平滑衰减到零，mpv 的波形是垂直截断。mpv 上游从 2015 年就知道这个问题（[mpv-player/mpv#2515](https://github.com/mpv-player/mpv/issues/2515)），一直没有修。

### 方案

暂停前把 mpv 音量分 5 步淡出到零（每步 25ms），再执行暂停；等暂停生效、音频缓冲排空后恢复音量。硬件被截断时信号已经是零，爆音不会发生。改动只在 iOS 生效。

### 测试

- iPhone 17 真机交叉对比：原逻辑暂停几乎必现爆音，改淡出后暂停和返回各测十余次，没有再出现
- 只影响 iOS 的暂停路径，Android/桌面行为不变
