### PR TITLE
fix: 隔离共享播放器的路由生命周期

### DIFF
--- a/lib/pages/live_room/controller.dart
+++ b/lib/pages/live_room/controller.dart
@@ -53,7 +53,9 @@ class LiveRoomController extends GetxController {
   int roomId = Get.arguments;
   int? ruid;
   DanmakuController<DanmakuExtra>? danmakuController;
-  final plPlayerController = PlPlayerController.getInstance(
+  final Object playerOwner = Object();
+  late final plPlayerController = PlPlayerController.getInstance(
+    owner: playerOwner,
     isLive: true,
   );
 
@@ -200,6 +202,7 @@ class LiveRoomController extends GetxController {
       autoplay: autoplay,
       isVertical: isPortrait.value,
       autoFullScreenFlag: autoFullScreenFlag,
+      owner: playerOwner,
     );
   }
 

--- a/lib/pages/live_room/view.dart
+++ b/lib/pages/live_room/view.dart
@@ -178,10 +178,9 @@ class _LiveRoomPageState extends State<LiveRoomPage>
     if (Platform.isAndroid && !plPlayerController.setSystemBrightness) {
       ScreenBrightnessPlatform.instance.resetApplicationScreenBrightness();
     }
-    PlPlayerController.setPlayCallBack(null);
     plPlayerController
       ..removeStatusLister(playerListener)
-      ..dispose();
+      ..dispose(owner: _liveRoomController.playerOwner);
     for (final e in LiveContributionRankType.values) {
       Get.delete<ContributionRankController>(
         tag: '${_liveRoomController.roomId}${e.name}',

--- a/lib/pages/video/controller.dart
+++ b/lib/pages/video/controller.dart
@@ -124,8 +124,10 @@ class VideoDetailController extends GetxController
   final videoPlayerKey = GlobalKey();
   final childKey = GlobalKey<MiniScaffoldState>();
 
-  final plPlayerController = PlPlayerController.getInstance()
-    ..brightness.value = -1;
+  final Object playerOwner = Object();
+  late final plPlayerController = PlPlayerController.getInstance(
+    owner: playerOwner,
+  )..brightness.value = -1;
   bool get setSystemBrightness => plPlayerController.setSystemBrightness;
   bool get removeSafeArea => plPlayerController.removeSafeArea;
   double get uiScale => plPlayerController.uiScale;
@@ -754,6 +756,7 @@ class VideoDetailController extends GetxController
       height: firstVideo.height,
       volume: volume,
       autoFullScreenFlag: autoFullScreenFlag,
+      owner: playerOwner,
     );
 
     if (isClosed) return;

--- a/lib/pages/video/view.dart
+++ b/lib/pages/video/view.dart
@@ -353,10 +353,10 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
       videoPlayerServiceHandler?.onVideoDetailDispose(heroTag);
       if (plPlayerController != null) {
         videoDetailController.makeHeartBeat();
-        plPlayerController!.dispose();
-      } else {
-        PlPlayerController.updatePlayCount();
       }
+      videoDetailController.plPlayerController.dispose(
+        owner: videoDetailController.playerOwner,
+      );
     }
     removeObserverMobile(this);
 

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -28,6 +28,7 @@ import 'package:PiliPlus/plugin/pl_player/models/fullscreen_mode.dart';
 import 'package:PiliPlus/plugin/pl_player/models/heart_beat_type.dart';
 import 'package:PiliPlus/plugin/pl_player/models/play_repeat.dart';
 import 'package:PiliPlus/plugin/pl_player/models/play_status.dart';
+import 'package:PiliPlus/plugin/pl_player/models/source_owner.dart';
 import 'package:PiliPlus/plugin/pl_player/models/video_fit_type.dart';
 import 'package:PiliPlus/plugin/pl_player/utils/fullscreen.dart';
 import 'package:PiliPlus/services/service_locator.dart';
@@ -98,7 +99,7 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
     durationInMilliseconds = value.inMilliseconds;
   }
 
-  int _playerCount = 0;
+  final PlayerSourceCoordinator _sourceCoordinator = PlayerSourceCoordinator();
 
   late double lastPlaybackSpeed = 1.0;
   final RxDouble _playbackSpeed = Pref.playSpeedDefault.obs;
