### PR TITLE
fix: 校验并回滚设置恢复

### DIFF
--- a/lib/utils/storage.dart
+++ b/lib/utils/storage.dart
@@ -87,13 +87,51 @@ abstract final class GStorage {
   static Future<void> importAllSettings(String data) =>
       importAllJsonSettings(jsonDecode(data));
 
-  static Future<List<void>> importAllJsonSettings(
+  static Future<void> importAllJsonSettings(
     Map<String, dynamic> map,
+  ) async {
+    final importedSetting = _settingsSection(map, setting.name);
+    final importedVideo = _settingsSection(map, video.name);
+    final previousSetting = Map<dynamic, dynamic>.of(setting.toMap());
+    final previousVideo = Map<dynamic, dynamic>.of(video.toMap());
+
+    try {
+      await _replaceBox(setting, importedSetting);
+      await _replaceBox(video, importedVideo);
+    } catch (error, stackTrace) {
+      try {
+        await _replaceBox(setting, previousSetting);
+        await _replaceBox(video, previousVideo);
+      } catch (rollbackError) {
+        Error.throwWithStackTrace(
+          StateError(
+            'Failed to import settings ($error) and restore the previous '
+            'snapshot ($rollbackError)',
+          ),
+          stackTrace,
+        );
+      }
+      Error.throwWithStackTrace(error, stackTrace);
+    }
+  }
+
+  static Map<dynamic, dynamic> _settingsSection(
+    Map<String, dynamic> data,
+    String name,
   ) {
-    return Future.wait([
-      setting.clear().then((_) => setting.putAll(map[setting.name])),
-      video.clear().then((_) => video.putAll(map[video.name])),
-    ]);
+    final section = data[name];
+    if (section is! Map) {
+      throw FormatException('Invalid or missing settings section: $name');
+    }
+    return Map<dynamic, dynamic>.of(section);
+  }
+
+  static Future<void> _replaceBox(
+    Box<dynamic> box,
+    Map<dynamic, dynamic> values,
+  ) async {
+    await box.clear();
+    await box.putAll(values);
   }
 
   static void regAdapter() {

--- a/test/utils/storage_import_test.dart
+++ b/test/utils/storage_import_test.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+
+import 'package:PiliPlus/utils/storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('piliplus-storage-test-');
+    Hive.init(tempDir.path);
+    GStorage.setting = await Hive.openBox<dynamic>('setting');
+    GStorage.video = await Hive.openBox<dynamic>('video');
+  });
+
+  setUp(() async {
+    await GStorage.setting.clear();
+    await GStorage.video.clear();
+    await GStorage.setting.putAll({'theme': 'dark', 'obsolete': true});
+    await GStorage.video.putAll({'speed': 2.0});
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    await tempDir.delete(recursive: true);
+  });
+
+  test('validates every section before clearing existing settings', () async {
+    await expectLater(
+      GStorage.importAllJsonSettings({
+        'setting': {'theme': 'light'},
+        'video': <Object?>[],
+      }),
+      throwsA(isA<FormatException>()),
+    );
+
+    expect(GStorage.setting.toMap(), {'theme': 'dark', 'obsolete': true});
+    expect(GStorage.video.toMap(), {'speed': 2.0});
+  });
+
+  test('restores both snapshots when a box replacement fails', () async {
+    await expectLater(
+      GStorage.importAllJsonSettings({
+        'setting': {'theme': 'light'},
+        'video': {'invalid': Object()},
+      }),
+      throwsA(anything),
+    );
+
+    expect(GStorage.setting.toMap(), {'theme': 'dark', 'obsolete': true});
+    expect(GStorage.video.toMap(), {'speed': 2.0});
+  });
+
+  test('replaces both settings sections after validation', () async {
+    await GStorage.importAllJsonSettings({
+      'setting': {'theme': 'light'},
+      'video': {'speed': 1.5, 'quality': 80},
+    });
+
+    expect(GStorage.setting.toMap(), {'theme': 'light'});
+    expect(GStorage.video.toMap(), {'speed': 1.5, 'quality': 80});
+  });
+}


### PR DESCRIPTION
### 现象

设置恢复会先清空现有 `setting` / `video` 数据，再读取导入分区；备份缺失、类型错误或中途写入失败时，当前设置可能已被部分清空。

### 方案

- 在修改 Hive box 前完整校验两个导入分区
- 替换前保存两份现有设置快照
- 任一 box 替换失败时恢复两个旧快照，并保留原始错误

### 验证

- `flutter test --no-pub test/utils/storage_import_test.dart`（3 个场景）
- `flutter analyze --no-pub lib/utils/storage.dart test/utils/storage_import_test.dart`