### PR TITLE
fix:分组关注也支持排序

### DIFF
--- a/lib/http/member.dart
+++ b/lib/http/member.dart
@@ -568,6 +568,7 @@ abstract final class MemberHttp {
     int? tagid,
     int? pn,
     int ps = 20,
+    String orderType = '', // ''=>最近关注，'attention'=>最常访问
   }) async {
     final res = await Request().get(
       Api.followUpGroup,
@@ -576,6 +577,7 @@ abstract final class MemberHttp {
         'tagid': tagid,
         'pn': pn,
         'ps': ps,
+        'order_type': orderType,
       },
     );
     if (res.data['code'] == 0) {

--- a/lib/pages/follow/child/child_controller.dart
+++ b/lib/pages/follow/child/child_controller.dart
@@ -2,14 +2,10 @@ import 'package:PiliPlus/http/follow.dart';
 import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/http/member.dart';
 import 'package:PiliPlus/http/user.dart';
-import 'package:PiliPlus/models/common/follow_order_type.dart';
 import 'package:PiliPlus/models_new/follow/data.dart';
 import 'package:PiliPlus/models_new/follow/list.dart';
 import 'package:PiliPlus/pages/common/common_list_controller.dart';
 import 'package:PiliPlus/pages/follow/controller.dart';
-import 'package:PiliPlus/utils/storage.dart';
-import 'package:PiliPlus/utils/storage_key.dart';
-import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:get/get.dart';
 
 class FollowChildController
@@ -23,13 +19,6 @@ class FollowChildController
   late final loadSameFollow = controller?.isOwner == false;
   late final Rx<LoadingState<List<FollowItemModel>?>> sameState =
       LoadingState<List<FollowItemModel>?>.loading().obs;
-
-  late final Rx<FollowOrderType> orderType = Pref.followOrderType.obs;
-
-  void setOrderType(FollowOrderType type) {
-    orderType.value = type;
-    GStorage.setting.put(SettingBoxKey.followOrderType, type.index);
-  }
 
   @override
   void onInit() {
@@ -77,14 +66,14 @@ class FollowChildController
         mid: mid,
         tagid: tagid,
         pn: page,
-        orderType: orderType.value.type,
+        orderType: controller?.orderType.value.type ?? '',
       );
     }
 
     return FollowHttp.followings(
       vmid: mid,
       pn: page,
-      orderType: orderType.value.type,
+      orderType: controller?.orderType.value.type ?? '',
     );
   }
 

