### PR TITLE
fix(video): 修复部分视频画质列表异常及无法播放问题

### DIFF
--- a/lib/http/download.dart
+++ b/lib/http/download.dart
@@ -41,17 +41,11 @@ abstract final class DownloadHttp {
     if (res case Success(:final response)) {
       final dash = response.dash;
       if (dash != null) {
-        final videoList = dash.video!;
-        final curHighestVideoQa = videoList.first.quality.code;
+        final videoList = dash.video;
         final preferVideoQa = entry.preferedVideoQuality;
-        int targetVideoQa = curHighestVideoQa;
-        if (response.acceptQuality?.isNotEmpty == true &&
-            preferVideoQa <= curHighestVideoQa) {
-          // 如果预设的画质低于当前最高
-          targetVideoQa = response.acceptQuality!.findClosestTarget(
-            (e) => e <= preferVideoQa,
-            (a, b) => a > b ? a : b,
-          );
+        final targetVideoQa = response.findAvailableVideoQuality(preferVideoQa);
+        if (videoList == null || videoList.isEmpty || targetVideoQa == null) {
+          throw StateError('视频资源不存在');
         }
 
         /// 优先顺序 设置中指定解码格式 -> 当前可选的首个解码格式

--- a/lib/http/download.dart
+++ b/lib/http/download.dart
@@ -41,12 +41,9 @@ abstract final class DownloadHttp {
     if (res case Success(:final response)) {
       final dash = response.dash;
       if (dash != null) {
-        final videoList = dash.video;
-        final preferVideoQa = entry.preferedVideoQuality;
-        final targetVideoQa = response.findAvailableVideoQuality(preferVideoQa);
-        if (videoList == null || videoList.isEmpty || targetVideoQa == null) {
-          throw StateError('视频资源不存在');
-        }
+        final targetVideoQa = response.findAvailableVideoQuality(
+          entry.preferedVideoQuality,
+        );
 
         /// 优先顺序 设置中指定解码格式 -> 当前可选的首个解码格式
         final supportFormats = response.supportFormats!;
@@ -70,7 +67,7 @@ abstract final class DownloadHttp {
               VideoQuality.fromCode(targetVideoQa).desc;
 
         /// 取出符合当前画质的videoList
-        final videosList = videoList
+        final videosList = dash.video!
             .where((e) => e.quality.code == targetVideoQa)
             .toList();
 
@@ -83,7 +80,7 @@ abstract final class DownloadHttp {
         final videoUrl = VideoUtils.getCdnUrl(videoDash.playUrls);
 
         final Type2File videoFile = Type2File(
-          id: videoDash.id!,
+          id: videoDash.id,
           baseUrl: videoUrl,
           bandwidth: videoDash.bandWidth!,
           codecid: videoDash.codecid!,
@@ -100,7 +97,7 @@ abstract final class DownloadHttp {
         if (audioDashList != null && audioDashList.isNotEmpty) {
           final preferAudioQa = Pref.defaultAudioQa;
           final List<int> audioIds = audioDashList
-              .map((map) => map.id!)
+              .map((map) => map.id)
               .toList();
           int closestNumber = audioIds.findClosestTarget(
             (e) => e <= preferAudioQa,
@@ -120,7 +117,7 @@ abstract final class DownloadHttp {
           );
           audioFileList = [
             Type2File(
-              id: audioDash.id!,
+              id: audioDash.id,
               baseUrl: audioUrl,
               bandwidth: audioDash.bandWidth!,
               codecid: audioDash.codecid!,

--- a/lib/http/video.dart
+++ b/lib/http/video.dart
@@ -201,7 +201,7 @@ abstract final class VideoHttp {
     int? avid,
     String? bvid,
     required int cid,
-    int? qn,
+    required int qn,
     dynamic epid,
     dynamic seasonId,
     required bool tryLook,
@@ -217,7 +217,7 @@ abstract final class VideoHttp {
       'ep_id': ?epid,
       'season_id': ?seasonId,
       'cid': cid,
-      'qn': qn ?? 80,
+      'qn': qn,
       // 获取所有格式的视频
       'fnval': 4048,
       'fourk': 1,

--- a/lib/models/video/play/url.dart
+++ b/lib/models/video/play/url.dart
@@ -58,44 +58,32 @@ class PlayUrlModel {
   Language? language;
   List<SegmentItemModel>? clipInfoList;
 
-  Set<int> get availableVideoQualities => {
-    for (final item in dash?.video ?? const <VideoItem>[]) ?item.id,
-  };
-
-  int? findAvailableVideoQuality(int preferredQuality) {
-    final qualities = availableVideoQualities.toList();
-    if (qualities.isEmpty) return null;
-    return qualities.findClosestTarget(
-      (quality) => quality <= preferredQuality,
-      (a, b) => a > b ? a : b,
-    );
+  int findAvailableVideoQuality(int preferredQuality) {
+    final curHighestVideoQa = dash!.video!.first.quality.code;
+    if (acceptQuality case final qualitys?
+        when preferredQuality <= curHighestVideoQa) {
+      return qualitys.findClosestTarget((e) => e <= preferredQuality, max);
+    } else {
+      return curHighestVideoQa;
+    }
   }
 
-  int? get missingVideoQualityBelowHighest {
-    final available = availableVideoQualities;
-    final highest = available.reduceOrNull((a, b) => a > b ? a : b);
-    if (highest == null) return null;
-    return supportFormats
-        ?.map((item) => item.quality)
-        .whereType<int>()
-        .where(
-          (quality) => quality < highest && !available.contains(quality),
-        )
-        .reduceOrNull((a, b) => a > b ? a : b);
-  }
+  int get missingVideoQualityBelowHighest {
+    final video = dash!.video!;
+    final available = video.availableVideoQualities;
+    final highest = video.first.id;
 
-  void mergeVideoStreams(PlayUrlModel other) {
-    final videos = dash?.video;
-    final otherVideos = other.dash?.video;
-    if (videos == null || otherVideos == null) return;
-    final keys = {
-      for (final item in videos) (item.id, item.codecid, item.codecs),
-    };
-    for (final item in otherVideos) {
-      if (keys.add((item.id, item.codecid, item.codecs))) {
-        videos.add(item);
+    int best = -1;
+    for (final item in supportFormats!) {
+      final quality = item.quality;
+      if (quality != null &&
+          best < quality &&
+          quality < highest &&
+          !available.contains(quality)) {
+        best = quality;
       }
     }
+    return best;
   }
 
   PlayUrlModel.fromJson(Map<String, dynamic> json) {
@@ -263,7 +251,7 @@ class Durl {
 }
 
 abstract class BaseItem {
-  int? id;
+  late int id;
   String? baseUrl;
   List<String>? backupUrl;
   int? bandWidth;
@@ -278,7 +266,7 @@ abstract class BaseItem {
   int? codecid;
 
   BaseItem({
-    this.id,
+    required this.id,
     this.baseUrl,
     this.backupUrl,
     this.bandWidth,
@@ -320,7 +308,7 @@ class VideoItem extends BaseItem {
   late VideoQuality quality;
 
   VideoItem({
-    super.id,
+    required super.id,
     super.baseUrl,
     super.backupUrl,
     super.bandWidth,
@@ -344,11 +332,24 @@ class VideoItem extends BaseItem {
 class AudioItem extends BaseItem {
   late String quality;
 
-  AudioItem();
-
   AudioItem.fromJson(Map<String, dynamic> json) : super.fromJson(json) {
     quality = AudioQuality.fromCode(json['id']).desc;
   }
+}
+
+extension BaseItemExt<T extends BaseItem> on List<T> {
+  void merge(List<T>? other) {
+    if (other == null) return;
+    final keys = {for (final item in this) (item.id, item.codecid)};
+    for (final item in other) {
+      if (keys.add((item.id, item.codecid))) {
+        add(item);
+      }
+    }
+    sort((a, b) => b.id.compareTo(a.id));
+  }
+
+  Set<int> get availableVideoQualities => map((i) => i.id).toSet();
 }
 
 class FormatItem {

--- a/lib/models/video/play/url.dart
+++ b/lib/models/video/play/url.dart
@@ -71,6 +71,33 @@ class PlayUrlModel {
     );
   }
 
+  int? get missingVideoQualityBelowHighest {
+    final available = availableVideoQualities;
+    final highest = available.reduceOrNull((a, b) => a > b ? a : b);
+    if (highest == null) return null;
+    return supportFormats
+        ?.map((item) => item.quality)
+        .whereType<int>()
+        .where(
+          (quality) => quality < highest && !available.contains(quality),
+        )
+        .reduceOrNull((a, b) => a > b ? a : b);
+  }
+
+  void mergeVideoStreams(PlayUrlModel other) {
+    final videos = dash?.video;
+    final otherVideos = other.dash?.video;
+    if (videos == null || otherVideos == null) return;
+    final keys = {
+      for (final item in videos) (item.id, item.codecid, item.codecs),
+    };
+    for (final item in otherVideos) {
+      if (keys.add((item.id, item.codecid, item.codecs))) {
+        videos.add(item);
+      }
+    }
+  }
+
   PlayUrlModel.fromJson(Map<String, dynamic> json) {
     from = json['from'];
     result = json['result'];

--- a/lib/models/video/play/url.dart
+++ b/lib/models/video/play/url.dart
@@ -58,6 +58,19 @@ class PlayUrlModel {
   Language? language;
   List<SegmentItemModel>? clipInfoList;
 
+  Set<int> get availableVideoQualities => {
+    for (final item in dash?.video ?? const <VideoItem>[]) ?item.id,
+  };
+
+  int? findAvailableVideoQuality(int preferredQuality) {
+    final qualities = availableVideoQualities.toList();
+    if (qualities.isEmpty) return null;
+    return qualities.findClosestTarget(
+      (quality) => quality <= preferredQuality,
+      (a, b) => a > b ? a : b,
+    );
+  }
+
   PlayUrlModel.fromJson(Map<String, dynamic> json) {
     from = json['from'];
     result = json['result'];

--- a/lib/pages/setting/widgets/select_dialog.dart
+++ b/lib/pages/setting/widgets/select_dialog.dart
@@ -4,6 +4,7 @@ import 'package:PiliPlus/http/browser_ua.dart';
 import 'package:PiliPlus/http/constants.dart';
 import 'package:PiliPlus/http/video.dart';
 import 'package:PiliPlus/models/common/video/cdn_type.dart';
+import 'package:PiliPlus/models/common/video/video_quality.dart';
 import 'package:PiliPlus/models/common/video/video_type.dart';
 import 'package:PiliPlus/models/video/play/url.dart';
 import 'package:PiliPlus/utils/storage_pref.dart';
@@ -131,6 +132,7 @@ class _CdnSelectDialogState extends State<CdnSelectDialog> {
     final result = await VideoHttp.videoUrl(
       cid: 196018899,
       bvid: 'BV1fK4y1t7hj',
+      qn: VideoQuality.high1080.code,
       tryLook: false,
       videoType: VideoType.ugc,
     );

--- a/lib/pages/video/controller.dart
+++ b/lib/pages/video/controller.dart
@@ -791,6 +791,15 @@ class VideoDetailController extends GetxController
 
   Volume? volume;
 
+  void _handleUnavailableVideo() {
+    SmartDialog.showToast('视频资源不存在');
+    _autoPlay.value = false;
+    videoState.value = false;
+    if (plPlayerController.isFullScreen.value) {
+      plPlayerController.triggerFullScreen(status: false);
+    }
+  }
+
   // 视频链接
   /// TODO: merge [DownloadHttp.getVideoUrl].
   Future<void> queryVideoUrl({
@@ -804,6 +813,20 @@ class VideoDetailController extends GetxController
       return;
     }
     isQuerying = true;
+    try {
+      await _queryVideoUrl(
+        fromReset: fromReset,
+        autoFullScreenFlag: autoFullScreenFlag,
+      );
+    } finally {
+      isQuerying = false;
+    }
+  }
+
+  Future<void> _queryVideoUrl({
+    required bool fromReset,
+    required bool autoFullScreenFlag,
+  }) async {
     if (plPlayerController.enableSponsorBlock && isBlock && !fromReset) {
       querySponsorBlock(bvid: bvid, cid: cid.value);
     }
@@ -822,6 +845,7 @@ class VideoDetailController extends GetxController
     final result = await VideoHttp.videoUrl(
       cid: cid.value,
       bvid: bvid,
+      qn: VideoQuality.hdrVivid.code,
       epid: epId,
       seasonId: seasonId,
       tryLook: plPlayerController.tryLook,
@@ -889,34 +913,20 @@ class VideoDetailController extends GetxController
           currentDecodeFormats = VideoDecodeFormatType.AVC;
           currentVideoQa.value = videoQuality;
           await _initPlayerIfNeeded(autoFullScreenFlag);
-          isQuerying = false;
           return;
         } else {
-          SmartDialog.showToast('视频资源不存在');
-          _autoPlay.value = false;
-          videoState.value = false;
-          if (plPlayerController.isFullScreen.value) {
-            plPlayerController.triggerFullScreen(status: false);
-          }
-          isQuerying = false;
+          _handleUnavailableVideo();
           return;
         }
       }
 
-      final List<VideoItem> videoList = data.dash!.video!;
+      final videoList = data.dash!.video;
       // if (kDebugMode) debugPrint("allVideosList:${allVideosList}");
-      // 当前可播放的最高质量视频
-      final curHighestVideoQa = videoList.first.quality.code;
-      // 预设的画质为null，则当前可用的最高质量
-      int targetVideoQa = curHighestVideoQa;
       final cacheVideoQa = plPlayerController.cacheVideoQa!;
-      if (data.acceptQuality?.isNotEmpty == true &&
-          cacheVideoQa <= curHighestVideoQa) {
-        // 如果预设的画质低于当前最高
-        targetVideoQa = data.acceptQuality!.findClosestTarget(
-          (e) => e <= cacheVideoQa,
-          (a, b) => a > b ? a : b,
-        );
+      final targetVideoQa = data.findAvailableVideoQuality(cacheVideoQa);
+      if (videoList == null || videoList.isEmpty || targetVideoQa == null) {
+        _handleUnavailableVideo();
+        return;
       }
       currentVideoQa.value = VideoQuality.fromCode(targetVideoQa);
 
@@ -981,7 +991,6 @@ class VideoDetailController extends GetxController
       }
       result.toast();
     }
-    isQuerying = false;
   }
 
   late final List<PostSegmentModel> postList = <PostSegmentModel>[];

--- a/lib/pages/video/controller.dart
+++ b/lib/pages/video/controller.dart
@@ -332,6 +332,7 @@ class VideoDetailController extends GetxController
   void initFileSource(BiliDownloadEntryInfo entry, {bool isInit = true}) {
     this.entry = entry;
     firstVideo = VideoItem(
+      id: entry.preferedVideoQuality,
       quality: VideoQuality.fromCode(entry.preferedVideoQuality),
       width: entry.ep?.width ?? entry.pageData?.width ?? 1,
       height: entry.ep?.height ?? entry.pageData?.height ?? 1,
@@ -789,17 +790,6 @@ class VideoDetailController extends GetxController
     queryVideoUrl(fromReset: true);
   }
 
-  Volume? volume;
-
-  void _handleUnavailableVideo() {
-    SmartDialog.showToast('视频资源不存在');
-    _autoPlay.value = false;
-    videoState.value = false;
-    if (plPlayerController.isFullScreen.value) {
-      plPlayerController.triggerFullScreen(status: false);
-    }
-  }
-
   Future<LoadingState<PlayUrlModel>> _getVideoUrl(int quality) {
     return VideoHttp.videoUrl(
       cid: cid.value,
@@ -816,12 +806,14 @@ class VideoDetailController extends GetxController
 
   Future<void> _supplementVideoQualities() async {
     final quality = data.missingVideoQualityBelowHighest;
-    if (quality == null) return;
+    if (quality == -1) return;
     final result = await _getVideoUrl(quality);
     if (result case Success(:final response)) {
-      data.mergeVideoStreams(response);
+      data.dash!.video!.merge(response.dash?.video);
     }
   }
+
+  Volume? volume;
 
   // 视频链接
   /// TODO: merge [DownloadHttp.getVideoUrl].
@@ -837,19 +829,14 @@ class VideoDetailController extends GetxController
     }
     isQuerying = true;
     try {
-      await _queryVideoUrl(
-        fromReset: fromReset,
-        autoFullScreenFlag: autoFullScreenFlag,
-      );
+      await _queryVideoUrl(fromReset, autoFullScreenFlag);
     } finally {
       isQuerying = false;
     }
   }
 
-  Future<void> _queryVideoUrl({
-    required bool fromReset,
-    required bool autoFullScreenFlag,
-  }) async {
+  @pragma('vm:prefer-inline')
+  Future<void> _queryVideoUrl(bool fromReset, bool autoFullScreenFlag) async {
     if (plPlayerController.enableSponsorBlock && isBlock && !fromReset) {
       querySponsorBlock(bvid: bvid, cid: cid.value);
     }
@@ -929,19 +916,19 @@ class VideoDetailController extends GetxController
           await _initPlayerIfNeeded(autoFullScreenFlag);
           return;
         } else {
-          _handleUnavailableVideo();
+          SmartDialog.showToast('视频资源不存在');
+          _autoPlay.value = false;
+          videoState.value = false;
+          if (plPlayerController.isFullScreen.value) {
+            plPlayerController.triggerFullScreen(status: false);
+          }
           return;
         }
       }
 
-      final videoList = data.dash!.video;
       // if (kDebugMode) debugPrint("allVideosList:${allVideosList}");
       final cacheVideoQa = plPlayerController.cacheVideoQa!;
       final targetVideoQa = data.findAvailableVideoQuality(cacheVideoQa);
-      if (videoList == null || videoList.isEmpty || targetVideoQa == null) {
-        _handleUnavailableVideo();
-        return;
-      }
       currentVideoQa.value = VideoQuality.fromCode(targetVideoQa);
 
       /// 优先顺序 设置中指定解码格式 -> 当前可选的首个解码格式
@@ -959,7 +946,7 @@ class VideoDetailController extends GetxController
       );
 
       /// 取出符合当前画质的videoList
-      final videosList = videoList
+      final videosList = data.dash!.video!
           .where((e) => e.quality.code == targetVideoQa)
           .toList();
 
@@ -976,7 +963,7 @@ class VideoDetailController extends GetxController
       AudioItem? firstAudio;
       final audioList = data.dash?.audio;
       if (audioList != null && audioList.isNotEmpty) {
-        final List<int> audioIds = audioList.map((map) => map.id!).toList();
+        final audioIds = audioList.map((map) => map.id).toList();
         int closestNumber = audioIds.findClosestTarget(
           (e) => e <= plPlayerController.cacheAudioQa,
           (a, b) => a > b ? a : b,
@@ -990,9 +977,7 @@ class VideoDetailController extends GetxController
           orElse: () => audioList.first,
         );
         audioUrl = VideoUtils.getCdnUrl(firstAudio.playUrls, isAudio: true);
-        if (firstAudio.id case final int id?) {
-          currentAudioQa = AudioQuality.fromCode(id);
-        }
+        currentAudioQa = AudioQuality.fromCode(firstAudio.id);
       } else {
         audioUrl = '';
       }

--- a/lib/pages/video/controller.dart
+++ b/lib/pages/video/controller.dart
@@ -800,6 +800,29 @@ class VideoDetailController extends GetxController
     }
   }
 
+  Future<LoadingState<PlayUrlModel>> _getVideoUrl(int quality) {
+    return VideoHttp.videoUrl(
+      cid: cid.value,
+      bvid: bvid,
+      qn: quality,
+      epid: epId,
+      seasonId: seasonId,
+      tryLook: plPlayerController.tryLook,
+      videoType: _actualVideoType ?? videoType,
+      language: currLang.value,
+      voiceBalance: plPlayerController.enableAudioNormalization,
+    );
+  }
+
+  Future<void> _supplementVideoQualities() async {
+    final quality = data.missingVideoQualityBelowHighest;
+    if (quality == null) return;
+    final result = await _getVideoUrl(quality);
+    if (result case Success(:final response)) {
+      data.mergeVideoStreams(response);
+    }
+  }
+
   // 视频链接
   /// TODO: merge [DownloadHttp.getVideoUrl].
   Future<void> queryVideoUrl({
@@ -842,20 +865,11 @@ class VideoDetailController extends GetxController
       preferCodecs = isWiFi ? Pref.preferCodecs : Pref.preferCodecsCellular;
     }
 
-    final result = await VideoHttp.videoUrl(
-      cid: cid.value,
-      bvid: bvid,
-      qn: VideoQuality.hdrVivid.code,
-      epid: epId,
-      seasonId: seasonId,
-      tryLook: plPlayerController.tryLook,
-      videoType: _actualVideoType ?? videoType,
-      language: currLang.value,
-      voiceBalance: plPlayerController.enableAudioNormalization,
-    );
+    final result = await _getVideoUrl(VideoQuality.hdrVivid.code);
 
     if (result case Success(:final response)) {
       data = response;
+      await _supplementVideoQualities();
 
       languages.value = data.language?.items;
       currLang.value = data.curLanguage;

--- a/lib/pages/video/widgets/header_control.dart
+++ b/lib/pages/video/widgets/header_control.dart
@@ -906,7 +906,7 @@ class HeaderControlState extends State<HeaderControl>
     if (currentVideoQa == null) return;
 
     final List<FormatItem> videoFormat = videoInfo.supportFormats!;
-    final availableVideoQualities = videoInfo.availableVideoQualities;
+    final availableQa = videoInfo.dash!.video!.availableVideoQualities;
 
     showBottomSheet(
       (context, setState) {
@@ -973,9 +973,7 @@ class HeaderControlState extends State<HeaderControl>
                         }
                       },
                       // 可能包含会员解锁画质
-                      enabled: availableVideoQualities.contains(
-                        item.quality,
-                      ),
+                      enabled: availableQa.contains(item.quality),
                       contentPadding: const EdgeInsets.symmetric(
                         horizontal: 20,
                       ),
@@ -1035,7 +1033,7 @@ class HeaderControlState extends State<HeaderControl>
                           return;
                         }
                         Get.back();
-                        final int quality = item.id!;
+                        final int quality = item.id;
                         final newQa = AudioQuality.fromCode(quality);
                         videoDetailCtr
                           ..plPlayerController.cacheAudioQa = newQa.code

--- a/lib/pages/video/widgets/header_control.dart
+++ b/lib/pages/video/widgets/header_control.dart
@@ -906,21 +906,7 @@ class HeaderControlState extends State<HeaderControl>
     if (currentVideoQa == null) return;
 
     final List<FormatItem> videoFormat = videoInfo.supportFormats!;
-
-    /// 总质量分类
-    final int totalQaSam = videoFormat.length;
-
-    /// 可用的质量分类
-    int usefulQaSam = 0;
-    final List<VideoItem> video = videoInfo.dash!.video!;
-    final Set<int> idSet = {};
-    for (final VideoItem item in video) {
-      final int id = item.id!;
-      if (!idSet.contains(id)) {
-        idSet.add(id);
-        usefulQaSam++;
-      }
-    }
+    final availableVideoQualities = videoInfo.availableVideoQualities;
 
     showBottomSheet(
       (context, setState) {
@@ -956,7 +942,7 @@ class HeaderControlState extends State<HeaderControl>
                   ),
                 ),
                 SliverList.builder(
-                  itemCount: totalQaSam,
+                  itemCount: videoFormat.length,
                   itemBuilder: (context, index) {
                     final item = videoFormat[index];
                     final isCurr = currentVideoQa.code == item.quality;
@@ -987,7 +973,9 @@ class HeaderControlState extends State<HeaderControl>
                         }
                       },
                       // 可能包含会员解锁画质
-                      enabled: index >= totalQaSam - usefulQaSam,
+                      enabled: availableVideoQualities.contains(
+                        item.quality,
+                      ),
                       contentPadding: const EdgeInsets.symmetric(
                         horizontal: 20,
                       ),

--- a/lib/plugin/pl_player/view/view.dart
+++ b/lib/plugin/pl_player/view/view.dart
@@ -804,11 +804,7 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
             return const SizedBox.shrink();
           }
           final videoFormat = videoInfo.supportFormats!;
-          final totalQaSam = videoFormat.length;
-          final usefulQaSam = videoInfo.dash!.video!
-              .map((i) => i.id)
-              .toSet()
-              .length;
+          final availableVideoQualities = videoInfo.availableVideoQualities;
           return PopupMenuButton<int>(
             tooltip: '画质',
             requestFocus: false,
@@ -816,10 +812,12 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
             color: Colors.black.withValues(alpha: 0.8),
             itemBuilder: (context) {
               return List.generate(
-                totalQaSam,
+                videoFormat.length,
                 (index) {
                   final item = videoFormat[index];
-                  final enabled = index >= totalQaSam - usefulQaSam;
+                  final enabled = availableVideoQualities.contains(
+                    item.quality,
+                  );
                   return PopupMenuItem<int>(
                     enabled: enabled,
                     height: 35,

--- a/lib/plugin/pl_player/view/view.dart
+++ b/lib/plugin/pl_player/view/view.dart
@@ -804,7 +804,7 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
             return const SizedBox.shrink();
           }
           final videoFormat = videoInfo.supportFormats!;
-          final availableVideoQualities = videoInfo.availableVideoQualities;
+          final availableQa = videoInfo.dash!.video!.availableVideoQualities;
           return PopupMenuButton<int>(
             tooltip: '画质',
             requestFocus: false,
@@ -815,9 +815,7 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
                 videoFormat.length,
                 (index) {
                   final item = videoFormat[index];
-                  final enabled = availableVideoQualities.contains(
-                    item.quality,
-                  );
+                  final enabled = availableQa.contains(item.quality);
                   return PopupMenuItem<int>(
                     enabled: enabled,
                     height: 35,
@@ -2055,7 +2053,7 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
 
   Future<void> screenshotWebp() async {
     final videoInfo = videoDetailController.data;
-    final ids = videoInfo.dash!.video!.map((i) => i.id!).toSet();
+    final ids = videoInfo.dash!.video!.availableVideoQualities;
     final video = videoDetailController.findVideoByQa(ids.min);
 
     VideoQuality qa = video.quality;


### PR DESCRIPTION
Fixes #2810

 ## 问题原因

  播放接口返回的 `support_formats` 只是服务端声明的画质列表，真正可播放的画质应以 `dash.video` 中的实际流为准。

  部分视频会根据请求的 `qn` 分批返回视频流。例如 `BV1bW411P7k9`：

  - 请求高画质时，`support_formats` 包含 116/80/64/32/16，但 `dash.video` 仅返回 116。
  - 请求 80 时，`dash.video` 才返回 80/64/32/16。

  原实现存在以下问题：

  1. 播放请求未强制指定 `qn`，会静默回退到 80。
  2. 画质菜单根据列表位置和数量推断画质是否可用，没有检查实际 DASH 流。
  3. 播放及下载可能从声明画质中选择一个实际不存在的流。
  4. 接口仅返回最高画质流时，没有补充请求缺失的低画质流。

  因此可能出现只可选择 1080P60、默认画质不生效或视频无法播放的问题。

  ## 修复内容

  - 将 `VideoHttp.videoUrl` 的 `qn` 改为必传参数，避免隐式回退。
  - 首次请求显式请求高画质流。
  - 使用 `dash.video` 中的实际画质 ID 判断画质是否可用。
  - 当高画质响应缺少低画质流时：
    - 仅额外请求一次缺失画质；
    - 合并并去重两个响应中的视频流。
  - 播放和下载均只从实际存在的 DASH 流中选择画质。
  - 对空视频流增加保护，避免后续 `first` 等操作抛出异常。
  - 使用 `try/finally` 确保请求结束后恢复 `isQuerying` 状态。
  - 修正播放器内及详情页画质菜单的可用状态判断。