### PR TITLE
perf: 将直播压缩帧解析移出 UI isolate

### DIFF
--- a/lib/tcp/live.dart
+++ b/lib/tcp/live.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:PiliPlus/services/logger.dart';
-import 'package:brotli/brotli.dart';
+import 'package:PiliPlus/tcp/live_frame_decoder.dart';
 import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
@@ -48,7 +47,7 @@ class PackageHeaderRes extends PackageHeader {
   final int headerSize;
 
   static PackageHeaderRes? fromBytesData(Uint8List data) {
-    if (data.length < 10) {
+    if (data.length < 16) {
       logger.w('数据不足以解析PackageHeader');
       return null;
     }
@@ -59,6 +58,11 @@ class PackageHeaderRes extends PackageHeader {
     final protocolVer = byteData.getUint16(6, Endian.big);
     final operationCode = byteData.getUint32(8, Endian.big);
     final seq = byteData.getUint32(12, Endian.big);
+
+    if (headerSize < 16 || totalSize < headerSize || totalSize > data.length) {
+      logger.w('PackageHeader尺寸无效');
+      return null;
+    }
 
     return PackageHeaderRes(
       totalSize: totalSize,
@@ -157,6 +161,7 @@ class LiveMessageStream {
   WebSocketChannel? _channel;
   StreamSubscription? _socketSubscription;
   Timer? _timer;
+  final LiveFrameDecoderWorker _decoder = LiveFrameDecoderWorker();
   final String logTag = "LiveStreamService";
 
   Future<void> init() async {
@@ -210,27 +215,6 @@ class LiveMessageStream {
     }
   }
 
-  @pragma('vm:notify-debugger-on-exception')
-  void _processingData(List<int> value) {
-    try {
-      final Uint8List data = value is Uint8List
-          ? value
-          : Uint8List.fromList(value);
-      final subHeader = PackageHeaderRes.fromBytesData(data);
-      if (subHeader != null) {
-        final msgBody = utf8.decode(
-          data.sublist(subHeader.headerSize, subHeader.totalSize),
-        );
-        for (final f in _eventListeners) {
-          f(jsonDecode(msgBody));
-        }
-        if (subHeader.totalSize < data.length) {
-          _processingData(data.sublist(subHeader.totalSize));
-        }
-      }
-    } catch (_) {}
-  }
-
   Future<void> _heartBeat() async {
     if (!_active) {
       if (kDebugMode) logger.i("$logTag init heartBeat inactive $hashCode");
@@ -269,33 +253,30 @@ class LiveMessageStream {
 
   @pragma('vm:notify-debugger-on-exception')
   void onData(dynamic data) {
-    final header = PackageHeaderRes.fromBytesData(data as Uint8List);
-    if (header != null) {
-      List<int> decompressedData = const [];
-      //心跳包回复不用处理
-      if (header.operationCode == 3) return;
-      if (header.operationCode == 8) {
-        _heartBeat();
+    if (data is! List<int>) return;
+    final bytes = data is Uint8List ? data : Uint8List.fromList(data);
+    _socketSubscription?.pause();
+    _decodeFrame(bytes).whenComplete(() {
+      if (_active) _socketSubscription?.resume();
+    });
+  }
+
+  Future<void> _decodeFrame(Uint8List data) async {
+    try {
+      final result = await _decoder.decode(data);
+      if (!_active) return;
+      if (result.authenticated) {
+        unawaited(_heartBeat());
       }
-      try {
-        switch (header.protocolVer) {
-          case 0:
-          case 1:
-            _processingData(data);
-            return;
-          case 2:
-            decompressedData = ZLibDecoder().convert(
-              Uint8List.sublistView(data, 0x10),
-            );
-            break;
-          case 3:
-            decompressedData = const BrotliDecoder().convert(
-              Uint8List.sublistView(data, 0x10),
-            );
-          //debugPrint('Body: ${utf8.decode()}');
+      for (final message in result.messages) {
+        for (final listener in List.of(_eventListeners)) {
+          listener(message);
         }
-        _processingData(decompressedData);
-      } catch (_) {}
+      }
+    } catch (error, stackTrace) {
+      if (kDebugMode) {
+        logger.w('$logTag frame decode failed: $error\n$stackTrace');
+      }
     }
   }
 
@@ -304,6 +285,7 @@ class LiveMessageStream {
     if (kDebugMode) logger.i("$logTag close $hashCode");
     _timer?.cancel();
     _timer = null;
+    _decoder.close();
     _eventListeners.clear();
     _socketSubscription?.cancel();
     _socketSubscription = null;

--- a/lib/tcp/live_frame_decoder.dart
+++ b/lib/tcp/live_frame_decoder.dart
@@ -1,0 +1,266 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import 'package:brotli/brotli.dart';
+
+final class LiveFrameDecodeResult {
+  const LiveFrameDecodeResult({
+    required this.messages,
+    required this.authenticated,
+  });
+
+  final List<dynamic> messages;
+  final bool authenticated;
+}
+
+final class LiveFrameDecoder {
+  static const int headerSize = 16;
+  static const int maxFrameBytes = 16 * 1024 * 1024;
+  static const int maxDecodedBytes = 32 * 1024 * 1024;
+  static const int maxPackets = 10000;
+  static const int maxCompressionDepth = 3;
+
+  static LiveFrameDecodeResult decode(Uint8List data) {
+    if (data.length > maxFrameBytes) {
+      throw const FormatException('Live frame exceeds $maxFrameBytes bytes');
+    }
+
+    final messages = <dynamic>[];
+    final cursors = <_FrameCursor>[_FrameCursor(data, 0)];
+    var authenticated = false;
+    var decodedBytes = data.length;
+    var packetCount = 0;
+
+    while (cursors.isNotEmpty) {
+      final cursor = cursors.last;
+      if (cursor.offset == cursor.data.length) {
+        cursors.removeLast();
+        continue;
+      }
+      if (cursor.data.length - cursor.offset < headerSize) {
+        throw const FormatException('Truncated live package header');
+      }
+      if (++packetCount > maxPackets) {
+        throw const FormatException('Live frame exceeds $maxPackets packages');
+      }
+
+      final header = ByteData.sublistView(
+        cursor.data,
+        cursor.offset,
+        cursor.offset + headerSize,
+      );
+      final totalSize = header.getUint32(0, Endian.big);
+      final packageHeaderSize = header.getUint16(4, Endian.big);
+      final protocolVersion = header.getUint16(6, Endian.big);
+      final operationCode = header.getUint32(8, Endian.big);
+      if (packageHeaderSize < headerSize ||
+          totalSize < packageHeaderSize ||
+          totalSize > cursor.data.length - cursor.offset) {
+        throw FormatException(
+          'Invalid live package size: total=$totalSize, '
+          'header=$packageHeaderSize',
+        );
+      }
+
+      final bodyStart = cursor.offset + packageHeaderSize;
+      final packageEnd = cursor.offset + totalSize;
+      final body = Uint8List.sublistView(
+        cursor.data,
+        bodyStart,
+        packageEnd,
+      );
+      cursor.offset = packageEnd;
+
+      if (operationCode == 3) {
+        continue;
+      }
+      if (operationCode == 8) {
+        authenticated = true;
+      }
+
+      switch (protocolVersion) {
+        case 0:
+        case 1:
+          if (body.isNotEmpty) {
+            messages.add(jsonDecode(utf8.decode(body)));
+          }
+        case 2:
+        case 3:
+          if (cursor.depth >= maxCompressionDepth) {
+            throw const FormatException(
+              'Live frame exceeds compression depth $maxCompressionDepth',
+            );
+          }
+          final List<int> decoded = protocolVersion == 2
+              ? ZLibDecoder().convert(body)
+              : const BrotliDecoder().convert(body);
+          decodedBytes += decoded.length;
+          if (decodedBytes > maxDecodedBytes) {
+            throw const FormatException(
+              'Decoded live frame exceeds $maxDecodedBytes bytes',
+            );
+          }
+          cursors.add(
+            _FrameCursor(
+              decoded is Uint8List ? decoded : Uint8List.fromList(decoded),
+              cursor.depth + 1,
+            ),
+          );
+        default:
+          throw FormatException(
+            'Unsupported live protocol version: $protocolVersion',
+          );
+      }
+    }
+
+    return LiveFrameDecodeResult(
+      messages: messages,
+      authenticated: authenticated,
+    );
+  }
+}
+
+final class _FrameCursor {
+  _FrameCursor(this.data, this.depth);
+
+  final Uint8List data;
+  final int depth;
+  int offset = 0;
+}
+
+final class LiveFrameDecoderWorker {
+  ReceivePort? _receivePort;
+  ReceivePort? _exitPort;
+  ReceivePort? _errorPort;
+  Isolate? _isolate;
+  SendPort? _sendPort;
+  Future<void>? _starting;
+  Completer<void>? _ready;
+  final Map<int, Completer<LiveFrameDecodeResult>> _pending = {};
+  int _nextId = 0;
+  bool _closed = false;
+
+  Future<LiveFrameDecodeResult> decode(Uint8List data) async {
+    if (_closed) throw StateError('Live frame decoder is closed');
+    await (_starting ??= _start());
+    if (_closed || _sendPort == null) {
+      throw StateError('Live frame decoder is closed');
+    }
+
+    final id = _nextId++;
+    final completer = Completer<LiveFrameDecodeResult>();
+    _pending[id] = completer;
+    _sendPort!.send([
+      id,
+      TransferableTypedData.fromList([data]),
+    ]);
+    return completer.future;
+  }
+
+  Future<void> _start() async {
+    final ready = _ready = Completer<void>();
+    _receivePort = ReceivePort()
+      ..listen((message) {
+        if (message is SendPort) {
+          _sendPort = message;
+          if (!ready.isCompleted) ready.complete();
+          return;
+        }
+        final response = message as List<dynamic>;
+        final completer = _pending.remove(response[0] as int);
+        if (completer == null) return;
+        if (response[1] as bool) {
+          completer.complete(
+            LiveFrameDecodeResult(
+              messages: List<dynamic>.from(response[2] as List),
+              authenticated: response[3] as bool,
+            ),
+          );
+        } else {
+          completer.completeError(
+            FormatException(response[2] as String),
+            StackTrace.fromString(response[3] as String),
+          );
+        }
+      });
+    _exitPort = ReceivePort()..listen((_) => _failPending('exited'));
+    _errorPort = ReceivePort()..listen((_) => _failPending('failed'));
+    _isolate = await Isolate.spawn(
+      _liveFrameDecoderEntry,
+      _receivePort!.sendPort,
+      debugName: 'PiliPlus live frame decoder',
+      onExit: _exitPort!.sendPort,
+      onError: _errorPort!.sendPort,
+      errorsAreFatal: true,
+    );
+    if (_closed) {
+      _isolate?.kill(priority: Isolate.immediate);
+      if (!ready.isCompleted) ready.complete();
+      return;
+    }
+    await ready.future;
+    _ready = null;
+  }
+
+  void _failPending(String reason) {
+    final error = StateError('Live frame decoder $reason');
+    final ready = _ready;
+    if (!_closed && ready != null && !ready.isCompleted) {
+      ready.completeError(error);
+    }
+    for (final completer in _pending.values) {
+      if (!completer.isCompleted) completer.completeError(error);
+    }
+    _pending.clear();
+    if (!_closed) {
+      _isolate = null;
+      _sendPort = null;
+      _starting = null;
+      _ready = null;
+      _receivePort?.close();
+      _receivePort = null;
+      _exitPort?.close();
+      _exitPort = null;
+      _errorPort?.close();
+      _errorPort = null;
+    }
+  }
+
+  void close() {
+    if (_closed) return;
+    _closed = true;
+    final ready = _ready;
+    if (ready != null && !ready.isCompleted) ready.complete();
+    _failPending('closed');
+    _isolate?.kill(priority: Isolate.immediate);
+    _isolate = null;
+    _sendPort = null;
+    _receivePort?.close();
+    _receivePort = null;
+    _exitPort?.close();
+    _exitPort = null;
+    _errorPort?.close();
+    _errorPort = null;
+  }
+}
+
+void _liveFrameDecoderEntry(SendPort mainPort) {
+  final receivePort = ReceivePort();
+  mainPort.send(receivePort.sendPort);
+  receivePort.listen((message) {
+    final request = message as List<dynamic>;
+    final id = request[0] as int;
+    try {
+      final data = (request[1] as TransferableTypedData)
+          .materialize()
+          .asUint8List();
+      final result = LiveFrameDecoder.decode(data);
+      mainPort.send([id, true, result.messages, result.authenticated]);
+    } catch (error, stackTrace) {
+      mainPort.send([id, false, error.toString(), stackTrace.toString()]);
+    }
+  });
+}

--- a/test/tcp/live_frame_decoder_test.dart
+++ b/test/tcp/live_frame_decoder_test.dart
@@ -1,0 +1,128 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:PiliPlus/tcp/live_frame_decoder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Uint8List _packet({
+  required int protocol,
+  required int operation,
+  required List<int> body,
+}) {
+  final header = ByteData(LiveFrameDecoder.headerSize)
+    ..setUint32(0, LiveFrameDecoder.headerSize + body.length, Endian.big)
+    ..setUint16(4, LiveFrameDecoder.headerSize, Endian.big)
+    ..setUint16(6, protocol, Endian.big)
+    ..setUint32(8, operation, Endian.big)
+    ..setUint32(12, 1, Endian.big);
+  return Uint8List.fromList([...header.buffer.asUint8List(), ...body]);
+}
+
+void main() {
+  test('decodes concatenated packages in order without tail copies', () {
+    final data = Uint8List.fromList([
+      ..._packet(
+        protocol: 0,
+        operation: 5,
+        body: utf8.encode('{"cmd":"first"}'),
+      ),
+      ..._packet(
+        protocol: 0,
+        operation: 5,
+        body: utf8.encode('{"cmd":"second"}'),
+      ),
+    ]);
+
+    final result = LiveFrameDecoder.decode(data);
+
+    expect(result.messages, [
+      {'cmd': 'first'},
+      {'cmd': 'second'},
+    ]);
+  });
+
+  test('iterates over thousands of concatenated packages', () {
+    final builder = BytesBuilder(copy: false);
+    for (var index = 0; index < 2000; index++) {
+      builder.add(
+        _packet(
+          protocol: 0,
+          operation: 5,
+          body: utf8.encode('{"index":$index}'),
+        ),
+      );
+    }
+
+    final result = LiveFrameDecoder.decode(builder.takeBytes());
+
+    expect(result.messages, hasLength(2000));
+    expect(result.messages.first, {'index': 0});
+    expect(result.messages.last, {'index': 1999});
+  });
+
+  test('decodes compressed nested packages', () {
+    final nested = _packet(
+      protocol: 0,
+      operation: 5,
+      body: utf8.encode('{"cmd":"compressed"}'),
+    );
+    final data = _packet(
+      protocol: 2,
+      operation: 5,
+      body: ZLibEncoder().convert(nested),
+    );
+
+    final result = LiveFrameDecoder.decode(data);
+
+    expect(result.messages, [
+      {'cmd': 'compressed'},
+    ]);
+  });
+
+  test('rejects truncated and invalid package sizes', () {
+    expect(
+      () => LiveFrameDecoder.decode(Uint8List(15)),
+      throwsFormatException,
+    );
+
+    final invalid = _packet(
+      protocol: 0,
+      operation: 5,
+      body: utf8.encode('{}'),
+    );
+    ByteData.sublistView(invalid).setUint32(0, 1024, Endian.big);
+    expect(() => LiveFrameDecoder.decode(invalid), throwsFormatException);
+  });
+
+  test('persistent worker transfers and decodes frames off-isolate', () async {
+    final worker = LiveFrameDecoderWorker();
+    addTearDown(worker.close);
+    final data = _packet(
+      protocol: 1,
+      operation: 8,
+      body: utf8.encode('{"code":0}'),
+    );
+
+    final result = await worker.decode(data);
+
+    expect(result.authenticated, isTrue);
+    expect(result.messages, [
+      {'code': 0},
+    ]);
+  });
+
+  test('closing during worker startup completes pending decode', () async {
+    final worker = LiveFrameDecoderWorker();
+    final data = _packet(
+      protocol: 0,
+      operation: 5,
+      body: utf8.encode('{}'),
+    );
+
+    final decoding = worker.decode(data);
+    worker.close();
+
+    await expectLater(decoding, throwsStateError);
+  });
+}


### PR DESCRIPTION
### 现象

直播 WebSocket 在 UI isolate 同步执行 zlib/brotli 解压、UTF-8 与 JSON 解析；多包数据通过递归 `sublist` 处理，每次复制剩余尾部，包数增加时接近二次复制并造成界面卡顿。

### 方案

- 新增长驻解析 isolate，使用 `TransferableTypedData` 移交帧数据
- 解析期间暂停 WebSocket 订阅，保持顺序并形成背压，避免任务/isolate 无界堆积
- 用显式游标栈线性扫描外层和压缩嵌套包，不再递归复制尾部
- 限制单帧、解压总量、包数和压缩层级，并严格校验 16 字节头及包尺寸
- worker 异常可失败当前请求并在下一帧重建，关闭竞态不会留下挂起 Future

### 验证

- `flutter test --no-pub test/tcp/live_frame_decoder_test.dart`（6 个解析/生命周期场景）
- `flutter analyze --no-pub lib/tcp/live_frame_decoder.dart lib/tcp/live.dart test/tcp/live_frame_decoder_test.dart`