### PR TITLE
feat(dlna): 支持 DLNA 设备列表持久化缓存与视频快速投屏分享

### DIFF
--- a/lib/pages/dlna/dlna_service.dart
+++ b/lib/pages/dlna/dlna_service.dart
@@ -1,0 +1,151 @@
+import 'package:PiliPlus/http/loading_state.dart';
+import 'package:PiliPlus/http/video.dart';
+import 'package:PiliPlus/utils/storage.dart';
+import 'package:PiliPlus/utils/storage_key.dart';
+import 'package:PiliPlus/utils/video_utils.dart';
+import 'package:dlna_dart/dlna.dart';
+import 'package:dlna_dart/xmlParser.dart';
+import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
+
+/// 内存中的投屏设备列表缓存
+final Map<String, DLNADevice> dlnaDeviceCache = {};
+
+/// 从持久化存储（Hive localCache）初始化设备缓存
+void initDlnaDeviceCache() {
+  if (dlnaDeviceCache.isNotEmpty) return;
+  try {
+    final raw = GStorage.localCache.get(LocalCacheKey.dlnaDevices);
+    if (raw is List) {
+      for (final item in raw) {
+        if (item is Map) {
+          final urlBase = item['URLBase']?.toString() ?? '';
+          final deviceType = item['deviceType']?.toString() ?? '';
+          final friendlyName = item['friendlyName']?.toString() ?? '';
+          final rawServiceList = item['serviceList'];
+          final List<dynamic> serviceList = rawServiceList is List
+              ? rawServiceList.map((e) => e is Map ? Map<String, dynamic>.from(e) : e).toList()
+              : [];
+          if (urlBase.isNotEmpty && friendlyName.isNotEmpty) {
+            final info = DeviceInfo(urlBase, deviceType, friendlyName, serviceList);
+            dlnaDeviceCache[urlBase] = DLNADevice(info);
+          }
+        }
+      }
+    }
+  } catch (e) {
+    // 忽略异常，降级为空缓存
+  }
+}
+
+/// 保存搜到的设备列表并持久化存储
+void saveDlnaDevices(Map<String, DLNADevice> devices) {
+  dlnaDeviceCache.addAll(devices);
+  try {
+    final list = dlnaDeviceCache.values.map((device) {
+      final info = device.info;
+      return {
+        'URLBase': info.URLBase,
+        'deviceType': info.deviceType,
+        'friendlyName': info.friendlyName,
+        'serviceList': info.serviceList,
+      };
+    }).toList();
+    GStorage.localCache.put(LocalCacheKey.dlnaDevices, list);
+  } catch (e) {
+    // 忽略异常
+  }
+}
+
+/// 把媒体投到指定设备
+Future<void> castDlnaDevice(
+  DLNADevice device, {
+  required String url,
+  String? title,
+}) async {
+  await device.setUrl(url, title: title ?? '');
+  await device.play();
+}
+/// 通用快捷投屏到指定已缓存设备
+Future<void> castToCachedDevice({
+  required DLNADevice device,
+  required int cid,
+  required int objectId,
+  required int playurlType,
+  String? title,
+  int? qn,
+}) async {
+  SmartDialog.showLoading(msg: '正在投屏至 ${device.info.friendlyName}...');
+  try {
+    final play = await VideoHttp.tvPlayUrl(
+      cid: cid,
+      objectId: objectId,
+      playurlType: playurlType,
+      qn: qn ?? 80,
+    );
+    if (play case Success(response: final playInfo)) {
+      final first = playInfo.durl?.firstOrNull;
+      if (first != null && first.playUrls.isNotEmpty) {
+        final cdnUrl = VideoUtils.getCdnUrl(first.playUrls);
+        await castDlnaDevice(device, url: cdnUrl, title: title);
+        SmartDialog.dismiss();
+        SmartDialog.showToast('已投屏至 ${device.info.friendlyName}');
+        return;
+      }
+    }
+    SmartDialog.dismiss();
+    SmartDialog.showToast('投屏失败: 无法获取播放地址');
+  } catch (e) {
+    SmartDialog.dismiss();
+    SmartDialog.showToast('投屏失败: $e');
+  }
+}
+
+/// 从 UGC 视频上下文解析可投屏的播放地址（按当前选中的清晰度与 CDN）
+Future<String?> resolveUgcCastUrl({
+  required int aid,
+  required int cid,
+  required int videoQa,
+}) async {
+  try {
+    final play = await VideoHttp.tvPlayUrl(
+      cid: cid,
+      objectId: aid,
+      playurlType: 1,
+      qn: videoQa,
+    );
+    if (play case Success(response: final playInfo)) {
+      final first = playInfo.durl?.firstOrNull;
+      if (first != null && first.playUrls.isNotEmpty) {
+        return VideoUtils.getCdnUrl(first.playUrls);
+      }
+    }
+    return null;
+  } catch (_) {
+    return null;
+  }
+}
+
+/// 从 PGC 影视上下文解析可投屏的播放地址
+Future<String?> resolvePgcCastUrl({
+  required int epId,
+  required int cid,
+  required int videoQa,
+}) async {
+  try {
+    final play = await VideoHttp.tvPlayUrl(
+      cid: cid,
+      objectId: epId,
+      playurlType: 2,
+      qn: videoQa,
+    );
+    if (play case Success(response: final playInfo)) {
+      final first = playInfo.durl?.firstOrNull;
+      if (first != null && first.playUrls.isNotEmpty) {
+        return VideoUtils.getCdnUrl(first.playUrls);
+      }
+    }
+    return null;
+  } catch (_) {
+    return null;
+  }
+}

