### PR TITLE
fix: 阻止迟到响应复活已删除账号

### DIFF
--- a/lib/pages/setting/view.dart
+++ b/lib/pages/setting/view.dart
@@ -261,9 +261,9 @@ class _SettingPageState extends State<SettingPage> {
               ),
             ),
             TextButton(
-              onPressed: () async {
-                await _removeAccounts(result);
-                if (context.mounted) Get.back();
+              onPressed: () {
+                Get.back();
+                _removeAccounts(result);
               },
               child: Text(
                 '仅登出',
@@ -279,9 +279,8 @@ class _SettingPageState extends State<SettingPage> {
                 if (logoutAccounts.isEmpty) {
                   SmartDialog.showToast('所选账号均退出登录失败');
                 } else {
-                  await _removeAccounts(logoutAccounts);
-                  if (!context.mounted) return;
                   Get.back();
+                  _removeAccounts(logoutAccounts);
                   if (logoutAccounts.length != result.length) {
                     result.removeWhere(logoutAccounts.contains);
                     SmartDialog.showToast(

--- a/lib/pages/setting/view.dart
+++ b/lib/pages/setting/view.dart
@@ -261,9 +261,9 @@ class _SettingPageState extends State<SettingPage> {
               ),
             ),
             TextButton(
-              onPressed: () {
-                _removeAccounts(result);
-                Get.back();
+              onPressed: () async {
+                await _removeAccounts(result);
+                if (context.mounted) Get.back();
               },
               child: Text(
                 '仅登出',
@@ -279,7 +279,8 @@ class _SettingPageState extends State<SettingPage> {
                 if (logoutAccounts.isEmpty) {
                   SmartDialog.showToast('所选账号均退出登录失败');
                 } else {
-                  _removeAccounts(logoutAccounts);
+                  await _removeAccounts(logoutAccounts);
+                  if (!context.mounted) return;
                   Get.back();
                   if (logoutAccounts.length != result.length) {
                     result.removeWhere(logoutAccounts.contains);

--- a/lib/utils/accounts/account.dart
+++ b/lib/utils/accounts/account.dart
@@ -81,13 +81,15 @@ class LoginAccount extends Account {
 
   @override
   Future<void> delete() {
-    assert(_hasDelete = true);
+    _hasDelete = true;
     return Future.wait([cookieJar.deleteAll(), _box.delete(_midStr)]);
   }
 
   @override
   Future<void> onChange() {
-    assert(!_hasDelete);
+    if (_hasDelete) {
+      return Future<void>.value();
+    }
     return _box.put(_midStr, this);
   }
 

--- a/lib/utils/accounts/account.dart
+++ b/lib/utils/accounts/account.dart
@@ -86,10 +86,8 @@ class LoginAccount extends Account {
   }
 
   @override
-  Future<void> onChange() {
-    if (_hasDelete) {
-      return Future<void>.value();
-    }
+  Future<void>? onChange() {
+    if (_hasDelete) return null;
     return _box.put(_midStr, this);
   }
 

--- a/test/utils/accounts/deleted_account_test.dart
+++ b/test/utils/accounts/deleted_account_test.dart
@@ -1,0 +1,70 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:PiliPlus/utils/accounts.dart';
+import 'package:PiliPlus/utils/accounts/account.dart';
+import 'package:PiliPlus/utils/storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+
+LoginAccount _account() => LoginAccount(
+  BiliCookieJar.fromJson({
+    'DedeUserID': '123',
+    'bili_jct': 'csrf',
+  }),
+  'access-key',
+  'refresh-token',
+);
+
+void main() {
+  late Directory tempDir;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('piliplus-account-test-');
+    Hive.init(tempDir.path);
+    GStorage.regAdapter();
+    Accounts.account = await Hive.openBox<LoginAccount>('account');
+  });
+
+  setUp(() => Accounts.account.clear());
+
+  tearDownAll(() async {
+    await Hive.close();
+    await tempDir.delete(recursive: true);
+  });
+
+  test('late account changes cannot recreate a deleted account', () async {
+    final account = _account();
+    await account.onChange();
+    expect(Accounts.account.containsKey('123'), isTrue);
+
+    final lateResponse = Completer<void>();
+    final persistLateResponse = lateResponse.future.then((_) {
+      account.cookieJar.saveFromResponse(
+        Uri.parse('https://www.bilibili.com'),
+        [Cookie('SESSDATA', 'late-cookie')..setBiliDomain()],
+      );
+      return account.onChange();
+    });
+
+    await account.delete();
+    lateResponse.complete();
+    await persistLateResponse;
+
+    expect(Accounts.account.containsKey('123'), isFalse);
+  });
+
+  test(
+    'delete tombstone is active before asynchronous deletion completes',
+    () async {
+      final account = _account();
+      await account.onChange();
+
+      final deletion = account.delete();
+      await account.onChange();
+      await deletion;
+
+      expect(Accounts.account.containsKey('123'), isFalse);
+    },
+  );
+}


### PR DESCRIPTION
### 现象

账号删除标记和持久化前置检查写在 `assert` 中，Release 构建会移除这些语句。退出账号后，迟到网络响应仍可调用 `onChange()`，把已删除账号重新写回 Hive。

### 方案

- 在运行时代码中同步设置删除墓碑
- 已删除账号的后续 `onChange()` 直接返回，不再写回 Hive
- 退出操作等待本地账号删除完成后再关闭对话框

### 验证

- `flutter test --no-pub test/utils/accounts/deleted_account_test.dart`（迟到响应、删除进行中两种场景）
- `flutter analyze --no-pub lib/utils/accounts/account.dart lib/pages/setting/view.dart test/utils/accounts/deleted_account_test.dart`