### PR TITLE
feat: 二级评论支持独立设置排序

### DIFF
--- a/lib/pages/setting/models/extra_settings.dart
+++ b/lib/pages/setting/models/extra_settings.dart
@@ -554,6 +554,12 @@ List<SettingsModel> get extraSettings => [
     onTap: _showReplySortDialog,
   ),
   NormalModel(
+    title: '二级评论展示',
+    leading: const Icon(Icons.subdirectory_arrow_right_outlined),
+    getSubtitle: () => '当前优先展示「${Pref.reply2SortType.title}」',
+    onTap: _showReply2SortDialog,
+  ),
+  NormalModel(
     title: '动态展示',
     leading: const Icon(Icons.dynamic_feed_rounded),
     getSubtitle: () => '当前优先展示「${Pref.defaultDynamicType.label}」',
@@ -1071,6 +1077,24 @@ Future<void> _showReplySortDialog(
   );
   if (res != null) {
     await GStorage.setting.put(SettingBoxKey.replySortType, res.index);
+    setState();
+  }
+}
+
+Future<void> _showReply2SortDialog(
+  BuildContext context,
+  VoidCallback setState,
+) async {
+  final res = await showDialog<ReplySortType>(
+    context: context,
+    builder: (context) => SelectDialog<ReplySortType>(
+      title: '二级评论展示',
+      value: Pref.reply2SortType,
+      values: ReplySortType.values.take(2).map((e) => (e, e.title)).toList(),
+    ),
+  );
+  if (res != null) {
+    await GStorage.setting.put(SettingBoxKey.reply2SortType, res.index);
     setState();
   }
 }

--- a/lib/pages/video/reply_reply/controller.dart
+++ b/lib/pages/video/reply_reply/controller.dart
@@ -1,5 +1,5 @@
 import 'package:PiliPlus/grpc/bilibili/main/community/reply/v1.pb.dart'
-    show ReplyInfo, DetailListReply;
+    show ReplyInfo, DetailListReply, Mode;
 import 'package:PiliPlus/grpc/reply.dart';
 import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/pages/common/publish/publish_route.dart';
@@ -53,6 +53,9 @@ class VideoReplyReplyController extends ReplyController
   @override
   void onInit() {
     super.onInit();
+    final cacheSortType = Pref.reply2SortType;
+    sortType.value = cacheSortType;
+    mode = cacheSortType == .time ? Mode.MAIN_LIST_TIME : Mode.MAIN_LIST_HOT;
     queryData();
   }
 

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -58,6 +58,7 @@ abstract final class SettingBoxKey {
       maxCacheSize = 'maxCacheSize',
       defaultShowComment = 'defaultShowComment',
       replySortType = 'replySortType',
+      reply2SortType = 'reply2SortType',
       defaultDynamicType = 'defaultDynamicType',
       showDynInteraction = 'showDynInteraction',
       enableHotKey = 'enableHotKey',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -743,6 +743,12 @@ abstract final class Pref {
         defaultValue: ReplySortType.hot.index,
       )];
 
+  static ReplySortType get reply2SortType =>
+      ReplySortType.values[_setting.get(
+        SettingBoxKey.reply2SortType,
+        defaultValue: ReplySortType.time.index,
+      )];
+
   static DynamicBadgeMode get dynamicBadgeMode =>
       DynamicBadgeMode.values[_setting.get(
         SettingBoxKey.dynamicBadgeMode,


### PR DESCRIPTION
背景

2.1.1 修复 #2491 后，二级评论跟随全局排序设置。当全局设为"最热评论"时，二级评论按热度排序，出现对话割裂：回复者可能排在被回复者前面，需要手动点"按时间"或"查看对话"才能看上下文，体验较差。

B站官方楼中楼固定按时间排序，不存在此问题。

改动

新增"二级评论展示"独立排序设置（设置 → 其他设置），一级评论排序不受影响：

- 新增 SettingBoxKey.reply2SortType 配置项
- VideoReplyReplyController.onInit() 读取独立设置，替代全局 replySortType
- 设置页新增"二级评论展示"入口，选项与"评论展示"一致（最热/最新）
- *默认值为"最新"*（按时间），与官方行为一致，如需按热度可在设置中单独配置
- 二级评论页内已有的排序切换按钮保留，可临时切换

改动量：4 个文件，+35/-1。
已在安卓平台上测试通过

关联

- Close #2652
- 相关讨论：#2625（曾提出类似诉求）
- 与 #2491 修复不冲突：二级评论默认按时间，但显示与实际排序始终一致（设置页显示"最新评论"即按时间排序）