### PR TITLE
fix: 正确注销选中的多账号会话

### DIFF
--- a/lib/pages/setting/view.dart
+++ b/lib/pages/setting/view.dart
@@ -11,6 +11,7 @@ import 'package:PiliPlus/pages/webdav/view.dart';
 import 'package:PiliPlus/utils/accounts.dart';
 import 'package:PiliPlus/utils/accounts/account.dart';
 import 'package:PiliPlus/utils/extension/size_ext.dart';
+import 'package:PiliPlus/utils/utils.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:get/get.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
@@ -227,9 +228,21 @@ class _SettingPageState extends State<SettingPage> {
       ),
     );
     if (!context.mounted || result == null || result.isEmpty) return;
-    Future<void> logout() {
-      _noAccount.value = result.length == Accounts.account.length;
-      return Accounts.deleteAll(result);
+    Future<void> removeAccounts(Set<LoginAccount> accounts) async {
+      await Accounts.deleteAll(accounts);
+      _noAccount.value = Accounts.account.isEmpty;
+    }
+
+    Future<({LoginAccount account, bool success})> logoutAccount(
+      LoginAccount account,
+    ) async {
+      try {
+        final res = await LoginHttp.logout(account);
+        return (account: account, success: res['status'] == true);
+      } catch (e, s) {
+        Utils.reportError(e, s);
+        return (account: account, success: false);
+      }
     }
 
     showDialog(
@@ -252,9 +265,9 @@ class _SettingPageState extends State<SettingPage> {
               ),
             ),
             TextButton(
-              onPressed: () {
+              onPressed: () async {
                 Get.back();
-                logout();
+                await removeAccounts(result);
               },
               child: Text(
                 '仅登出',
@@ -264,14 +277,34 @@ class _SettingPageState extends State<SettingPage> {
             TextButton(
               onPressed: () async {
                 SmartDialog.showLoading();
-                final res = await LoginHttp.logout(Accounts.main);
-                if (res['status']) {
+                try {
+                  final responses = await Future.wait(
+                    result.map(logoutAccount),
+                  );
+                  final successfulAccounts = {
+                    for (final response in responses)
+                      if (response.success) response.account,
+                  };
+                  if (successfulAccounts.isNotEmpty) {
+                    await removeAccounts(successfulAccounts);
+                  }
+                  final failedMids = responses
+                      .where((response) => !response.success)
+                      .map((response) => response.account.mid)
+                      .join('、');
                   SmartDialog.dismiss();
-                  logout();
-                  Get.back();
-                } else {
+                  if (successfulAccounts.length == result.length) {
+                    Get.back();
+                  } else if (successfulAccounts.isEmpty) {
+                    SmartDialog.showToast('账号 $failedMids 退出登录失败');
+                  } else {
+                    Get.back();
+                    SmartDialog.showToast('账号 $failedMids 退出登录失败');
+                  }
+                } catch (e, s) {
+                  Utils.reportError(e, s);
                   SmartDialog.dismiss();
-                  SmartDialog.showToast(res['msg'].toString());
+                  SmartDialog.showToast('退出登录失败：$e');
                 }
               },
               child: const Text('确认'),


### PR DESCRIPTION
### 现象

多账号退出确认操作始终使用主账号发起远程注销。选择副账号时会意外注销主账号，而被选账号只删除本地数据，服务端会话仍然有效。

### 方案

- 对每个已选账号分别调用远程注销，确保使用对应账号的 Cookie 和 CSRF
- 仅删除远程注销成功的本地账号，失败账号保留以便重试
- 失败提示列出对应 UID，并保留“仅登出”的本地删除行为

### 验证

- `git diff --check`
- 本机 Flutter 3.35.1 / Dart 3.9.0 低于项目 `.fvmrc` 要求的 Flutter 3.47.1 / Dart >=3.13.0，因此未运行本地分析或构建
- GitHub Actions 检查套件状态为 `action_required`，等待上游维护者批准 fork PR 工作流
