### PR TITLE
fix: WebDAV 配置变更后重建客户端

### DIFF
--- a/lib/pages/webdav/webdav.dart
+++ b/lib/pages/webdav/webdav.dart
@@ -8,42 +8,64 @@ import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:webdav_client/webdav_client.dart' as webdav;
 
-class WebDav {
-  late String _webdavDirectory;
-  String? _fileName;
+typedef _WebDavConfig = ({
+  String uri,
+  String username,
+  String password,
+  String directory,
+});
 
+class WebDav {
+  _WebDavConfig? _clientConfig;
   webdav.Client? _client;
 
   WebDav._internal();
   static final WebDav _instance = WebDav._internal();
   factory WebDav() => _instance;
 
-  Future<Pair<bool, String?>> init() async {
-    final webDavUri = Pref.webdavUri;
-    final webDavUsername = Pref.webdavUsername;
-    final webDavPassword = Pref.webdavPassword;
-    _webdavDirectory = Pref.webdavDirectory;
-    if (!_webdavDirectory.endsWith('/')) {
-      _webdavDirectory += '/';
+  _WebDavConfig _getConfig() {
+    String directory = Pref.webdavDirectory;
+    if (!directory.endsWith('/')) {
+      directory += '/';
     }
-    _webdavDirectory += Constants.appName;
+    return (
+      uri: Pref.webdavUri,
+      username: Pref.webdavUsername,
+      password: Pref.webdavPassword,
+      directory: '$directory${Constants.appName}',
+    );
+  }
 
+  Future<webdav.Client> _connect(
+    _WebDavConfig config, {
+    bool force = false,
+  }) async {
+    final cachedClient = _client;
+    if (!force && cachedClient != null && _clientConfig == config) {
+      return cachedClient;
+    }
+
+    final client =
+        webdav.newClient(
+            config.uri,
+            user: config.username,
+            password: config.password,
+          )
+          ..setHeaders({'accept-charset': 'utf-8'})
+          ..setConnectTimeout(12000)
+          ..setReceiveTimeout(12000)
+          ..setSendTimeout(12000);
+
+    await client.mkdirAll(config.directory);
+    _clientConfig = config;
+    _client = client;
+    return client;
+  }
+
+  Future<Pair<bool, String?>> init() async {
     try {
-      _client = null;
-      final client =
-          webdav.newClient(
-              webDavUri,
-              user: webDavUsername,
-              password: webDavPassword,
-            )
-            ..setHeaders({'accept-charset': 'utf-8'})
-            ..setConnectTimeout(12000)
-            ..setReceiveTimeout(12000)
-            ..setSendTimeout(12000);
+      await _connect(_getConfig(), force: true);
 
-      await client.mkdirAll(_webdavDirectory);
-
-      _client = client;
       return Pair(first: true, second: null);
     } catch (e) {
       return Pair(first: false, second: e.toString());
@@ -55,21 +77,22 @@ class WebDav {
   }
 
   Future<void> backup() async {
-    if (_client == null) {
-      final res = await init();
-      if (!res.first) {
-        SmartDialog.showToast('备份失败，请检查配置: ${res.second}');
-        return;
-      }
+    // Keep the payload bound to the same settings snapshot as the connection.
+    final config = _getConfig();
+    final data = GStorage.exportAllSettings();
+    final webdav.Client client;
+    try {
+      client = await _connect(config);
+    } catch (e) {
+      SmartDialog.showToast('备份失败，请检查配置: $e');
+      return;
     }
     try {
-      String data = GStorage.exportAllSettings();
-      _fileName ??= _getFileName();
-      final path = '$_webdavDirectory/$_fileName';
+      final path = '${config.directory}/${_getFileName()}';
       try {
-        await _client!.remove(path);
+        await client.remove(path);
       } catch (_) {}
-      await _client!.write(path, utf8.encode(data));
+      await client.write(path, utf8.encode(data));
       SmartDialog.showToast('备份成功');
     } catch (e) {
       SmartDialog.showToast('备份失败: $e');
@@ -77,17 +100,17 @@ class WebDav {
   }
 
   Future<void> restore() async {
-    if (_client == null) {
-      final res = await init();
-      if (!res.first) {
-        SmartDialog.showToast('恢复失败，请检查配置: ${res.second}');
-        return;
-      }
+    final config = _getConfig();
+    final webdav.Client client;
+    try {
+      client = await _connect(config);
+    } catch (e) {
+      SmartDialog.showToast('恢复失败，请检查配置: $e');
+      return;
     }
     try {
-      _fileName ??= _getFileName();
-      final path = '$_webdavDirectory/$_fileName';
-      final data = await _client!.read(path);
+      final path = '${config.directory}/${_getFileName()}';
+      final data = await client.read(path);
       await GStorage.importAllSettings(utf8.decode(data));
       SmartDialog.showToast('恢复成功');
     } catch (e) {


### PR DESCRIPTION
### 现象

WebDAV 客户端、目录和文件名缓存在进程级单例中。应用内导入另一套 WebDAV 设置后，备份仍可能复用旧服务商的客户端，却序列化并上传当前的新设置。

### 方案

- 使用不可变配置快照绑定 URI、用户名、密码和目录
- 仅在缓存客户端与完整配置快照一致时复用连接，任一字段变化都会重建客户端
- 备份在首次异步操作前同时捕获配置和导出数据，保证接收端与数据来自同一设置快照
- 恢复操作使用局部客户端和目录，不再依赖可被其他操作覆盖的共享路径状态
- 设置页显式保存仍强制重连，以保留现有连接验证语义
- 保持现有 WebDAV 备份内容和用户操作方式不变

### 验证

- `dart format --output=none --set-exit-if-changed lib/pages/webdav/webdav.dart`
- `git diff --check`
- 已按锁文件中的 `webdav_client` 提交检查客户端生命周期；该依赖没有公开的 close/dispose API，因此保留按配置绑定的单客户端缓存
- 本机 Flutter 3.35.1 / Dart 3.9.0 低于项目 `.fvmrc` 要求的 Flutter 3.47.1 / Dart >=3.13.0，因此未运行本地 Flutter 分析或构建
- GitHub Actions 检查套件状态为 `action_required`，等待上游维护者批准 fork PR 工作流
