### PR TITLE
feat: 新增"自动选择最佳音质"选项

### DIFF
--- a/lib/http/download.dart
+++ b/lib/http/download.dart
@@ -108,14 +108,10 @@ abstract final class DownloadHttp {
           final List<int> audioIds = audioDashList
               .map((map) => map.id!)
               .toList();
-          int closestNumber = audioIds.findClosestTarget(
-            (e) => e <= preferAudioQa,
-            (a, b) => a > b ? a : b,
+          final int closestNumber = AudioQuality.selectAudioQuality(
+            preferAudioQa,
+            audioIds,
           );
-          if (!audioIds.contains(preferAudioQa) &&
-              audioIds.any((e) => e > preferAudioQa)) {
-            closestNumber = AudioQuality.k192.code;
-          }
           final AudioItem audioDash = audioDashList.firstWhere(
             (e) => e.id == closestNumber,
             orElse: () => audioDashList.first,

--- a/lib/models/common/video/audio_quality.dart
+++ b/lib/models/common/video/audio_quality.dart
@@ -1,4 +1,5 @@
 enum AudioQuality {
+  autoAdvanced(-1, '自动选择最佳音质'),
   u_100010(100010, '100010'),
   u_100009(100009, '100009'),
   u_100008(100008, '100008'),
@@ -18,4 +19,51 @@ enum AudioQuality {
   static final _codeMap = {for (final i in values) i.code: i};
 
   static AudioQuality fromCode(int code) => _codeMap[code]!;
+
+  /// 设置页可选音质列表：新增的“自动选择最佳音质”置于最前，其余保持原顺序不变。
+  static const List<AudioQuality> defaultAudioQualityOptions = [
+    autoAdvanced,
+    u_100010,
+    u_100009,
+    u_100008,
+    hiRes,
+    dolby_30250,
+    dolby_30255,
+    k192,
+    k132,
+    k64,
+  ];
+
+  /// 自动选择时的回退优先级：Hi-Res → 杜比全景声 → 杜比音效 → 192K → 132K → 64K。
+  /// 三种高级音效互斥（同一视频最多只有一种），故高级音效之间的先后不影响实际结果。
+  static const List<int> _autoFallbackOrder = [
+    30251, // Hi-Res
+    30250, // 杜比全景声
+    30255, // 杜比音效
+    30280, // 192K
+    30232, // 132K
+    30216, // 64K
+  ];
+
+  /// 根据目标音质 [target] 从可用音轨 [available] 中选出实际音轨 id。
+  /// [target] 为 -1（自动选择最佳音质）时按 [_autoFallbackOrder] 取第一个可用音轨；
+  /// 否则保持原有的固定选择逻辑，不改变现有用户行为。
+  static int selectAudioQuality(int target, List<int> available) {
+    if (target == autoAdvanced.code) {
+      for (final id in _autoFallbackOrder) {
+        if (available.contains(id)) {
+          return id;
+        }
+      }
+      return available.first;
+    }
+    final candidates = available.where((e) => e <= target).toList();
+    int closestNumber = candidates.isNotEmpty
+        ? candidates.reduce((a, b) => a > b ? a : b)
+        : available.reduce((a, b) => a > b ? a : b);
+    if (!available.contains(target) && available.any((e) => e > target)) {
+      closestNumber = AudioQuality.k192.code;
+    }
+    return closestNumber;
+  }
 }

--- a/lib/pages/audio/controller.dart
+++ b/lib/pages/audio/controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:PiliPlus/common/constants.dart';
 import 'package:PiliPlus/common/widgets/dialog/simple_dialog_option.dart';
+import 'package:PiliPlus/models/common/video/audio_quality.dart';
 import 'package:PiliPlus/grpc/audio.dart';
 import 'package:PiliPlus/grpc/bilibili/app/listener/v1.pb.dart'
     show
@@ -292,10 +293,22 @@ class AudioController extends GetxController
           return;
         }
         position.value = 0;
-        final audio = audios.findClosestTarget(
-          (e) => e.id <= cacheAudioQa,
-          (a, b) => a.id > b.id ? a : b,
-        );
+        final int? autoTargetId =
+            cacheAudioQa == AudioQuality.autoAdvanced.code
+                ? AudioQuality.selectAudioQuality(
+                    AudioQuality.autoAdvanced.code,
+                    audios.map((e) => e.id).toList(),
+                  )
+                : null;
+        final audio = autoTargetId != null
+            ? audios.firstWhere(
+                (e) => e.id == autoTargetId,
+                orElse: () => audios.first,
+              )
+            : audios.findClosestTarget(
+                (e) => e.id <= cacheAudioQa,
+                (a, b) => a.id > b.id ? a : b,
+              );
         _onOpenMedia(VideoUtils.getCdnUrl(audio.playUrls));
       } else if (playInfo.hasPlayUrl()) {
         final playUrl = playInfo.playUrl;

--- a/lib/pages/setting/models/video_settings.dart
+++ b/lib/pages/setting/models/video_settings.dart
@@ -276,7 +276,9 @@ Future<void> _showAudioQaDialog(
     builder: (context) => SelectDialog<int>(
       title: '默认音质',
       value: Pref.defaultAudioQa,
-      values: AudioQuality.values.map((e) => (e.code, e.desc)).toList(),
+      values: AudioQuality.defaultAudioQualityOptions
+          .map((e) => (e.code, e.desc))
+          .toList(),
     ),
   );
   if (res != null) {
@@ -294,7 +296,9 @@ Future<void> _showAudioCellularQaDialog(
     builder: (context) => SelectDialog<int>(
       title: '蜂窝网络音质',
       value: Pref.defaultAudioQaCellular,
-      values: AudioQuality.values.map((e) => (e.code, e.desc)).toList(),
+      values: AudioQuality.defaultAudioQualityOptions
+          .map((e) => (e.code, e.desc))
+          .toList(),
     ),
   );
   if (res != null) {

--- a/lib/pages/video/controller.dart
+++ b/lib/pages/video/controller.dart
@@ -952,14 +952,10 @@ class VideoDetailController extends GetxController
       final audioList = data.dash?.audio;
       if (audioList != null && audioList.isNotEmpty) {
         final List<int> audioIds = audioList.map((map) => map.id!).toList();
-        int closestNumber = audioIds.findClosestTarget(
-          (e) => e <= plPlayerController.cacheAudioQa,
-          (a, b) => a > b ? a : b,
+        final int closestNumber = AudioQuality.selectAudioQuality(
+          plPlayerController.cacheAudioQa,
+          audioIds,
         );
-        if (!audioIds.contains(plPlayerController.cacheAudioQa) &&
-            audioIds.any((e) => e > plPlayerController.cacheAudioQa)) {
-          closestNumber = AudioQuality.k192.code;
-        }
         firstAudio = audioList.firstWhere(
           (e) => e.id == closestNumber,
           orElse: () => audioList.first,


### PR DESCRIPTION
Close #2488

### 功能描述

新增可选的"自动选择最佳音质"选项（默认音质 / 蜂窝网络音质均可选择），现有选项、默认值以及用户行为均保持不变。

选择该选项后，播放 / 下载时按优先级自动选择当前视频可用的最佳音轨：

Hi-Res → 杜比全景声 → 杜比音效 → 192K → 132K → 64K

由于三种高级音效互斥（同一视频最多只有一种），优先级中高级音效之间的顺序不影响实际结果。不选择该选项的用户，行为与之前完全一致。

### 改动文件

- `lib/models/common/video/audio_quality.dart`：新增 `autoAdvanced` 选项、`defaultAudioQualityOptions` 列表与 `selectAudioQuality` 选择逻辑
- `lib/pages/setting/models/video_settings.dart`：设置页改用 `defaultAudioQualityOptions`（"自动选择最佳音质"置于列表最前）
- `lib/pages/video/controller.dart`、`lib/http/download.dart`、`lib/pages/audio/controller.dart`：改用 `selectAudioQuality`

### 验证

- 已通过 GitHub Actions 构建 dev APK 并实机测试：auto 模式在 Hi-Res / 杜比视频上均能正确选择最佳音轨，固定选项行为不变
- 未选择该选项时行为与原版完全一致

### 其他

Issue 中提到的设置页 UI 显示问题暂未改动