### PR TITLE
fix: remove no_clip

### DIFF
--- a/lib/pages/video/controller.dart
+++ b/lib/pages/video/controller.dart
@@ -864,7 +864,7 @@ class VideoDetailController extends GetxController
           // it will cause all files to be opened simultaneously
           if (durl.length > 1) {
             // TODO: refa
-            final sb = StringBuffer('edl://!no_clip;!no_chapters;');
+            final sb = StringBuffer('edl://!no_chapters;');
             for (var i in durl) {
               final video = VideoUtils.getCdnUrl(i.playUrls);
               sb.write('%${video.length}%$video,length=${i.length! / 1000};');

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -813,10 +813,10 @@ class PlPlayerController with BlockConfigMixin {
         // dely_open need provide length
         video =
             ('edl://'
-            '!no_clip;!no_chapters;'
+            '!no_chapters;'
             // '!delay_open,media_type=video;'
             '%${isFileSource ? utf8.encode(video).length : video.length}%$video;'
-            '!new_stream;!no_clip;!no_chapters;'
+            '!new_stream;!no_chapters;'
             // '!delay_open,media_type=audio;'
             '%${isFileSource ? utf8.encode(audio).length : audio.length}%$audio');
       }


### PR DESCRIPTION
> It also exists solely to support internal ytdl requirements. Using ``no_clip`` with segments is not recommended and probably breaks.


fix: #1967