### PR TITLE
fix: 修复 HyperOS 小窗模式下界面空白只剩底栏的问题

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -301,8 +301,29 @@ class MyApp extends StatelessWidget {
 
   static Widget _builder(BuildContext context, Widget? child) {
     final uiScale = Pref.uiScale;
-    final mediaQuery = MediaQuery.of(context);
+    var mediaQuery = MediaQuery.of(context);
     final textScaler = TextScaler.linear(Pref.defaultTextScale);
+    // 修复 HyperOS 小窗/自由窗口模式下 MediaQuery 异常上报接近整个窗口
+    // 高度的安全区 padding，导致内容被顶出屏幕只剩底栏的问题。
+    // 参考: https://github.com/flutter/flutter/issues/161086
+    if (Platform.isAndroid) {
+      final sizeHeight = mediaQuery.size.height;
+      final viewPadding = mediaQuery.viewPadding;
+      final topAbnormal = viewPadding.top > sizeHeight * 0.4;
+      final bottomAbnormal = viewPadding.bottom > sizeHeight * 0.4;
+      if (topAbnormal || bottomAbnormal) {
+        mediaQuery = mediaQuery.copyWith(
+          padding: mediaQuery.padding.copyWith(
+            top: topAbnormal ? 0 : mediaQuery.padding.top,
+            bottom: bottomAbnormal ? 0 : mediaQuery.padding.bottom,
+          ),
+          viewPadding: viewPadding.copyWith(
+            top: topAbnormal ? 0 : viewPadding.top,
+            bottom: bottomAbnormal ? 0 : viewPadding.bottom,
+          ),
+        );
+      }
+    }
     if (uiScale != 1.0) {
       child = MediaQuery(
         data: mediaQuery.copyWith(


### PR DESCRIPTION
### 问题描述

在小米 HyperOS 的小窗（自由窗口）模式下，PiliPlus 整个界面显示为空白，只剩底部导航栏可见。

### 根因分析

这是 Flutter 引擎在 HyperOS 小窗模式下的已知 bug（[flutter/flutter#161086](https://github.com/flutter/flutter/issues/161086)，上游列为低优先级）：进入小窗后 MediaQuery 上报的 `viewPadding`/`padding` 异常接近整个窗口高度（实测如 top=640dp、750dp），SafeArea/ListView 等组件据此避让，把内容整体顶出可视区域，导致只剩底栏。

### 修改方案

在 MaterialApp 的 builder 中检测异常 padding：

- 仅针对 Android 生效；
- 当 `viewPadding` 的 top/bottom 超过当前窗口高度的 40%（正常状态栏远小于此值）时，判定为 HyperOS 小窗异常，将该边 padding/viewPadding 归零；
- 正常模式下不触发，不影响全屏、分屏及其它平台表现。

### 影响范围

- 仅改动 `lib/main.dart` 的 `_builder`，无其它文件变化；
- 异常判定阈值保守，正常使用无感。

### 验证

- 已在小米平板 8 Pro（HyperOS4）小窗模式下真机验证：修复前界面空白只剩底栏，修复后小窗显示正常；
- GitHub Actions 云编译通过（Android 三架构 APK 已生成）。