@@ -560,11 +561,15 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
   }
 
   // 获取实例 传参
-  static PlPlayerController getInstance({bool isLive = false}) {
+  static PlPlayerController getInstance({
+    required Object owner,
+    bool isLive = false,
+  }) {
     // 如果实例尚未创建，则创建一个新实例
-    return (_instance ??= PlPlayerController._())
-      ..isLive = isLive
-      .._playerCount += 1;
+    final instance = _instance ??= PlPlayerController._();
+    instance._sourceCoordinator.register(owner);
+    instance.isLive = isLive;
+    return instance;
   }
 
   bool _processing = false;
@@ -576,6 +581,7 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
   // 初始化资源
   Future<void> setDataSource(
     DataSource dataSource, {
+    required Object owner,
     bool isLive = false,
     bool autoplay = true,
     // 初始化播放位置
@@ -598,8 +604,9 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
     VoidCallback? onInit,
     Volume? volume,
     bool autoFullScreenFlag = false,
-  }) async {
+  }) => _sourceCoordinator.run(owner, (isCurrent) async {
     try {
+      if (!isCurrent()) return;
       _processing = true;
       this.isLive = isLive;
       _videoType = videoType ?? VideoType.ugc;
@@ -629,17 +636,13 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
         await pause(notify: false);
       }
 
-      if (_playerCount == 0) {
+      if (!isCurrent()) {
         return;
       }
       // 配置Player 音轨、字幕等等
-      await _createVideoController(dataSource, seekTo, volume);
+      await _createVideoController(dataSource, seekTo, volume, isCurrent);
 
-      if (_playerCount == 0) {
-        _removeListeners();
-        _videoPlayerController?.dispose();
-        _videoPlayerController = null;
-        _videoController = null;
+      if (!isCurrent() || _videoPlayerController == null) {
         return;
       }
 
@@ -652,10 +655,13 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
         triggerFullScreen(status: true);
       }
 
-      await _initializePlayer();
+      await _initializePlayer(isCurrent);
+      if (!isCurrent()) return;
       onInit?.call();
     } catch (err, stackTrace) {
-      dataStatus.value = DataStatus.error;
+      if (isCurrent()) {
+        dataStatus.value = DataStatus.error;
+      }
       if (kDebugMode) {
         debugPrint(stackTrace.toString());
         debugPrint('plPlayer err:  $err');
@@ -663,7 +669,7 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
     } finally {
       _processing = false;
     }
-  }
+  });
 
   String? shadersDirPath;
   Future<String> get copyShadersToExternalDirectory async {
@@ -765,6 +771,7 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
     DataSource dataSource,
     Duration? seekTo,
     Volume? volume,
+    bool Function() isCurrent,
   ) async {
     isBuffering.value = false;
     _heartDuration = 0;
@@ -774,7 +781,7 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
 
     if (player == null) {
       player = await _initPlayer();
-      if (_playerCount == 0) {
+      if (!isCurrent()) {
         _removeListeners();
         player.dispose();
         player = null;
@@ -838,8 +845,8 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
   }
 
   // 开始播放
-  Future<void> _initializePlayer() async {
-    if (_instance == null) return;
+  Future<void> _initializePlayer(bool Function() isCurrent) async {
+    if (!isCurrent() || _instance == null) return;
     // 设置倍速
     if (isLive) {
       await setPlaybackSpeed(1.0);
@@ -848,6 +855,7 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
         await setPlaybackSpeed(_playbackSpeed.value);
       }
     }
+    if (!isCurrent()) return;
     _initVideoFit();
     // if (_looping) {
     //   await setLooping(_looping);
@@ -1034,7 +1042,7 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
 
   /// 跳转至指定位置
   Future<void> seekTo(Duration position, {bool isSeek = true}) async {
-    if (_playerCount == 0) {
+    if (!_sourceCoordinator.hasOwners) {
       return;
     }
     if (position < Duration.zero) {
@@ -1101,7 +1109,7 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
 
   /// 播放视频
   Future<void> play({bool repeat = false, bool hideControls = true}) async {
-    if (_playerCount == 0) return;
+    if (!_sourceCoordinator.hasOwners) return;
     // 播放时自动隐藏控制条
     controls = !hideControls;
     // repeat为true，将从头播放
@@ -1408,7 +1416,7 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
   }
 
   void addPositionListener(ValueChanged<Duration> listener) {
-    if (_playerCount == 0) return;
+    if (!_sourceCoordinator.hasOwners) return;
     _positionListeners.add(listener);
   }
 
@@ -1416,7 +1424,7 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
       _positionListeners.remove(listener);
 
   void addStatusLister(ValueChanged<PlayerStatus> listener) {
-    if (_playerCount == 0) return;
+    if (!_sourceCoordinator.hasOwners) return;
     _statusListeners.add(listener);
   }
 
@@ -1508,22 +1516,28 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
   void onCloseAll() {
     _isCloseAll = true;
     if (PlatformUtils.isDesktop) exitDesktopFullScreen();
-    dispose();
+    _sourceCoordinator.clear();
+    _disposeAll();
     Get.until((route) => route.isFirst);
   }
 
-  void dispose() {
-    // 每次减1，最后销毁
-    resetScreenRotation();
-    cancelLongPressTimer();
-    _cancelSubForSeek();
-    if (!_isCloseAll && _playerCount > 1) {
-      _playerCount -= 1;
+  void dispose({required Object owner}) {
+    final wasActive = _sourceCoordinator.isActive(owner);
+    if (!_sourceCoordinator.release(owner)) return;
+    if (wasActive) {
+      setPlayCallBack(null);
+    }
+    if (_sourceCoordinator.hasOwners) {
       _heartDuration = 0;
       return;
     }
+    _disposeAll();
+  }
 
-    _playerCount = 0;
+  void _disposeAll() {
+    resetScreenRotation();
+    cancelLongPressTimer();
+    _cancelSubForSeek();
     if (removeSafeArea) {
       showSystemBar();
     }
@@ -1571,14 +1585,6 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
     _videoController = null;
     _instance = null;
     videoPlayerServiceHandler?.clear();
-  }
-
-  static void updatePlayCount() {
-    if (_instance?._playerCount == 1) {
-      _instance?.dispose();
-    } else {
-      _instance?._playerCount -= 1;
-    }
   }
 
   void setContinuePlayInBackground() {
@@ -1687,7 +1693,7 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
 
       setPlayCallBack(null);
 
-      if (Platform.isAndroid && _playerCount <= 1) {
+      if (Platform.isAndroid && _sourceCoordinator.ownerCount <= 1) {
         _disableAutoEnterPip();
         if (!setSystemBrightness) {
           ScreenBrightnessPlatform.instance.resetApplicationScreenBrightness();

--- a/lib/plugin/pl_player/models/source_owner.dart
+++ b/lib/plugin/pl_player/models/source_owner.dart
@@ -1,0 +1,55 @@
+import 'dart:collection';
+
+typedef PlayerSourceOperation = Future<void> Function(
+  bool Function() isCurrent,
+);
+
+final class PlayerSourceCoordinator {
+  final Set<Object> _owners = HashSet<Object>.identity();
+  Object? _activeOwner;
+  int _revision = 0;
+  Future<void> _tail = Future<void>.value();
+
+  bool get hasOwners => _owners.isNotEmpty;
+  int get ownerCount => _owners.length;
+
+  void register(Object owner) => _owners.add(owner);
+
+  bool isActive(Object owner) => identical(_activeOwner, owner);
+
+  bool release(Object owner) {
+    final removed = _owners.remove(owner);
+    if (removed && identical(_activeOwner, owner)) {
+      _activeOwner = null;
+      _revision += 1;
+    }
+    return removed;
+  }
+
+  void clear() {
+    _owners.clear();
+    _activeOwner = null;
+    _revision += 1;
+  }
+
+  Future<void> run(Object owner, PlayerSourceOperation operation) {
+    if (!_owners.contains(owner)) {
+      return Future<void>.value();
+    }
+
+    _activeOwner = owner;
+    final revision = ++_revision;
+    bool isCurrent() =>
+        _owners.contains(owner) &&
+        identical(_activeOwner, owner) &&
+        revision == _revision;
+
+    final result = _tail.then((_) async {
+      if (isCurrent()) {
+        await operation(isCurrent);
+      }
+    });
+    _tail = result.then<void>((_) {}, onError: (_, _) {});
+    return result;
+  }
+}

--- a/test/plugin/pl_player/source_owner_test.dart
+++ b/test/plugin/pl_player/source_owner_test.dart
@@ -1,0 +1,95 @@
+import 'dart:async';
+
+import 'package:PiliPlus/plugin/pl_player/models/source_owner.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('latest owner prevents an older operation from committing', () async {
+    final coordinator = PlayerSourceCoordinator();
+    final firstOwner = Object();
+    final secondOwner = Object();
+    final firstStarted = Completer<void>();
+    final unblockFirst = Completer<void>();
+    final commits = <String>[];
+    coordinator
+      ..register(firstOwner)
+      ..register(secondOwner);
+
+    final first = coordinator.run(firstOwner, (isCurrent) async {
+      firstStarted.complete();
+      await unblockFirst.future;
+      if (isCurrent()) commits.add('first');
+    });
+    await firstStarted.future;
+    final second = coordinator.run(secondOwner, (isCurrent) async {
+      if (isCurrent()) commits.add('second');
+    });
+
+    unblockFirst.complete();
+    await Future.wait([first, second]);
+
+    expect(commits, ['second']);
+  });
+
+  test('released owners cannot start or finish source operations', () async {
+    final coordinator = PlayerSourceCoordinator();
+    final owner = Object();
+    final started = Completer<void>();
+    final unblock = Completer<void>();
+    var commits = 0;
+    coordinator.register(owner);
+
+    final operation = coordinator.run(owner, (isCurrent) async {
+      started.complete();
+      await unblock.future;
+      if (isCurrent()) commits += 1;
+    });
+    await started.future;
+    expect(coordinator.release(owner), isTrue);
+    unblock.complete();
+    await operation;
+    await coordinator.run(owner, (_) async => commits += 1);
+
+    expect(commits, 0);
+    expect(coordinator.hasOwners, isFalse);
+  });
+
+  test('releasing an inactive owner keeps the active owner current', () async {
+    final coordinator = PlayerSourceCoordinator();
+    final firstOwner = Object();
+    final secondOwner = Object();
+    var secondCommitted = false;
+    coordinator
+      ..register(firstOwner)
+      ..register(secondOwner);
+
+    final operation = coordinator.run(secondOwner, (isCurrent) async {
+      expect(coordinator.release(firstOwner), isTrue);
+      secondCommitted = isCurrent();
+    });
+    await operation;
+
+    expect(secondCommitted, isTrue);
+    expect(coordinator.isActive(secondOwner), isTrue);
+  });
+
+  test('a failed operation does not block the next owner', () async {
+    final coordinator = PlayerSourceCoordinator();
+    final firstOwner = Object();
+    final secondOwner = Object();
+    var secondCommitted = false;
+    coordinator
+      ..register(firstOwner)
+      ..register(secondOwner);
+
+    await expectLater(
+      coordinator.run(firstOwner, (_) async => throw StateError('failed')),
+      throwsStateError,
+    );
+    await coordinator.run(secondOwner, (isCurrent) async {
+      secondCommitted = isCurrent();
+    });
+
+    expect(secondCommitted, isTrue);
+  });
+}


### PR DESCRIPTION
### 现象

视频页和直播页共享播放器单例，但异步数据源切换只按页面计数判断存活。旧路由的 `Player.create/open` 迟到后仍可覆盖新路由，旧路由释放时也无法准确识别自己拥有的工作。

### 方案

- 为每个视频/直播控制器分配身份 owner
- 用 generation 让后发数据源立即使旧任务失效，并串行执行原生播放器切换
- 仅允许当前 owner 更新状态、触发回调；迟到创建的原生资源会立即释放
- 按 owner 注销页面，释放非活动页面不会中断当前页面，最后一个 owner 才销毁共享单例

### 验证

- `flutter test --no-pub test/plugin/pl_player/source_owner_test.dart`（4 个并发/生命周期场景）
- `flutter analyze --no-pub` 定向检查 7 个相关生产与测试文件