### PR TITLE
fix: 校验断点续传响应与媒体完整性

### DIFF
--- a/lib/services/download/download_manager.dart
+++ b/lib/services/download/download_manager.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:PiliPlus/http/init.dart';
 import 'package:PiliPlus/models_new/download/bili_download_entry_info.dart';
+import 'package:PiliPlus/services/download/download_resume.dart';
 import 'package:PiliPlus/utils/extension/file_ext.dart';
 import 'package:PiliPlus/utils/extension/string_ext.dart';
 import 'package:dio/dio.dart';
@@ -39,13 +40,11 @@ class DownloadManager {
       received = 0;
     }
 
-    final sink = file.openWrite(
-      mode: received == 0 ? FileMode.writeOnly : FileMode.writeOnlyAppend,
-    );
+    IOSink? sink;
 
     Future<void> onError(Object e, {bool delete = false}) async {
       try {
-        await sink.close();
+        await sink?.close();
       } catch (_) {}
       if (_status == DownloadStatus.downloading) {
         _status = DownloadStatus.failDownload;
@@ -56,32 +55,74 @@ class DownloadManager {
       onDone(e);
     }
 
-    Response<ResponseBody> response;
+    Future<Response<ResponseBody>> request([int? rangeStart]) =>
+        Request.http11Dio.get<ResponseBody>(
+          url.http2https,
+          options: Options(
+            headers: {
+              if (rangeStart != null) 'range': 'bytes=$rangeStart-',
+            },
+            responseType: ResponseType.stream,
+            validateStatus: (status) =>
+                status == 200 || status == 206 || status == 416,
+          ),
+          cancelToken: _cancelToken,
+        );
+
     try {
-      response = await Request.http11Dio.get<ResponseBody>(
-        url.http2https,
-        options: Options(
-          headers: {'range': 'bytes=$received-'},
-          responseType: ResponseType.stream,
-          validateStatus: (status) =>
-              status != null &&
-              (status == 416 || (status >= 200 && status < 300)),
-        ),
-        cancelToken: _cancelToken,
+      var response = await request(received);
+      var data = response.data;
+      if (data == null) {
+        throw StateError('Download response has no body');
+      }
+      var plan = DownloadResumePolicy.fromResponse(
+        statusCode: response.statusCode!,
+        localLength: received,
+        contentLength: data.contentLength,
+        contentRange: response.headers.value('content-range'),
       );
-    } on DioException catch (e) {
-      await onError(e, delete: true);
-      return;
-    }
-    final data = response.data!;
-    final contentLength = data.contentLength + received;
 
-    if (received == 0) {
-      onReceiveProgress?.call(0, contentLength);
-    }
+      if (plan.mode == DownloadWriteMode.retryWithoutRange) {
+        await data.stream.drain<void>();
+        response = await request();
+        data = response.data;
+        if (data == null) {
+          throw StateError('Download retry response has no body');
+        }
+        plan = DownloadResumePolicy.fromResponse(
+          statusCode: response.statusCode!,
+          localLength: 0,
+          contentLength: data.contentLength,
+          contentRange: response.headers.value('content-range'),
+        );
+        if (plan.mode == DownloadWriteMode.retryWithoutRange) {
+          throw StateError('Server rejected a full download request');
+        }
+      }
 
-    int? last;
-    try {
+      if (plan.mode == DownloadWriteMode.complete) {
+        await data.stream.drain<void>();
+        plan.validateCompletedLength(received);
+        onReceiveProgress?.call(received, plan.expectedLength ?? 0);
+        _status = DownloadStatus.completed;
+        onDone();
+        return;
+      }
+
+      if (plan.mode == DownloadWriteMode.overwrite) {
+        received = 0;
+      }
+      sink = file.openWrite(
+        mode: plan.mode == DownloadWriteMode.append
+            ? FileMode.writeOnlyAppend
+            : FileMode.writeOnly,
+      );
+      final contentLength = plan.expectedLength ?? 0;
+      if (received == 0) {
+        onReceiveProgress?.call(0, contentLength);
+      }
+
+      int? last;
       await for (final chunk in data.stream) {
         sink.add(chunk);
         received += chunk.length;
@@ -92,10 +133,13 @@ class DownloadManager {
         }
       }
       await sink.close();
+      sink = null;
+      plan.validateCompletedLength(received);
+      onReceiveProgress?.call(received, contentLength);
       _status = DownloadStatus.completed;
       onDone();
     } catch (e) {
-      await onError(e);
+      await onError(e, delete: e is FormatException);
       return;
     }
   }

--- a/lib/services/download/download_resume.dart
+++ b/lib/services/download/download_resume.dart
@@ -1,0 +1,88 @@
+enum DownloadWriteMode { append, overwrite, complete, retryWithoutRange }
+
+final class DownloadResumePlan {
+  const DownloadResumePlan(this.mode, this.expectedLength);
+
+  final DownloadWriteMode mode;
+  final int? expectedLength;
+
+  void validateCompletedLength(int actualLength) {
+    if (expectedLength case final expected? when expected != actualLength) {
+      throw StateError(
+        'Incomplete download: expected $expected bytes, got $actualLength',
+      );
+    }
+  }
+}
+
+abstract final class DownloadResumePolicy {
+  static final RegExp _partialRange = RegExp(
+    r'^bytes\s+(\d+)-(\d+)/(\d+)$',
+    caseSensitive: false,
+  );
+  static final RegExp _unsatisfiedRange = RegExp(
+    r'^bytes\s+\*/(\d+)$',
+    caseSensitive: false,
+  );
+
+  static DownloadResumePlan fromResponse({
+    required int statusCode,
+    required int localLength,
+    required int contentLength,
+    required String? contentRange,
+  }) {
+    switch (statusCode) {
+      case 200:
+        return DownloadResumePlan(
+          DownloadWriteMode.overwrite,
+          contentLength >= 0 ? contentLength : null,
+        );
+      case 206:
+        final match = contentRange == null
+            ? null
+            : _partialRange.firstMatch(contentRange.trim());
+        if (match == null) {
+          throw const FormatException('Missing or invalid Content-Range');
+        }
+        final start = int.parse(match.group(1)!);
+        final end = int.parse(match.group(2)!);
+        final total = int.parse(match.group(3)!);
+        if (start != localLength || end < start || end >= total) {
+          throw FormatException(
+            'Unexpected Content-Range: $contentRange for $localLength bytes',
+          );
+        }
+        final responseLength = end - start + 1;
+        if (contentLength >= 0 && contentLength != responseLength) {
+          throw FormatException(
+            'Content-Length $contentLength does not match range length '
+            '$responseLength',
+          );
+        }
+        return DownloadResumePlan(
+          localLength == 0
+              ? DownloadWriteMode.overwrite
+              : DownloadWriteMode.append,
+          total,
+        );
+      case 416:
+        final match = contentRange == null
+            ? null
+            : _unsatisfiedRange.firstMatch(contentRange.trim());
+        if (match == null) {
+          throw const FormatException(
+            'Missing or invalid unsatisfied Content-Range',
+          );
+        }
+        final total = int.parse(match.group(1)!);
+        return DownloadResumePlan(
+          total == localLength
+              ? DownloadWriteMode.complete
+              : DownloadWriteMode.retryWithoutRange,
+          total,
+        );
+      default:
+        throw StateError('Unexpected download status: $statusCode');
+    }
+  }
+}

--- a/test/services/download/download_resume_test.dart
+++ b/test/services/download/download_resume_test.dart
@@ -1,0 +1,76 @@
+import 'package:PiliPlus/services/download/download_resume.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('DownloadResumePolicy', () {
+    test('overwrites when a server ignores a range request', () {
+      final plan = DownloadResumePolicy.fromResponse(
+        statusCode: 200,
+        localLength: 100,
+        contentLength: 500,
+        contentRange: null,
+      );
+
+      expect(plan.mode, DownloadWriteMode.overwrite);
+      expect(plan.expectedLength, 500);
+    });
+
+    test('appends only an exactly matching partial response', () {
+      final plan = DownloadResumePolicy.fromResponse(
+        statusCode: 206,
+        localLength: 100,
+        contentLength: 400,
+        contentRange: 'bytes 100-499/500',
+      );
+
+      expect(plan.mode, DownloadWriteMode.append);
+      expect(plan.expectedLength, 500);
+    });
+
+    test('rejects a partial response starting at the wrong offset', () {
+      expect(
+        () => DownloadResumePolicy.fromResponse(
+          statusCode: 206,
+          localLength: 100,
+          contentLength: 500,
+          contentRange: 'bytes 0-499/500',
+        ),
+        throwsFormatException,
+      );
+    });
+
+    test('accepts 416 only when the local file is already complete', () {
+      final complete = DownloadResumePolicy.fromResponse(
+        statusCode: 416,
+        localLength: 500,
+        contentLength: 0,
+        contentRange: 'bytes */500',
+      );
+      final stale = DownloadResumePolicy.fromResponse(
+        statusCode: 416,
+        localLength: 600,
+        contentLength: 0,
+        contentRange: 'bytes */500',
+      );
+
+      expect(complete.mode, DownloadWriteMode.complete);
+      expect(stale.mode, DownloadWriteMode.retryWithoutRange);
+    });
+
+    test('rejects mismatched response and final lengths', () {
+      expect(
+        () => DownloadResumePolicy.fromResponse(
+          statusCode: 206,
+          localLength: 100,
+          contentLength: 399,
+          contentRange: 'bytes 100-499/500',
+        ),
+        throwsFormatException,
+      );
+
+      const plan = DownloadResumePlan(DownloadWriteMode.append, 500);
+      expect(() => plan.validateCompletedLength(499), throwsStateError);
+      expect(() => plan.validateCompletedLength(500), returnsNormally);
+    });
+  });
+}


### PR DESCRIPTION
### 现象

断点续传在收到任意 2xx 或 416 后直接以追加模式写入，并在流结束时标记完成。服务器忽略 Range、返回错误区间或提前截断时，可能拼接并完成损坏媒体。

### 方案

- 仅接受 200 / 206 / 416，并在打开文件前生成写入计划
- 206 必须有与本地长度精确衔接的 `Content-Range`，同时校验响应段长度
- 200 视为服务器忽略 Range，截断本地文件后完整写入
- 416 仅在服务端总长等于本地长度时视为完成，否则无 Range 重试
- 流结束后校验最终文件长度，截断流不再标记完成

### 验证

- `flutter test --no-pub test/services/download/download_resume_test.dart`（5 组状态机场景）
- `flutter analyze --no-pub lib/services/download/download_resume.dart lib/services/download/download_manager.dart test/services/download/download_resume_test.dart`