--- a/lib/pages/dlna/view.dart
+++ b/lib/pages/dlna/view.dart
@@ -7,6 +7,7 @@ import 'package:PiliPlus/common/widgets/view_sliver_safe_area.dart';
 import 'package:dlna_dart/dlna.dart';
 import 'package:get/get.dart';
 import 'package:material_ui/material_ui.dart';
+import 'package:PiliPlus/pages/dlna/dlna_service.dart';
 
 class DLNAPage extends StatefulWidget {
   const DLNAPage({super.key});
@@ -29,26 +30,25 @@ class _DLNAPageState extends State<DLNAPage> {
   @override
   void initState() {
     super.initState();
-    _onSearch(isInit: true);
+    initDlnaDeviceCache();
+    // 先复用缓存设备（可立即点击投屏），同时后台重新搜索刷新
+    _deviceList.addAll(dlnaDeviceCache);
   }
 
   Future<void> _onSearch({bool isInit = false}) async {
     if (_isSearching) return;
     _isSearching = true;
-    if (!isInit && mounted) {
-      _lastDevice = null;
-      _deviceList.clear();
-      setState(() {});
-    }
+    if (mounted) setState(() {});
     final deviceManager = await _searcher.start();
     if (!mounted) {
+      _isSearching = false;
       return;
     }
     _timer = Timer(const Duration(seconds: 20), _searcher.stop);
     await for (final deviceList in deviceManager.devices.stream) {
       if (mounted) {
         _deviceList.addAll(deviceList);
-        setState(() {});
+        saveDlnaDevices(deviceList);
       }
     }
     if (mounted) {

--- a/lib/pages/video/introduction/pgc/controller.dart
+++ b/lib/pages/video/introduction/pgc/controller.dart
@@ -18,6 +18,7 @@ import 'package:PiliPlus/models_new/video/video_detail/stat_detail.dart';
 import 'package:PiliPlus/pages/common/common_intro_controller.dart';
 import 'package:PiliPlus/pages/dynamics_repost/view.dart';
 import 'package:PiliPlus/pages/video/reply/controller.dart';
+import 'package:PiliPlus/pages/dlna/dlna_service.dart';
 import 'package:PiliPlus/plugin/pl_player/models/play_repeat.dart';
 import 'package:PiliPlus/services/service_locator.dart';
 import 'package:PiliPlus/utils/feed_back.dart';
@@ -120,6 +121,7 @@ class PgcIntroController extends CommonIntroController {
   // 分享视频
   @override
   void actionShareVideo(BuildContext context) {
+    initDlnaDeviceCache();
     String videoUrl =
         '${HttpString.baseUrl}/bangumi/play/ep$epId${videoDetailCtr.playedTimePos}';
     showDialog(
@@ -233,6 +235,38 @@ class PgcIntroController extends CommonIntroController {
                   );
                 } catch (e) {
                   SmartDialog.showToast(e.toString());
+                }
+              },
+            ),
+          for (final device in dlnaDeviceCache.values)
+            DialogOption(
+              child: Text(
+                '分享至${device.info.friendlyName}',
+                style: const TextStyle(fontSize: 14),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              onPressed: () {
+                Get.back();
+                final cid = videoDetailCtr.cid.value;
+                if (cid != 0 && epId != null) {
+                  final item = pgcItem.episodes?.firstWhereOrNull(
+                    (item) => item.epId == epId,
+                  );
+                  final title = item != null
+                      ? (item.shareCopy ??
+                          '${pgcItem.title} ${item.showTitle ?? item.longTitle}')
+                      : pgcItem.title;
+                  castToCachedDevice(
+                    device: device,
+                    cid: cid,
+                    objectId: epId!,
+                    playurlType: 2,
+                    title: title,
+                    qn: videoDetailCtr.currentVideoQa.value?.code,
+                  );
+                } else {
+                  SmartDialog.showToast('无法获取视频信息');
                 }
               },
             ),

--- a/lib/pages/video/introduction/ugc/controller.dart
+++ b/lib/pages/video/introduction/ugc/controller.dart
@@ -24,6 +24,7 @@ import 'package:PiliPlus/models_new/video/video_detail/stat_detail.dart';
 import 'package:PiliPlus/models_new/video/video_detail/ugc_season.dart';
 import 'package:PiliPlus/pages/common/common_intro_controller.dart';
 import 'package:PiliPlus/pages/dynamics_repost/view.dart';
+import 'package:PiliPlus/pages/dlna/dlna_service.dart';
 import 'package:PiliPlus/pages/video/related/controller.dart';
 import 'package:PiliPlus/pages/video/reply/controller.dart';
 import 'package:PiliPlus/plugin/pl_player/models/play_repeat.dart';
@@ -282,6 +283,7 @@ class UgcIntroController extends CommonIntroController with ReloadMixin {
   // 分享视频
   @override
   void actionShareVideo(BuildContext context) {
+    initDlnaDeviceCache();
     final videoDetail = this.videoDetail.value;
     final playedTimePos = videoDetailCtr.playedTimePos;
     String videoUrl = '${HttpString.baseUrl}/video/$bvid';
@@ -386,6 +388,33 @@ class UgcIntroController extends CommonIntroController with ReloadMixin {
                   );
                 } catch (e) {
                   SmartDialog.showToast(e.toString());
+                }
+              },
+            ),
+          for (final device in dlnaDeviceCache.values)
+            ListTile(
+              dense: true,
+              title: Text(
+                '分享至${device.info.friendlyName}',
+                style: const TextStyle(fontSize: 14),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              onTap: () {
+                Get.back();
+                final cid = videoDetailCtr.cid.value;
+                final aid = videoDetail.aid;
+                if (cid != 0 && aid != null) {
+                  castToCachedDevice(
+                    device: device,
+                    cid: cid,
+                    objectId: aid,
+                    playurlType: 1,
+                    title: videoDetail.title,
+                    qn: videoDetailCtr.currentVideoQa.value?.code,
+                  );
+                } else {
+                  SmartDialog.showToast('无法获取视频信息');
                 }
               },
             ),

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -247,7 +247,8 @@ abstract final class LocalCacheKey {
       danmakuFilterRules = 'danmakuFilterRules',
       mixinKey = 'mixinKey',
       timeStamp = 'timeStamp',
-      buvid = 'buvid';
+      buvid = 'buvid',
+      dlnaDevices = 'dlnaDevices';
 }
 
 abstract final class VideoBoxKey {


### PR DESCRIPTION
- 新增 DlnaService，支持 DLNA 设备本地持久化存储（Hive）
- 投屏页面优先展示历史缓存设备，无需等待 SSDP 搜索即可立即投屏
- UGC 与 PGC 视频详情页分享弹窗末尾增加快速投屏选项
<img width="234" height="506" alt="IMG_595F60807E38-1" src="https://github.com/user-attachments/assets/959c48cf-1ec9-4cc3-b0a8-131160cba691" />
