### PR TITLE
fix(linux): 关闭窗口后保留托盘图标

### DIFF
--- a/lib/pages/main/view.dart
+++ b/lib/pages/main/view.dart
@@ -63,6 +63,14 @@ class _MainAppState extends PopScopeState<MainApp>
       windowManager
         ..addListener(this)
         ..setPreventClose(true);
+      if (Platform.isLinux) {
+        // Keep the process (and tray) alive when closing hides to tray.
+        const windowChannel = MethodChannel('piliplus/window');
+        windowChannel.invokeMethod(
+          'set_quit_on_close',
+          !(_mainController.showTrayIcon && _mainController.minimizeOnExit),
+        );
+      }
       if (_mainController.showTrayIcon) {
         trayManager.addListener(this);
         _handleTray();

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -1,11 +1,19 @@
 #include "my_application.h"
 
+#include <string.h>
+
 #include <flutter_linux/flutter_linux.h>
 #ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
 #endif
 
 #include "flutter/generated_plugin_registrant.h"
+
+// In hide-to-tray mode (Dart sets this to false) the window close should be
+// delegated to window_manager so the process and tray icon stay alive.
+static gboolean g_quit_on_window_close = TRUE;
+
+static FlMethodChannel *g_window_channel = nullptr;
 
 struct _MyApplication {
   GtkApplication parent_instance;
@@ -22,6 +30,9 @@ static void first_frame_cb(MyApplication *self, FlView *view) {
 // Called when window is requested to be closed.
 static gboolean window_delete_event_cb(GtkWidget *widget, GdkEvent *event,
                                        gpointer data) {
+  if (!g_quit_on_window_close) {
+    return FALSE;
+  }
   // Get the application and quit it.
   GtkApplication *app = gtk_window_get_application(GTK_WINDOW(widget));
   if (app != nullptr) {
@@ -29,6 +40,26 @@ static gboolean window_delete_event_cb(GtkWidget *widget, GdkEvent *event,
   }
   // Return TRUE to prevent further processing of the delete event.
   return TRUE;
+}
+
+// Handles "set_quit_on_close" on the piliplus/window channel; Dart passes
+// false when the tray icon should keep the app alive on window close.
+static void my_application_method_call_cb(FlMethodChannel *channel,
+                                          FlMethodCall *method_call,
+                                          gpointer user_data) {
+  if (strcmp(fl_method_call_get_name(method_call), "set_quit_on_close") == 0) {
+    FlValue *args = fl_method_call_get_args(method_call);
+    gboolean value = FALSE;
+    if (fl_value_get_type(args) == FL_VALUE_TYPE_BOOL) {
+      value = fl_value_get_bool(args);
+    }
+    g_quit_on_window_close = value;
+    g_autoptr(FlMethodResponse) response =
+        FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_null()));
+    fl_method_call_respond(method_call, response, nullptr);
+  } else {
+    fl_method_call_respond_not_implemented(method_call, nullptr);
+  }
 }
 
 // Implements GApplication::activate.
@@ -101,6 +132,14 @@ static void my_application_activate(GApplication *application) {
                    NULL);
 
   fl_register_plugins(FL_PLUGIN_REGISTRY(view));
+
+  g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
+  g_window_channel =
+      fl_method_channel_new(fl_engine_get_binary_messenger(
+                                fl_view_get_engine(view)),
+                            "piliplus/window", FL_METHOD_CODEC(codec));
+  fl_method_channel_set_method_call_handler(
+      g_window_channel, my_application_method_call_cb, self, nullptr);
 
   gtk_widget_grab_focus(GTK_WIDGET(view));
 }


### PR DESCRIPTION

### 背景

在 Linux 上，#1795（`2b5f111fb`）为修复"窗口关闭后后台进程不终止"的问题，在 `linux/runner/my_application.cc` 添加了 `delete-event` 回调：

```c
static gboolean window_delete_event_cb(GtkWidget *widget, GdkEvent *event,
                                       gpointer data) {
  GtkApplication *app = gtk_window_get_application(GTK_WINDOW(widget));
  if (app != nullptr) {
    g_application_quit(G_APPLICATION(app));   // 直接退出整个应用
  }
  return TRUE;
}
```

该回调**无条件调用 `g_application_quit()`**，绕过了 Dart 侧 `window_manager` 的 `setPreventClose(true)` 拦截机制与 `onWindowClose` 决策，导致：

- 即使开启了"显示托盘图标 + 退出窗口时最小化"，关闭窗口也会直接终结整个进程 → **托盘图标立即消失**。
- 违背了托盘"独立于主窗口常驻"的设计初衷。

该功能本应只针对"不使用显示托盘图标"（即关闭即退出）的情景。

### 改动

将"关闭窗口是否退出进程"的决定权交还 Dart 侧原有逻辑，通过新增 `piliplus/window` 方法通道把该决策同步给原生层。

- `linux/runner/my_application.cc`
  - `window_delete_event_cb` 增加判断：`g_quit_on_window_close` 为 `false`（隐藏到托盘模式）时返回 `FALSE`，放行给 `window_manager` 拦截（触发 Dart `onWindowClose` → 隐藏窗口），进程与托盘存活；为 `true` 时才 `g_application_quit`（保留 pr#1795 的干净退出）。
  - 新增 `piliplus/window` 通道的 `set_quit_on_close` 处理器。
- `lib/pages/main/view.dart`
  - **仅针对 Linux**（`Platform.isLinux` 守护）在 `initState` 通过通道将开关设为 `!(showTrayIcon && minimizeOnExit)`，与既有 `onWindowClose` 分支完全一致：
    - 托盘 + 退出时最小化 → `false` → 隐藏到托盘，托盘常驻；
    - 其余情况 → `true` → 退出进程。
  - Windows/macOS 的代码与原生层**未做任何改动**。

### 三端行为一致性

改动仅作用于 Linux 的原生关闭回调；Windows/macOS 走各自 `window_manager` 的拦截机制（`WM_CLOSE` / `windowShouldClose`），不受影响。

**托盘模式**（`showTrayIcon` + `minimizeOnExit` 均开启，默认配置）：

| 平台 | 改动前 | 改动后 |
|------|--------|--------|
| Windows | 关闭→隐藏→托盘存活 | 同左（未改） |
| macOS | 关闭→隐藏→托盘存活 | 同左（未改） |
| Linux | ❌ pr#1795 强杀进程，托盘立即消失 | 关闭→隐藏→**托盘存活**（修复，对齐 W/M） |

**非托盘模式**（关闭即退出）：

| 平台 | 改动前 | 改动后 |
|------|--------|--------|
| Windows | 关闭→退出进程 | 同左（未改） |
| macOS | 关闭→退出进程 | 同左（未改） |
| Linux | 关闭→干净退出（`g_application_quit`） | 关闭→干净退出（行为等同） |

**结论**：本分支改动后三端行为统一一致。唯一实质变化在 Linux 的托盘模式（修复不一致），非托盘路径无回归。

### 验证

- `flutter build linux --debug` 构建通过。
- Linux debug bundle 启动正常：主窗口渲染、无异常、无方法通道报错。
- 默认配置下开关为 `false`，关闭窗口走隐藏路径，托盘不销毁。
- 功能已在实际运行中验证有效。
