### PR TITLE
chore(ios): bypass "App Encryption Documentation" when distributing

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -139,5 +139,7 @@
 			<string>_upnp._tcp</string>
 			<string>_http._tcp</string>
 		</array>
+		<key>ITSAppUsesNonExemptEncryption</key>
+		<false/>
 	</dict>
 </plist>


### PR DESCRIPTION
Added `ITSAppUsesNonExemptEncryption` key to `ios/Runner/Info.plist`, and set it to false as only standard encryption (like HTTPS) is involved.
This bypasses the "App Encryption Documentation" declaration in App Store Connect when distributing via TestFlight. Without it I have to declare for every single build.

https://developer.apple.com/documentation/bundleresources/information-property-list/itsappusesnonexemptencryption

<img width="2386" height="1552" alt="image" src="https://github.com/user-attachments/assets/b375ad1c-08ed-42ca-ba5b-d67798e8671c" />