--- a/lib/pages/follow/child/child_controller.dart
+++ b/lib/pages/follow/child/child_controller.dart
@@ -73,7 +73,12 @@ class FollowChildController
   @override
   Future<LoadingState<FollowData>> customGetData() {
     if (tagid != null) {
-      return MemberHttp.followUpGroup(mid: mid, tagid: tagid, pn: page);
+      return MemberHttp.followUpGroup(
+        mid: mid,
+        tagid: tagid,
+        pn: page,
+        orderType: orderType.value.type,
+      );
     }
 
     return FollowHttp.followings(

--- a/lib/pages/follow/child/child_view.dart
+++ b/lib/pages/follow/child/child_view.dart
@@ -5,11 +5,8 @@ import 'package:PiliPlus/common/sliver_single_child_delegate.dart';
 import 'package:PiliPlus/common/widgets/button/more_btn.dart';
 import 'package:PiliPlus/common/widgets/flutter/refresh_indicator.dart';
 import 'package:PiliPlus/common/widgets/loading_widget/http_error.dart';
-import 'package:PiliPlus/common/widgets/scaffold/simple_scaffold.dart';
 import 'package:PiliPlus/http/loading_state.dart';
-import 'package:PiliPlus/models/common/follow_order_type.dart';
 import 'package:PiliPlus/models_new/follow/list.dart';
-import 'package:PiliPlus/pages/common/fab_mixin.dart';
 import 'package:PiliPlus/pages/follow/child/child_controller.dart';
 import 'package:PiliPlus/pages/follow/controller.dart';
 import 'package:PiliPlus/pages/follow/widgets/follow_item.dart';
@@ -40,11 +37,7 @@ class FollowChildPage extends StatefulWidget {
 }
 
 class _FollowChildPageState extends State<FollowChildPage>
-    with
-        AutomaticKeepAliveClientMixin,
-        SingleTickerProviderStateMixin,
-        BaseFabMixin,
-        LazyFabMixin {
+    with AutomaticKeepAliveClientMixin {
   late String _tag;
   late FollowChildController _followController;
 
@@ -84,7 +77,7 @@ class _FollowChildPageState extends State<FollowChildPage>
     super.build(context);
     final colorScheme = ColorScheme.of(context);
     final padding = MediaQuery.viewPaddingOf(context);
-    Widget child = Padding(
+    return Padding(
       padding: EdgeInsets.only(left: padding.left, right: padding.right),
       child: refreshIndicator(
         onRefresh: _followController.onRefresh,
@@ -109,35 +102,6 @@ class _FollowChildPageState extends State<FollowChildPage>
         ),
       ),
     );
-    if (widget.onSelect != null ||
-        (widget.controller?.isOwner == true && widget.tagid == null)) {
-      return ScaffoldLayout(
-        body: fabAnimWrapper(child: child),
-        fab: SlideTransition(
-          position: fabAnimation,
-          child: Padding(
-            padding: .only(
-              right: kFloatingActionButtonMargin + padding.right,
-              bottom: kFloatingActionButtonMargin + padding.bottom,
-            ),
-            child: FloatingActionButton.extended(
-              onPressed: () => _followController
-                ..setOrderType(
-                  _followController.orderType.value == FollowOrderType.def
-                      ? FollowOrderType.attention
-                      : FollowOrderType.def,
-                )
-                ..onReload(),
-              icon: const Icon(Icons.format_list_bulleted, size: 20),
-              label: Obx(
-                () => Text(_followController.orderType.value.title),
-              ),
-            ),
-          ),
-        ),
-      );
-    }
-    return child;
   }
 
   Widget _buildBody(LoadingState<List<FollowItemModel>?> loadingState) {

--- a/lib/pages/follow/controller.dart
+++ b/lib/pages/follow/controller.dart
@@ -1,12 +1,20 @@
 import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/http/member.dart';
+import 'package:PiliPlus/models/common/follow_order_type.dart';
 import 'package:PiliPlus/models/member/tags.dart';
+import 'package:PiliPlus/pages/follow/child/child_controller.dart';
 import 'package:PiliPlus/utils/accounts.dart';
+import 'package:PiliPlus/utils/storage.dart';
+import 'package:PiliPlus/utils/storage_key.dart';
+import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:get/get.dart';
 import 'package:material_ui/material_ui.dart';
 
 class FollowController extends GetxController with GetTickerProviderStateMixin {
+  final String tag;
+  FollowController(this.tag);
+
   late final int mid;
   late final RxnString name;
   late final bool isOwner;
@@ -14,6 +22,19 @@ class FollowController extends GetxController with GetTickerProviderStateMixin {
   late final Rx<LoadingState> followState = LoadingState.loading().obs;
   late final RxList<MemberTagItemModel> tabs = <MemberTagItemModel>[].obs;
   TabController? tabController;
+
+  late final Rx<FollowOrderType> orderType = Pref.followOrderType.obs;
+
+  void toggleOrderType() {
+    final FollowOrderType type = orderType.value == .def ? .attention : .def;
+    orderType.value = type;
+    for (var e in tabs) {
+      try {
+        Get.find<FollowChildController>(tag: '$tag${e.tagid}').onReload();
+      } catch (_) {}
+    }
+    GStorage.setting.put(SettingBoxKey.followOrderType, type.index);
+  }
 
   @override
   void onInit() {

--- a/lib/pages/follow/view.dart
+++ b/lib/pages/follow/view.dart
@@ -6,6 +6,7 @@ import 'package:PiliPlus/common/widgets/scroll_physics.dart' show tabBarView;
 import 'package:PiliPlus/common/widgets/view_safe_area.dart';
 import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/models/member/tags.dart';
+import 'package:PiliPlus/pages/common/fab_mixin.dart';
 import 'package:PiliPlus/pages/follow/child/child_controller.dart';
 import 'package:PiliPlus/pages/follow/child/child_view.dart';
 import 'package:PiliPlus/pages/follow/controller.dart';
@@ -37,23 +38,53 @@ class FollowPage extends StatefulWidget {
   }
 }
 
-class _FollowPageState extends State<FollowPage> {
+class _FollowPageState extends State<FollowPage>
+    with SingleTickerProviderStateMixin, BaseFabMixin, LazyFabMixin {
   final _tag = Utils.generateRandomString(8);
   late final FollowController _followController;
 
   @override
   void initState() {
     super.initState();
-    _followController = Get.put(FollowController(), tag: _tag);
+    _followController = Get.put(FollowController(_tag), tag: _tag);
+  }
+
+  @override
+  bool onNotification(UserScrollNotification notification) {
+    if (notification.metrics.axisDirection == .down) {
+      return super.onNotification(notification);
+    }
+    return false;
   }
 
   @override
   Widget build(BuildContext context) {
+    final padding = MediaQuery.viewPaddingOf(context);
     return SimpleScaffold(
       appBar: _buildAppBar,
       body: _followController.isOwner
-          ? Obx(() => _buildBody(_followController.followState.value))
+          ? fabAnimWrapper(
+              child: Obx(() => _buildBody(_followController.followState.value)),
+            )
           : _childPage(),
+      fab: _followController.isOwner
+          ? SlideTransition(
+              position: fabAnimation,
+              child: Padding(
+                padding: .only(
+                  right: kFloatingActionButtonMargin + padding.right,
+                  bottom: kFloatingActionButtonMargin + padding.bottom,
+                ),
+                child: FloatingActionButton.extended(
+                  onPressed: _followController.toggleOrderType,
+                  icon: const Icon(Icons.format_list_bulleted, size: 20),
+                  label: Obx(
+                    () => Text(_followController.orderType.value.title),
+                  ),
+                ),
+              ),
+            )
+          : null,
     );
   }
 


### PR DESCRIPTION
# 问题

关注列表支持排序：`最常访问`，`最近关注`。但是进入分组后，排序失效了

<img width="1264" height="2736" alt="img_v3_02152_d371c6e4-d619-4999-9aca-fec215c2e27g" src="https://github.com/user-attachments/assets/10b7997a-8016-4caf-91e4-9e9ab2fb7420" />
<img width="1264" height="2736" alt="img_v3_02152_0d551145-b33b-433c-8cab-0b02947a5acg" src="https://github.com/user-attachments/assets/0d5869d8-6527-4c61-8bde-c08e82b8582c" />

可以看到本来排在第一位的up，进入分组后，又变回 `最近关注` 排序了

# 调研

分组接口实际是支持排序参数的，如下：

默认排序时：
<img width="3862" height="1318" alt="image" src="https://github.com/user-attachments/assets/a120f572-6d63-408f-a8fc-00e69b246b7b" />

增加排序参数时：
<img width="3844" height="1358" alt="image" src="https://github.com/user-attachments/assets/3cec81f5-ac63-42c9-9812-6197292ee143" />

# 解决

为分组关注接口，增加参数：order_type。详见pr

代码仅最小修改，其他复杂场景暂不考虑：
- 如果其他分组数据已加载，是否触发reload
- 分组页面是否也展示排序切换

# 代码 & 验证 说明

本次修改为codex修改，代码仅供参考。
验证：机器上没有android开发环境，本次修改代码未真人验证
