### PR TITLE
feat: add option to disable triple action

### DIFF
--- a/lib/pages/setting/models/play_settings.dart
+++ b/lib/pages/setting/models/play_settings.dart
@@ -84,6 +84,13 @@ List<SettingsModel> get playSettings => [
     defaultVal: true,
   ),
   const SwitchModel(
+    title: '禁用一键三连',
+    subtitle: '禁止长按点赞或使用快捷键触发一键三连',
+    leading: Icon(Icons.thumb_up_off_alt),
+    setKey: SettingBoxKey.disableTriple,
+    defaultVal: false,
+  ),
+  const SwitchModel(
     title: '左右侧滑动调节亮度/音量',
     leading: Icon(MdiIcons.tuneVerticalVariant),
     setKey: SettingBoxKey.enableSlideVolumeBrightness,

--- a/lib/pages/video/introduction/ugc/widgets/triple_mixin.dart
+++ b/lib/pages/video/introduction/ugc/widgets/triple_mixin.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:PiliPlus/pages/video/pay_coins/view.dart';
 import 'package:PiliPlus/utils/global_data.dart';
 import 'package:PiliPlus/utils/platform_utils.dart';
+import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:get/get.dart';
@@ -92,13 +93,20 @@ mixin TripleMixin on GetxController, TickerProvider {
 
   void onStartTriple() {
     _timer ??= Timer(_duration, () {
+      if (Pref.disableTriple) {
+        SmartDialog.showToast('已禁用');
+        _cancelTimer();
+        return;
+      }
       HapticFeedback.lightImpact();
       if (hasTriple) {
         SmartDialog.showToast('已完成三连');
       } else {
         tripleAnimCtr.forward().whenComplete(() {
           tripleAnimCtr.reset();
-          actionTriple();
+          if (!Pref.disableTriple) {
+            actionTriple();
+          }
         });
       }
       _cancelTimer();
@@ -106,6 +114,17 @@ mixin TripleMixin on GetxController, TickerProvider {
   }
 
   void onCancelTriple([bool isTapUp = false]) {
+    if (Pref.disableTriple) {
+      if (_tripleAnimCtr?.status == .forward) {
+        _tripleAnimCtr!.reverse();
+      } else if (_timer != null && _timer!.tick == 0) {
+        _cancelTimer();
+        if (isTapUp) {
+          actionLikeVideo();
+        }
+      }
+      return;
+    }
     if (tripleAnimCtr.status == .forward) {
       tripleAnimCtr.reverse();
     } else if (_timer != null && _timer!.tick == 0) {

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -44,6 +44,7 @@ abstract final class SettingBoxKey {
       useRelativeSlide = 'useRelativeSlide',
       sliderDuration = 'sliderOffset',
       enableQuickDouble = 'enableQuickDouble',
+      disableTriple = 'disableTriple',
       fullScreenGestureReverse = 'fullScreenGestureReverse',
       enableBackgroundPlay = 'enableBackgroundPlay',
       continuePlayInBackground = 'continuePlayInBackground',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -773,6 +773,9 @@ abstract final class Pref {
   static bool get enableQuickDouble =>
       _setting.get(SettingBoxKey.enableQuickDouble, defaultValue: true);
 
+  static bool get disableTriple =>
+      _setting.get(SettingBoxKey.disableTriple, defaultValue: false);
+
   static bool get fullScreenGestureReverse =>
       _setting.get(SettingBoxKey.fullScreenGestureReverse, defaultValue: false);
 

--- a/test/pages/video/introduction/ugc/widgets/triple_mixin_test.dart
+++ b/test/pages/video/introduction/ugc/widgets/triple_mixin_test.dart
@@ -1,0 +1,116 @@
+import 'dart:io';
+
+import 'package:PiliPlus/pages/video/introduction/ugc/widgets/triple_mixin.dart';
+import 'package:PiliPlus/utils/storage.dart';
+import 'package:PiliPlus/utils/storage_key.dart';
+import 'package:PiliPlus/utils/storage_pref.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:material_ui/material_ui.dart';
+
+class _TickerController extends GetxController implements TickerProvider {
+  @override
+  Ticker createTicker(TickerCallback onTick) => Ticker(onTick);
+}
+
+class _TripleController extends _TickerController with TripleMixin {
+  int likeCount = 0;
+  int tripleCount = 0;
+
+  @override
+  int get copyright => 1;
+
+  @override
+  bool get isLogin => true;
+
+  @override
+  void actionLikeVideo() => likeCount++;
+
+  @override
+  void actionTriple() => tripleCount++;
+
+  @override
+  void onPayCoin(int coin, bool coinWithLike) {}
+}
+
+void main() {
+  late Directory tempDir;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('piliplus-triple-test-');
+    Hive.init(tempDir.path);
+    GStorage.setting = await Hive.openBox('setting');
+  });
+
+  setUp(() => GStorage.setting.clear());
+
+  tearDownAll(() async {
+    await Hive.close();
+    await tempDir.delete(recursive: true);
+  });
+
+  testWidgets('triple remains enabled by default', (tester) async {
+    final controller = _TripleController();
+    expect(Pref.disableTriple, isFalse);
+
+    controller.onStartTriple();
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pump(const Duration(seconds: 2));
+
+    expect(controller.tripleCount, 1);
+    expect(controller.likeCount, 0);
+    controller.onClose();
+  });
+
+  group('when triple is disabled', () {
+    setUp(() async {
+      await GStorage.setting.put(SettingBoxKey.disableTriple, true);
+    });
+
+    testWidgets('a short press remains a normal like', (tester) async {
+      expect(Pref.disableTriple, isTrue);
+      final controller = _TripleController()..onStartTriple();
+      await tester.pump(const Duration(milliseconds: 100));
+      controller.onCancelTriple(true);
+
+      expect(controller.tripleCount, 0);
+      expect(controller.likeCount, 1);
+      controller.onClose();
+    });
+
+    testWidgets('a long press reports that triple is disabled', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          builder: FlutterSmartDialog.init(),
+          home: const Scaffold(body: SizedBox.expand()),
+        ),
+      );
+      final controller = _TripleController()..onStartTriple();
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pump();
+
+      expect(find.text('已禁用'), findsOneWidget);
+      controller.onCancelTriple(true);
+
+      expect(controller.tripleCount, 0);
+      expect(controller.likeCount, 0);
+
+      await tester.pump(const Duration(seconds: 3));
+      await tester.pumpWidget(const SizedBox.shrink());
+      controller.onClose();
+    });
+
+    testWidgets('a cancelled press does nothing', (tester) async {
+      final controller = _TripleController()..onStartTriple();
+      await tester.pump(const Duration(milliseconds: 100));
+      controller.onCancelTriple();
+
+      expect(controller.tripleCount, 0);
+      expect(controller.likeCount, 0);
+      controller.onClose();
+    });
+  });
+}


### PR DESCRIPTION
## 功能说明

  在“播放器设置”中添加“禁用一键三连”选项，主要是可以帮助改变手快三连把币投了的习惯。

  该选项默认关闭，不改变现有用户的操作习惯。

  ## 行为变化

  启用该选项后：

  - 短按点赞按钮仍会正常点赞。
  - 长按达到三连触发时间后提示“已禁用”。
  - 不会播放三连动画、触发震动或调用三连接口。
  - 对UGC、番剧、音频、全屏操作栏和桌面快捷键均有效。
  - 直播快捷键的刷新功能不受影响。

  ## 测试

  - [x] 默认状态下可以正常触发一键三连。
  - [x] 禁用后短按可以正常点赞。
  - [x] 禁用后长按显示“已禁用”，且不触发点赞或三连。
  - [x] 取消按压不会触发点赞或三连。
  - [x] `flutter test --no-pub` 通过，共 6 项测试。
  - [x] 本次修改涉及的文件通过静态分析。