### PR TITLE
perf: 限制直播聊天消息保留量

### DIFF
--- a/lib/pages/live_room/controller.dart
+++ b/lib/pages/live_room/controller.dart
@@ -20,6 +20,7 @@ import 'package:PiliPlus/models_new/live/live_room_play_info/stream.dart';
 import 'package:PiliPlus/models_new/live/live_superchat/item.dart';
 import 'package:PiliPlus/pages/common/publish/publish_route.dart';
 import 'package:PiliPlus/pages/danmaku/danmaku_model.dart';
+import 'package:PiliPlus/pages/live_room/live_message_buffer.dart';
 import 'package:PiliPlus/pages/live_room/send_danmaku/view.dart';
 import 'package:PiliPlus/pages/video/widgets/header_control.dart';
 import 'package:PiliPlus/plugin/pl_player/controller.dart';
@@ -47,6 +48,9 @@ import 'package:get/get.dart';
 import 'package:material_ui/material_ui.dart';
 
 class LiveRoomController extends GetxController {
+  static const maxRetainedMessages = 2000;
+  static const _messageTrimCount = 256;
+
   LiveRoomController(this.heroTag);
   final String heroTag;
 
@@ -102,9 +106,14 @@ class LiveRoomController extends GetxController {
   // dm
   LiveDmInfoData? dmInfo;
   List<RichTextItem>? savedDanmaku;
-  int builtLength = 0;
-  final messages = <dynamic>[].obs;
-  bool get shouldRefresh => builtLength != messages.length;
+  final messages = LiveMessageList<dynamic>();
+  late final LiveMessageBuffer<dynamic> _messageBuffer = LiveMessageBuffer(
+    messages.nonReactiveValues,
+    maxLength: maxRetainedMessages,
+    trimCount: _messageTrimCount,
+  );
+  bool get shouldRefresh => _messageBuffer.shouldRefresh;
+  int get messageCountForBuild => _messageBuffer.markBuilt();
   late final fsSC = Rxn<SuperChatItem>();
   late final RxList<SuperChatItem> superChatMsg = <SuperChatItem>[].obs;
   final disableAutoScroll = false.obs;
@@ -394,7 +403,8 @@ class LiveRoomController extends GetxController {
     final res = await LiveHttp.liveRoomDmPrefetch(roomId: roomId);
     if (res case Success(:final response)) {
       if (response != null && response.isNotEmpty) {
-        messages.addAll(response);
+        _messageBuffer.addAll(response);
+        messages.refresh();
         scrollToBottom();
       }
     } else {
@@ -465,7 +475,8 @@ class LiveRoomController extends GetxController {
     cancelLiveTimer();
     savedDanmaku?.clear();
     savedDanmaku = null;
-    messages.clear();
+    _messageBuffer.clear();
+    messages.refresh();
     if (showSuperChat) {
       superChatMsg.clear();
       fsSC.value = null;
@@ -512,13 +523,14 @@ class LiveRoomController extends GetxController {
         danmakuController?.addDanmaku(item);
       }
       if (autoScroll && !disableAutoScroll.value) {
-        messages.add(msg);
+        _messageBuffer.add(msg);
+        messages.refresh();
         scrollToBottom();
         return;
       }
     }
 
-    messages.addOnly(msg);
+    _messageBuffer.add(msg);
   }
 
   @pragma('vm:notify-debugger-on-exception')

--- a/lib/pages/live_room/live_message_buffer.dart
+++ b/lib/pages/live_room/live_message_buffer.dart
@@ -1,0 +1,72 @@
+import 'package:get/get.dart';
+
+final class LiveMessageList<E> extends RxList<E> {
+  List<E> get nonReactiveValues => value;
+}
+
+final class LiveMessageBuffer<E> {
+  LiveMessageBuffer(
+    this.values, {
+    required this.maxLength,
+    required this.trimCount,
+  }) {
+    if (maxLength <= 0) {
+      throw ArgumentError.value(maxLength, 'maxLength');
+    }
+    if (trimCount <= 0 || trimCount > maxLength) {
+      throw ArgumentError.value(trimCount, 'trimCount');
+    }
+  }
+
+  final List<E> values;
+  final int maxLength;
+  final int trimCount;
+  int _revision = 0;
+  int _builtRevision = 0;
+
+  bool get shouldRefresh => _revision != _builtRevision;
+
+  int markBuilt() {
+    _builtRevision = _revision;
+    return values.length;
+  }
+
+  void add(E value) {
+    values.add(value);
+    _trim();
+    _revision += 1;
+  }
+
+  void addAll(Iterable<E> newValues) {
+    if (newValues is List<E> && newValues.length >= maxLength) {
+      final retained = List<E>.of(
+        newValues.getRange(newValues.length - maxLength, newValues.length),
+      );
+      values
+        ..clear()
+        ..addAll(retained);
+    } else {
+      var added = false;
+      for (final value in newValues) {
+        values.add(value);
+        added = true;
+      }
+      if (!added) return;
+      _trim();
+    }
+    _revision += 1;
+  }
+
+  void clear() {
+    if (values.isEmpty) return;
+    values.clear();
+    _revision += 1;
+  }
+
+  void _trim() {
+    final overflow = values.length - maxLength;
+    if (overflow <= 0) return;
+    final removeCount = overflow > trimCount ? overflow : trimCount;
+    values.removeRange(0, removeCount);
+  }
+}

--- a/lib/pages/live_room/widgets/chat_panel.dart
+++ b/lib/pages/live_room/widgets/chat_panel.dart
@@ -54,8 +54,7 @@ class LiveRoomChatPanel extends StatelessWidget {
             padding: const EdgeInsets.symmetric(horizontal: 12),
             controller: liveRoomController.scrollController,
             separatorBuilder: (_, _) => const SizedBox(height: 8),
-            itemCount: liveRoomController.builtLength =
-                liveRoomController.messages.length,
+            itemCount: liveRoomController.messageCountForBuild,
             physics: platformClampingPhysics,
             itemBuilder: (_, index) {
               final item = liveRoomController.messages[index];

--- a/test/pages/live_room/live_message_buffer_test.dart
+++ b/test/pages/live_room/live_message_buffer_test.dart
@@ -1,0 +1,61 @@
+import 'package:PiliPlus/pages/live_room/live_message_buffer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('retains only the newest values from a large batch', () {
+    final values = <int>[];
+    LiveMessageBuffer(
+      values,
+      maxLength: 5,
+      trimCount: 2,
+    ).addAll(List.generate(10, (index) => index));
+
+    expect(values, [5, 6, 7, 8, 9]);
+    expect(values.length, lessThanOrEqualTo(5));
+  });
+
+  test('tracks replacement changes even when length stays constant', () {
+    final values = <int>[1, 2, 3];
+    final buffer = LiveMessageBuffer(values, maxLength: 3, trimCount: 1);
+    expect(buffer.markBuilt(), 3);
+    expect(buffer.shouldRefresh, isFalse);
+
+    buffer.add(4);
+
+    expect(values, [2, 3, 4]);
+    expect(values, hasLength(3));
+    expect(buffer.shouldRefresh, isTrue);
+    expect(buffer.markBuilt(), 3);
+    expect(buffer.shouldRefresh, isFalse);
+  });
+
+  test('trims single additions in chunks under the hard limit', () {
+    final values = List.generate(5, (index) => index);
+    LiveMessageBuffer(values, maxLength: 5, trimCount: 2).add(5);
+
+    expect(values, [2, 3, 4, 5]);
+    expect(values.length, lessThanOrEqualTo(5));
+  });
+
+  test('non-reactive mutation waits for an explicit refresh', () async {
+    final messages = LiveMessageList<int>();
+    final buffer = LiveMessageBuffer(
+      messages.nonReactiveValues,
+      maxLength: 3,
+      trimCount: 1,
+    );
+    var notifications = 0;
+    final subscription = messages.listen((_) => notifications += 1);
+    addTearDown(subscription.cancel);
+    await pumpEventQueue();
+    final initialNotifications = notifications;
+
+    buffer.add(1);
+    await pumpEventQueue();
+    expect(notifications, initialNotifications);
+
+    messages.refresh();
+    await pumpEventQueue();
+    expect(notifications, initialNotifications + 1);
+  });
+}


### PR DESCRIPTION
### 现象

直播聊天 `messages` 在整个会话中只增不减，长时间观看或高流量直播间会持续占用内存。简单截断后列表长度会保持不变，原有按长度判断“是否需要刷新”的逻辑也会漏掉新消息。

### 方案

- 将聊天历史限制为最多 2000 条
- 达到上限后分块淘汰 256 条旧消息，避免每条新消息都搬移整张列表
- 用内容 revision 代替列表长度判断未展示更新，等长替换也能在用户回到底部时刷新
- 用户上滑时仍只非响应式更新缓冲区，自动滚动和显式刷新语义保持不变
- 预取消息同样经过统一上限

### 验证

- `flutter test --no-pub test/pages/live_room/live_message_buffer_test.dart`（4 个上限/刷新场景）
- `flutter analyze --no-pub lib/pages/live_room/live_message_buffer.dart lib/pages/live_room/controller.dart lib/pages/live_room/widgets/chat_panel.dart test/pages/live_room/live_message_buffer_test.dart`