### PR TITLE
fix(player): 修复前后台切换时的播放异常

### DIFF
--- a/lib/pages/live_room/controller.dart
+++ b/lib/pages/live_room/controller.dart
@@ -210,28 +210,36 @@ class LiveRoomController extends GetxController {
   Future<void>? playerInit({
     bool autoplay = true,
     bool autoFullScreenFlag = false,
+    int? sourceRevision,
+    int? playIntent,
   }) {
-    if (videoUrl == null) {
-      return null;
-    }
+    if (videoUrl == null) return null;
+    playIntent ??= plPlayerController.playIntent;
+    sourceRevision ??= plPlayerController.claimSource(this);
     return plPlayerController.setDataSource(
       NetworkSource(videoSource: videoUrl!, audioSource: null),
       isLive: true,
       autoplay: autoplay,
       isVertical: isPortrait.value,
       autoFullScreenFlag: autoFullScreenFlag,
+      sourceRevision: sourceRevision,
+      autoplayIntent: playIntent,
     );
   }
 
   Future<void> queryLiveUrl({bool autoFullScreenFlag = false}) async {
+    final playIntent = plPlayerController.playIntent;
+    final sourceRevision = plPlayerController.claimSource(this);
     currentQn ??= await ConnectivityUtils.isWiFi
         ? Pref.liveQuality
         : Pref.liveQualityCellular;
+    if (!plPlayerController.ownsSource(this, sourceRevision)) return;
     final res = await LiveHttp.liveRoomInfo(
       roomId: roomId,
       qn: currentQn,
       onlyAudio: plPlayerController.onlyPlayAudio.value,
     );
+    if (!plPlayerController.ownsSource(this, sourceRevision)) return;
     if (res case Success(:final response)) {
       if (response.liveStatus != 1) {
         _showDialog('当前直播间未开播');
@@ -256,7 +264,10 @@ class LiveRoomController extends GetxController {
         formatIndex: formatIndex,
         codecIndex: codecIndex,
         liveUrlIndex: liveUrlIndex,
+        sourceRevision: sourceRevision,
+        playIntent: playIntent,
       );
+      if (!plPlayerController.ownsSource(this, sourceRevision)) return;
       isLoaded.value = true;
     } else {
       _showDialog(res.toString());
@@ -296,12 +307,16 @@ class LiveRoomController extends GetxController {
     }
   }
 
-  Future<void>? initLiveUrl({
+  Future<void> initLiveUrl({
     int streamIndex = 0,
     int formatIndex = 0,
     int codecIndex = 0,
     int liveUrlIndex = 0,
-  }) {
+    int? sourceRevision,
+    int? playIntent,
+  }) async {
+    playIntent ??= plPlayerController.playIntent;
+    sourceRevision ??= plPlayerController.claimSource(this);
     this.streamIndex = streamIndex;
     this.formatIndex = formatIndex;
     this.codecIndex = codecIndex;
@@ -324,7 +339,13 @@ class LiveRoomController extends GetxController {
     currentQnDesc.value =
         LiveQuality.fromCode(currentQn)?.desc ?? currentQn.toString();
     videoUrl = VideoUtils.getLiveCdnUrl(item, index: liveUrlIndex);
-    return playerInit()?.whenComplete(_startSizeSub);
+    final init = playerInit(
+      sourceRevision: sourceRevision,
+      playIntent: playIntent,
+    );
+    if (init == null) return;
+    await init;
+    if (plPlayerController.ownsSource(this, sourceRevision)) _startSizeSub();
   }
 
   Future<void> queryLiveInfoH5() async {

--- a/lib/pages/live_room/view.dart
+++ b/lib/pages/live_room/view.dart
@@ -265,6 +265,7 @@ class _LiveRoomPageState extends State<LiveRoomPage>
             fill: fill,
             alignment: alignment,
             plPlayerController: plPlayerController,
+            sourceOwner: _liveRoomController,
             headerControl: LiveHeaderControl(
               key: _liveRoomController.headerKey,
               title: roomInfoH5?.roomInfo?.title,

--- a/lib/pages/video/controller.dart
+++ b/lib/pages/video/controller.dart
@@ -78,6 +78,18 @@ import 'package:hive_ce/hive.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:media_kit/media_kit.dart' hide Subtitle;
 
+typedef _VideoUrlQuery = ({
+  bool fromReset,
+  bool autoFullScreenFlag,
+  bool? autoplay,
+  String? language,
+  _VideoUrlSource source,
+  int playIntent,
+  int sourceRevision,
+});
+
+typedef _VideoUrlSource = ({String bvid, int cid, int? epId, int? seasonId});
+
 class VideoDetailController extends GetxController
     with GetTickerProviderStateMixin, BlockMixin {
   /// 路由传参
@@ -552,10 +564,7 @@ class VideoDetailController extends GetxController
       alignment: Alignment.centerLeft,
       child: SlideTransition(
         position: animation.drive(
-          Tween<Offset>(
-            begin: const Offset(-1.0, 0.0),
-            end: Offset.zero,
-          ),
+          Tween<Offset>(begin: const Offset(-1.0, 0.0), end: Offset.zero),
         ),
         child: Padding(
           padding: const EdgeInsets.only(top: 5),
@@ -702,13 +711,21 @@ class VideoDetailController extends GetxController
     playerInit();
   }
 
-  Future<void>? _initPlayerIfNeeded(bool autoFullScreenFlag) {
+  Future<void>? _initPlayerIfNeeded(
+    bool autoFullScreenFlag, {
+    bool? autoplay,
+    int? sourceRevision,
+    int? playIntent,
+  }) {
     if (_autoPlay.value ||
-        (plPlayerController.preInitPlayer && !plPlayerController.processing) &&
+        plPlayerController.preInitPlayer &&
             (isFileSource
                 ? true
                 : videoPlayerKey.currentState?.mounted == true)) {
       return playerInit(
+        autoplay: autoplay,
+        sourceRevision: sourceRevision,
+        playIntent: playIntent,
         autoFullScreenFlag: autoFullScreenFlag && _autoPlay.value,
       );
     }
@@ -718,7 +735,11 @@ class VideoDetailController extends GetxController
   Future<void> playerInit({
     bool? autoplay,
     bool autoFullScreenFlag = false,
+    int? sourceRevision,
+    int? playIntent,
   }) async {
+    playIntent ??= plPlayerController.playIntent;
+    sourceRevision ??= plPlayerController.claimSource(this);
     Duration? seek = defaultST ?? playedTime;
     if (seek == .zero) seek = null;
     seek ??= getFirstSegment();
@@ -730,10 +751,7 @@ class VideoDetailController extends GetxController
               isMp4: entry.mediaType == 1,
               hasDashAudio: entry.hasDashAudio,
             )
-          : NetworkSource(
-              videoSource: videoUrl!,
-              audioSource: audioUrl,
-            ),
+          : NetworkSource(videoSource: videoUrl!, audioSource: audioUrl),
       seekTo: seek,
       duration: data.timeLength == null
           ? null
@@ -755,9 +773,13 @@ class VideoDetailController extends GetxController
       height: firstVideo.height,
       volume: volume,
       autoFullScreenFlag: autoFullScreenFlag,
+      sourceRevision: sourceRevision,
+      autoplayIntent: playIntent,
     );
 
-    if (isClosed) return;
+    if (isClosed || !plPlayerController.ownsSource(this, sourceRevision)) {
+      return;
+    }
 
     if (!isFileSource) {
       if (plPlayerController.enableBlock) {
@@ -776,7 +798,13 @@ class VideoDetailController extends GetxController
     defaultST = null;
   }
 
-  bool isQuerying = false;
+  Future<bool>? _videoUrlQuery;
+  _VideoUrlQuery? _pendingVideoUrlQuery;
+
+  bool get isQuerying => _videoUrlQuery != null;
+
+  _VideoUrlSource get _videoUrlSource =>
+      (bvid: bvid, cid: cid.value, epId: epId, seasonId: seasonId);
 
   final languages = Rxn<List<LanguageItem>>();
   final currLang = Rxn<String>();
@@ -786,28 +814,35 @@ class VideoDetailController extends GetxController
       SmartDialog.showToast('账号未登录');
       return;
     }
-    currLang.value = language;
-    queryVideoUrl(fromReset: true);
+    queryVideoUrl(fromReset: true, language: language);
   }
 
-  Future<LoadingState<PlayUrlModel>> _getVideoUrl(int quality) {
+  Future<LoadingState<PlayUrlModel>> _getVideoUrl(
+    _VideoUrlSource source,
+    int quality,
+    String? language,
+  ) {
     return VideoHttp.videoUrl(
-      cid: cid.value,
-      bvid: bvid,
+      cid: source.cid,
+      bvid: source.bvid,
       qn: quality,
-      epid: epId,
-      seasonId: seasonId,
+      epid: source.epId,
+      seasonId: source.seasonId,
       tryLook: plPlayerController.tryLook,
       videoType: _actualVideoType ?? videoType,
-      language: currLang.value,
+      language: language,
       voiceBalance: plPlayerController.enableAudioNormalization,
     );
   }
 
-  Future<void> _supplementVideoQualities() async {
+  Future<void> _supplementVideoQualities(
+    PlayUrlModel data,
+    _VideoUrlSource source,
+    String? language,
+  ) async {
     final quality = data.missingVideoQualityBelowHighest;
     if (quality == -1) return;
-    final result = await _getVideoUrl(quality);
+    final result = await _getVideoUrl(source, quality, language);
     if (result case Success(:final response)) {
       data.dash!.video!.merge(response.dash?.video);
     }
@@ -815,33 +850,159 @@ class VideoDetailController extends GetxController
 
   Volume? volume;
 
+  static final _urlDeadlinePattern = RegExp(
+    r'(?:(?:^|[?&]|%3f|%26)deadline|'
+    r'(?:^|[?&]|%3f|%26)hdnts(?:=|%3d)exp|'
+    r'(?:~|%7e)exp)'
+    r'(?:=|%3d)(\d+)(?=$|[&#~;]|%26|%3b|%7e)',
+    caseSensitive: false,
+  );
+
+  static Iterable<int> _urlDeadlines(String? url) => _urlDeadlinePattern
+      .allMatches(url ?? '')
+      .map((match) => int.tryParse(match.group(1)!))
+      .whereType<int>()
+      .where((deadline) => deadline > 0);
+
+  bool get playUrlExpired {
+    final deadlines = [..._urlDeadlines(videoUrl), ..._urlDeadlines(audioUrl)];
+    if (deadlines.isEmpty) return false;
+    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    return deadlines.reduce(min) <= now + 60;
+  }
+
+  bool get _playUrlReady =>
+      videoUrl != null &&
+      audioUrl != null &&
+      plPlayerController.dataStatus.value == .loaded &&
+      !playUrlExpired;
+
+  /// Returns null when no refresh is needed and false when refresh failed.
+  Future<bool?> refreshExpiredPlayUrl() async {
+    if (isFileSource) return null;
+    if (isClosed) return false;
+    if (_videoUrlQuery case final query?) {
+      try {
+        await query;
+      } catch (_) {}
+      return _playUrlReady;
+    }
+    if (!playUrlExpired) return null;
+
+    playedTime =
+        plPlayerController.videoPlayerController?.state.position ?? playedTime;
+    _autoPlay.value = true;
+    try {
+      await queryVideoUrl(fromReset: true, autoplay: false);
+    } catch (_) {}
+    return _playUrlReady;
+  }
+
   // 视频链接
   /// TODO: merge [DownloadHttp.getVideoUrl].
-  Future<void> queryVideoUrl({
+  Future<bool> queryVideoUrl({
     bool fromReset = false,
     bool autoFullScreenFlag = false,
+    bool? autoplay,
+    String? language,
   }) async {
     if (isFileSource) {
-      return _initPlayerIfNeeded(autoFullScreenFlag);
+      final init = _initPlayerIfNeeded(autoFullScreenFlag, autoplay: autoplay);
+      if (init != null) await init;
+      return init == null || plPlayerController.dataStatus.value == .loaded;
     }
-    if (isQuerying) {
-      return;
+
+    final sourceRevision = plPlayerController.claimSource(this);
+
+    final query = (
+      fromReset: fromReset,
+      autoFullScreenFlag: autoFullScreenFlag,
+      autoplay: autoplay,
+      language: language ?? currLang.value,
+      source: _videoUrlSource,
+      playIntent: plPlayerController.playIntent,
+      sourceRevision: sourceRevision,
+    );
+    if (_videoUrlQuery case final active?) {
+      _pendingVideoUrlQuery = query;
+      return active;
     }
-    isQuerying = true;
-    try {
-      await _queryVideoUrl(fromReset, autoFullScreenFlag);
-    } finally {
-      isQuerying = false;
+
+    late final Future<bool> active;
+    active = _drainVideoUrlQueries(query).whenComplete(() {
+      if (identical(_videoUrlQuery, active)) _videoUrlQuery = null;
+    });
+    _videoUrlQuery = active;
+    return active;
+  }
+
+  Future<bool> _drainVideoUrlQueries(_VideoUrlQuery current) async {
+    while (true) {
+      _pendingVideoUrlQuery = null;
+      late final bool success;
+      try {
+        success = await _queryVideoUrl(current);
+      } catch (_) {
+        if (_pendingVideoUrlQuery == null) rethrow;
+        success = false;
+      }
+      final pending = _pendingVideoUrlQuery;
+      if (pending == null) return success;
+      current = pending;
     }
   }
 
-  @pragma('vm:prefer-inline')
-  Future<void> _queryVideoUrl(bool fromReset, bool autoFullScreenFlag) async {
+  Future<bool> _queryVideoUrl(_VideoUrlQuery query) async {
+    final fromReset = query.fromReset;
+    final autoFullScreenFlag = query.autoFullScreenFlag;
+    final autoplay = query.autoplay;
+    final language = query.language;
+    final source = query.source;
+
+    bool isStale() =>
+        isClosed ||
+        !plPlayerController.ownsSource(this, query.sourceRevision) ||
+        source != _videoUrlSource;
+
+    Future<bool> initPlayer() async {
+      final init = _initPlayerIfNeeded(
+        autoFullScreenFlag,
+        autoplay: false,
+        sourceRevision: query.sourceRevision,
+        playIntent: query.playIntent,
+      );
+      if (init == null) return !isStale();
+      await init;
+      if (isStale() || plPlayerController.dataStatus.value != .loaded) {
+        if (plPlayerController.ownsSource(this, query.sourceRevision)) {
+          await plPlayerController.pause(notify: false);
+        }
+        return false;
+      }
+      final shouldAutoplay = query.playIntent == plPlayerController.playIntent
+          ? autoplay ?? _autoPlay.value
+          : plPlayerController.wantsPlayback;
+      if (shouldAutoplay) {
+        await plPlayerController.autoplayIfAllowed(
+          sourceRevision: query.sourceRevision,
+        );
+        if (isStale()) {
+          if (plPlayerController.ownsSource(this, query.sourceRevision)) {
+            await plPlayerController.pause(notify: false);
+          }
+          return false;
+        }
+      }
+      return true;
+    }
+
+    if (isStale()) return false;
     if (plPlayerController.enableSponsorBlock && isBlock && !fromReset) {
-      querySponsorBlock(bvid: bvid, cid: cid.value);
+      querySponsorBlock(bvid: source.bvid, cid: source.cid);
     }
     if (plPlayerController.cacheVideoQa == null) {
       final isWiFi = await ConnectivityUtils.isWiFi;
+      if (isStale()) return false;
       plPlayerController
         ..cacheVideoQa = isWiFi
             ? Pref.defaultVideoQa
@@ -852,11 +1013,31 @@ class VideoDetailController extends GetxController
       preferCodecs = isWiFi ? Pref.preferCodecs : Pref.preferCodecsCellular;
     }
 
-    final result = await _getVideoUrl(VideoQuality.hdrVivid.code);
+    final result = await _getVideoUrl(
+      source,
+      VideoQuality.hdrVivid.code,
+      language,
+    );
+    if (isStale()) return false;
 
     if (result case Success(:final response)) {
+      if (response.dash == null && response.durl?.isNotEmpty != true) {
+        SmartDialog.showToast('视频资源不存在');
+        if (!fromReset) {
+          _autoPlay.value = false;
+          videoState.value = false;
+          if (plPlayerController.isFullScreen.value) {
+            plPlayerController.triggerFullScreen(status: false);
+          }
+        }
+        return false;
+      }
+
+      if (response.dash != null) {
+        await _supplementVideoQualities(response, source, language);
+        if (isStale()) return false;
+      }
       data = response;
-      await _supplementVideoQualities();
 
       languages.value = data.language?.items;
       currLang.value = data.curLanguage;
@@ -886,44 +1067,34 @@ class VideoDetailController extends GetxController
         );
       }
       if (data.dash == null) {
-        if (data.durl case final durl?) {
-          // it will cause all files to be opened simultaneously
-          if (durl.length > 1) {
-            // TODO: refa
-            final sb = StringBuffer('edl://!no_chapters;');
-            for (var i in durl) {
-              final video = VideoUtils.getCdnUrl(i.playUrls);
-              sb.write('%${video.length}%$video,length=${i.length! / 1000};');
-            }
-            videoUrl = sb.toString();
-          } else {
-            videoUrl = VideoUtils.getCdnUrl(durl.single.playUrls);
+        final durl = data.durl!;
+        // it will cause all files to be opened simultaneously
+        if (durl.length > 1) {
+          // TODO: refa
+          final sb = StringBuffer('edl://!no_chapters;');
+          for (var i in durl) {
+            final video = VideoUtils.getCdnUrl(i.playUrls);
+            sb.write('%${video.length}%$video,length=${i.length! / 1000};');
           }
-
-          audioUrl = '';
-
-          // 实际为FLV/MP4格式，但已被淘汰，这里仅做兜底处理
-          final videoQuality = VideoQuality.fromCode(data.quality!);
-          firstVideo = VideoItem(
-            id: data.quality!,
-            baseUrl: videoUrl,
-            codecs: 'avc1',
-            quality: videoQuality,
-          );
-          _setVideoHeight();
-          currentDecodeFormats = VideoDecodeFormatType.AVC;
-          currentVideoQa.value = videoQuality;
-          await _initPlayerIfNeeded(autoFullScreenFlag);
-          return;
+          videoUrl = sb.toString();
         } else {
-          SmartDialog.showToast('视频资源不存在');
-          _autoPlay.value = false;
-          videoState.value = false;
-          if (plPlayerController.isFullScreen.value) {
-            plPlayerController.triggerFullScreen(status: false);
-          }
-          return;
+          videoUrl = VideoUtils.getCdnUrl(durl.single.playUrls);
         }
+
+        audioUrl = '';
+
+        // 实际为FLV/MP4格式，但已被淘汰，这里仅做兜底处理
+        final videoQuality = VideoQuality.fromCode(data.quality!);
+        firstVideo = VideoItem(
+          id: data.quality!,
+          baseUrl: videoUrl,
+          codecs: 'avc1',
+          quality: videoQuality,
+        );
+        _setVideoHeight();
+        currentDecodeFormats = VideoDecodeFormatType.AVC;
+        currentVideoQa.value = videoQuality;
+        return initPlayer();
       }
 
       // if (kDebugMode) debugPrint("allVideosList:${allVideosList}");
@@ -981,14 +1152,17 @@ class VideoDetailController extends GetxController
       } else {
         audioUrl = '';
       }
-      await _initPlayerIfNeeded(autoFullScreenFlag);
+      return initPlayer();
     } else {
-      _autoPlay.value = false;
-      videoState.value = false;
-      if (plPlayerController.isFullScreen.value) {
-        plPlayerController.triggerFullScreen(status: false);
+      if (!fromReset) {
+        _autoPlay.value = false;
+        videoState.value = false;
+        if (plPlayerController.isFullScreen.value) {
+          plPlayerController.triggerFullScreen(status: false);
+        }
       }
       result.toast();
+      return false;
     }
   }
 
@@ -1600,13 +1774,7 @@ class VideoDetailController extends GetxController
       if (kDebugMode) {
         debugPrint(title);
       }
-      Get.toNamed(
-        '/dlna',
-        parameters: {
-          'url': url,
-          'title': ?title,
-        },
-      );
+      Get.toNamed('/dlna', parameters: {'url': url, 'title': ?title});
     } else {
       res.toast();
     }

--- a/lib/pages/video/view.dart
+++ b/lib/pages/video/view.dart
@@ -291,34 +291,51 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
   }
 
   /// 未开启自动播放时触发播放
-  Future<void>? handlePlay() {
-    if (!videoDetailController.isFileSource) {
-      if (videoDetailController.isQuerying) {
-        if (kDebugMode) debugPrint('handlePlay: querying');
-        return null;
-      }
-      if (videoDetailController.videoUrl == null ||
-          videoDetailController.audioUrl == null) {
-        if (kDebugMode) {
-          debugPrint('handlePlay: videoUrl/audioUrl not initialized');
-        }
-        videoDetailController.queryVideoUrl();
-        return null;
-      }
-    }
+  Future<void> handlePlay() async {
     final plPlayerController = this.plPlayerController =
         videoDetailController.plPlayerController;
     videoDetailController.autoPlay = true;
     plPlayerController
       ..addStatusLister(playerListener)
       ..addPositionListener(positionListener);
+
+    if (!videoDetailController.isFileSource) {
+      if (videoDetailController.isQuerying) {
+        if (kDebugMode) debugPrint('handlePlay: querying');
+        plPlayerController.requestPlayback();
+        return;
+      }
+      if (videoDetailController.videoUrl == null ||
+          videoDetailController.audioUrl == null) {
+        if (kDebugMode) {
+          debugPrint('handlePlay: videoUrl/audioUrl not initialized');
+        }
+        videoDetailController.queryVideoUrl(autoplay: true);
+        return;
+      }
+    }
+    final playIntent = plPlayerController.playIntent;
+    final refreshResult = await videoDetailController.refreshExpiredPlayUrl();
+    if (refreshResult != null) {
+      if (refreshResult &&
+          mounted &&
+          playIntent == plPlayerController.playIntent) {
+        if ((!PlatformUtils.isMobile ||
+                WidgetsBinding.instance.lifecycleState == .resumed) &&
+            plPlayerController.autoEnterFullScreen) {
+          plPlayerController.triggerFullScreen();
+        }
+        await plPlayerController.autoplayIfAllowed();
+      }
+      return;
+    }
     if (plPlayerController.preInitPlayer) {
       if (plPlayerController.autoEnterFullScreen) {
         plPlayerController.triggerFullScreen();
       }
-      return plPlayerController.play();
+      await plPlayerController.play();
     } else {
-      return videoDetailController.playerInit(
+      await videoDetailController.playerInit(
         autoplay: true,
         autoFullScreenFlag: true,
       );
@@ -1216,6 +1233,7 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
               maxWidth: width,
               maxHeight: height,
               plPlayerController: plPlayerController!,
+              sourceOwner: videoDetailController,
               videoDetailController: videoDetailController,
               introController: introController,
               headerControl: HeaderControl(

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -1,4 +1,4 @@
-import 'dart:async' show StreamSubscription, Timer;
+import 'dart:async' show StreamSubscription, Timer, unawaited;
 import 'dart:convert' show ascii, utf8;
 import 'dart:io' show Platform;
 import 'dart:math' show max, min;
@@ -63,6 +63,7 @@ import 'package:media_kit_video/media_kit_video.dart';
 import 'package:native_device_orientation/native_device_orientation.dart';
 import 'package:path/path.dart' as path;
 import 'package:screen_brightness_platform_interface/screen_brightness_platform_interface.dart';
+import 'package:synchronized/synchronized.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -130,6 +131,12 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
       Pref.continuePlayInBackground.obs;
 
   bool _autoPlay = false;
+  int? _pendingAutoplayRevision;
+  bool _wantsPlayback = false;
+  int _playIntent = 0;
+  Object? _sourceOwner;
+  Object? _sourceRequestOwner;
+  int _sourceRevision = 0;
 
   // 记录历史记录
   int? _aid;
@@ -155,6 +162,81 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
   // final Durations durations;
 
   String get bvid => _bvid!;
+
+  int claimSource(Object owner) {
+    _sourceRequestOwner = owner;
+    return ++_sourceRevision;
+  }
+
+  bool isSourceOwner(Object owner) => identical(_sourceOwner, owner);
+
+  bool ownsSource(Object owner, int revision) =>
+      revision == _sourceRevision &&
+      identical(_sourceRequestOwner, owner);
+
+  int get playIntent => _playIntent;
+  bool get wantsPlayback => _wantsPlayback;
+
+  bool takePendingAutoplay(Object owner) {
+    if (!isSourceOwner(owner) ||
+        _pendingAutoplayRevision != _sourceRevision) {
+      return false;
+    }
+    _pendingAutoplayRevision = null;
+    return true;
+  }
+
+  void requestPlayback() {
+    _pendingAutoplayRevision = null;
+    _wantsPlayback = true;
+    _playIntent++;
+  }
+
+  void cancelAutoResume() {
+    _pendingAutoplayRevision = null;
+    _wantsPlayback = false;
+    _playIntent++;
+  }
+
+  void deferAutoplay() => _pendingAutoplayRevision = _sourceRevision;
+
+  Future<void> autoplayIfAllowed({int? sourceRevision}) async {
+    sourceRevision ??= _sourceRevision;
+    if (sourceRevision != _sourceRevision) return;
+
+    _wantsPlayback = true;
+    if (PlatformUtils.isMobile &&
+        !continuePlayInBackground.value &&
+        WidgetsBinding.instance.lifecycleState != AppLifecycleState.resumed) {
+      _pendingAutoplayRevision = sourceRevision;
+      return;
+    }
+
+    _pendingAutoplayRevision = null;
+    final play = playIfExists();
+    if (play == null) {
+      _pendingAutoplayRevision = sourceRevision;
+      return;
+    }
+
+    final playIntent = _playIntent;
+    await play;
+    if (sourceRevision != _sourceRevision) return;
+    if (playIntent != _playIntent) {
+      if (!_wantsPlayback) await pause(notify: false);
+      return;
+    }
+    if (PlatformUtils.isMobile &&
+        !continuePlayInBackground.value &&
+        WidgetsBinding.instance.lifecycleState != AppLifecycleState.resumed) {
+      await pause(notify: false);
+      if (sourceRevision == _sourceRevision &&
+          playIntent == _playIntent &&
+          _wantsPlayback) {
+        _pendingAutoplayRevision = sourceRevision;
+      }
+    }
+  }
 
   /// 视频播放速度
   double get playbackSpeed => _playbackSpeed.value;
@@ -449,8 +531,11 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
     bool notify = true,
     bool isInterrupt = false,
   }) async {
-    if (_instance?.playerStatus.isPlaying ?? false) {
-      await _instance?.pause(notify: notify, isInterrupt: isInterrupt);
+    final instance = _instance;
+    if (instance?.playerStatus.isPlaying ?? false) {
+      await instance?.pause(notify: notify, isInterrupt: isInterrupt);
+    } else if (notify) {
+      instance?.cancelAutoResume();
     }
   }
 
@@ -567,8 +652,7 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
       .._playerCount += 1;
   }
 
-  bool _processing = false;
-  bool get processing => _processing;
+  final _sourceLock = Lock();
 
   // offline
   bool get isFileSource => dataSource is FileSource;
@@ -598,70 +682,84 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
     VoidCallback? onInit,
     Volume? volume,
     bool autoFullScreenFlag = false,
+    required int sourceRevision,
+    required int autoplayIntent,
   }) async {
     try {
-      _processing = true;
-      this.isLive = isLive;
-      _videoType = videoType ?? VideoType.ugc;
-      this.width = width;
-      this.height = height;
-      this.dataSource = dataSource;
-      _autoPlay = autoplay;
-      // 初始化视频倍速
-      // _playbackSpeed.value = speed;
-      // 初始化数据加载状态
-      dataStatus.value = DataStatus.loading;
-      // 初始化全屏方向
-      _isVertical = isVertical ?? false;
-      _aid = aid;
-      _bvid = bvid;
-      this.cid = cid;
-      _epid = epid;
-      _seasonId = seasonId;
-      _pgcType = pgcType;
+      await _sourceLock.synchronized(() async {
+        if (sourceRevision != _sourceRevision) return;
+        _sourceOwner = _sourceRequestOwner;
+        this.isLive = isLive;
+        _videoType = videoType ?? VideoType.ugc;
+        this.width = width;
+        this.height = height;
+        this.dataSource = dataSource;
+        _autoPlay = autoplay;
+        _pendingAutoplayRevision = null;
+        // 初始化视频倍速
+        // _playbackSpeed.value = speed;
+        // 初始化数据加载状态
+        dataStatus.value = DataStatus.loading;
+        // 初始化全屏方向
+        _isVertical = isVertical ?? false;
+        _aid = aid;
+        _bvid = bvid;
+        this.cid = cid;
+        _epid = epid;
+        _seasonId = seasonId;
+        _pgcType = pgcType;
 
-      if (showSeekPreview) {
-        _clearPreview();
-      }
-      cancelLongPressTimer();
-      if (_videoPlayerController != null &&
-          _videoPlayerController!.state.playing) {
-        await pause(notify: false);
-      }
+        if (showSeekPreview) {
+          _clearPreview();
+        }
+        cancelLongPressTimer();
+        if (_videoPlayerController != null &&
+            _videoPlayerController!.state.playing) {
+          await pause(notify: false);
+        }
+        if (sourceRevision != _sourceRevision) return;
 
-      if (_playerCount == 0) {
-        return;
-      }
-      // 配置Player 音轨、字幕等等
-      await _createVideoController(dataSource, seekTo, volume);
+        if (_playerCount == 0) {
+          return;
+        }
+        // 配置Player 音轨、字幕等等
+        await _createVideoController(
+          dataSource,
+          seekTo,
+          volume,
+          sourceRevision,
+        );
 
-      if (_playerCount == 0) {
-        _removeListeners();
-        _videoPlayerController?.dispose();
-        _videoPlayerController = null;
-        _videoController = null;
-        return;
-      }
+        if (sourceRevision != _sourceRevision) return;
 
-      updateDuration(duration ?? _videoPlayerController!.state.duration);
-      position.value = buffered.value = seekTo?.inSeconds ?? 0;
+        if (_playerCount == 0) {
+          _removeListeners();
+          _videoPlayerController?.dispose();
+          _videoPlayerController = null;
+          _videoController = null;
+          return;
+        }
 
-      dataStatus.value = .loaded;
+        updateDuration(duration ?? _videoPlayerController!.state.duration);
+        position.value = buffered.value = seekTo?.inSeconds ?? 0;
 
-      if (autoFullScreenFlag && autoEnterFullScreen) {
-        triggerFullScreen(status: true);
-      }
+        dataStatus.value = .loaded;
 
-      await _initializePlayer();
-      onInit?.call();
+        if (autoFullScreenFlag && autoEnterFullScreen) {
+          triggerFullScreen(status: true);
+        }
+
+        await _initializePlayer(autoplayIntent, sourceRevision);
+        if (sourceRevision == _sourceRevision) onInit?.call();
+      });
     } catch (err, stackTrace) {
-      dataStatus.value = DataStatus.error;
+      if (sourceRevision == _sourceRevision) {
+        dataStatus.value = DataStatus.error;
+      }
       if (kDebugMode) {
         debugPrint(stackTrace.toString());
         debugPrint('plPlayer err:  $err');
       }
-    } finally {
-      _processing = false;
     }
   }
 
@@ -722,6 +820,8 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
     final opt = {
       'video-sync': Pref.videoSync,
       if (Platform.isAndroid) 'ao': Pref.audioOutput,
+      'stream-lavf-o':
+          'reconnect=1,reconnect_on_network_error=1,reconnect_streamed=1',
       'volume':
           (PlatformUtils.isMobile ? Pref.playerVolume : volume.value * 100)
               .toString(),
@@ -765,6 +865,7 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
     DataSource dataSource,
     Duration? seekTo,
     Volume? volume,
+    int sourceRevision,
   ) async {
     isBuffering.value = false;
     _heartDuration = 0;
@@ -786,6 +887,7 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
         await setShader();
       }
     }
+    if (sourceRevision != _sourceRevision) return;
 
     final Map<String, String> extras = {
       if (dataSource is FileSource)
@@ -838,8 +940,11 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
   }
 
   // 开始播放
-  Future<void> _initializePlayer() async {
-    if (_instance == null) return;
+  Future<void> _initializePlayer(
+    int autoplayIntent,
+    int sourceRevision,
+  ) async {
+    if (_instance == null || sourceRevision != _sourceRevision) return;
     // 设置倍速
     if (isLive) {
       await setPlaybackSpeed(1.0);
@@ -848,6 +953,7 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
         await setPlaybackSpeed(_playbackSpeed.value);
       }
     }
+    if (sourceRevision != _sourceRevision) return;
     _initVideoFit();
     // if (_looping) {
     //   await setLooping(_looping);
@@ -859,8 +965,10 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
     // }
 
     // 自动播放
-    if (_autoPlay) {
-      playIfExists();
+    if (sourceRevision == _sourceRevision &&
+        ((_autoPlay && autoplayIntent == _playIntent) ||
+            (autoplayIntent != _playIntent && _wantsPlayback))) {
+      unawaited(autoplayIfAllowed(sourceRevision: sourceRevision));
       // await play(duration: duration);
     }
   }
@@ -1101,6 +1209,7 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
 
   /// 播放视频
   Future<void> play({bool repeat = false, bool hideControls = true}) async {
+    requestPlayback();
     if (_playerCount == 0) return;
     // 播放时自动隐藏控制条
     controls = !hideControls;
@@ -1120,6 +1229,7 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
 
   /// 暂停播放
   Future<void> pause({bool notify = true, bool isInterrupt = false}) async {
+    if (notify) cancelAutoResume();
     await _videoPlayerController?.pause();
     playerStatus.value = PlayerStatus.paused;
 
@@ -1524,6 +1634,11 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
     }
 
     _playerCount = 0;
+    _pendingAutoplayRevision = null;
+    _wantsPlayback = false;
+    _sourceOwner = null;
+    _sourceRequestOwner = null;
+    _sourceRevision++;
     if (removeSafeArea) {
       showSystemBar();
     }
@@ -1583,6 +1698,10 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
 
   void setContinuePlayInBackground() {
     continuePlayInBackground.toggle();
+    if (continuePlayInBackground.value &&
+        _pendingAutoplayRevision == _sourceRevision) {
+      unawaited(autoplayIfAllowed());
+    }
     if (!tempPlayerConf) {
       setting.put(
         SettingBoxKey.continuePlayInBackground,

--- a/lib/plugin/pl_player/view/view.dart
+++ b/lib/plugin/pl_player/view/view.dart
@@ -90,6 +90,7 @@ class PLVideoPlayer extends StatefulWidget {
     required this.maxWidth,
     required this.maxHeight,
     required this.plPlayerController,
+    required this.sourceOwner,
     this.videoDetailController,
     this.introController,
     required this.headerControl,
@@ -105,6 +106,7 @@ class PLVideoPlayer extends StatefulWidget {
   final double maxWidth;
   final double maxHeight;
   final PlPlayerController plPlayerController;
+  final Object sourceOwner;
   final VideoDetailController? videoDetailController;
   final CommonIntroController? introController;
   final Widget headerControl;
@@ -149,7 +151,18 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
   GestureType? _gestureType;
   Offset? _initialFocalPoint;
 
-  bool _pauseDueToPauseUponEnteringBackgroundMode = false;
+  bool _resumeOnForeground = false;
+  Future<void>? _backgroundPause;
+  Future<void>? _backgroundResume;
+  int? _backgroundPlayIntent;
+
+  bool get _ownsCurrentPlayer =>
+      plPlayerController.isSourceOwner(widget.sourceOwner);
+
+  bool get _canResumePlayback =>
+      _ownsCurrentPlayer &&
+      (plPlayerController.continuePlayInBackground.value ||
+          WidgetsBinding.instance.lifecycleState == .resumed);
 
   StreamSubscription? _brightnessListener;
   void _onBrightnessChanged(double value) {
@@ -253,6 +266,13 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
   void initState() {
     super.initState();
     addObserverMobile(this);
+    if (WidgetsBinding.instance.lifecycleState == .resumed) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || !_ownsCurrentPlayer) return;
+        _consumePendingAutoplay();
+        _resumeIfNeeded();
+      });
+    }
 
     _controlsListener = plPlayerController.showControls.listen(
       _onControlChanged,
@@ -329,19 +349,107 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (!plPlayerController.continuePlayInBackground.value) {
-      late final player = plPlayerController.videoPlayerController;
-      if (const <AppLifecycleState>[.paused, .detached].contains(state)) {
-        if (player != null && player.state.playing) {
-          _pauseDueToPauseUponEnteringBackgroundMode = true;
-          player.pause();
-        }
-      } else {
-        if (_pauseDueToPauseUponEnteringBackgroundMode) {
-          _pauseDueToPauseUponEnteringBackgroundMode = false;
-          player?.play();
-        }
+    if (!_ownsCurrentPlayer) return;
+    if (state == .resumed) _consumePendingAutoplay();
+    if (plPlayerController.continuePlayInBackground.value &&
+        state != .resumed) {
+      _resumeOnForeground = false;
+      _backgroundPlayIntent = null;
+      return;
+    }
+
+    final player = plPlayerController.videoPlayerController;
+    if (const <AppLifecycleState>[
+      .paused,
+      .detached,
+    ].contains(state)) {
+      if (player != null &&
+          player.state.playing &&
+          plPlayerController.wantsPlayback) {
+        _resumeOnForeground = true;
+        _backgroundPlayIntent = plPlayerController.playIntent;
+        _backgroundPause = player.pause();
+      } else if (_backgroundResume != null &&
+          _backgroundPlayIntent == plPlayerController.playIntent) {
+        _resumeOnForeground = true;
       }
+    } else if (state == .resumed) {
+      _resumeIfNeeded();
+    }
+  }
+
+  void _consumePendingAutoplay() {
+    if (plPlayerController.takePendingAutoplay(widget.sourceOwner)) {
+      _resumeOnForeground = true;
+      _backgroundPlayIntent = plPlayerController.playIntent;
+    }
+  }
+
+  void _resumeIfNeeded() {
+    if (!_resumeOnForeground ||
+        _backgroundResume != null ||
+        !mounted ||
+        !_canResumePlayback) {
+      return;
+    }
+
+    _resumeOnForeground = false;
+    final pause = _backgroundPause;
+    final playIntent =
+        _backgroundPlayIntent ?? plPlayerController.playIntent;
+    _backgroundPause = null;
+    final resume = _resumeAfterBackground(pause, playIntent);
+    _backgroundResume = resume;
+    unawaited(
+      resume.whenComplete(() {
+        _backgroundResume = null;
+        if (!_resumeOnForeground) _backgroundPlayIntent = null;
+        _resumeIfNeeded();
+      }),
+    );
+  }
+
+  Future<void> _resumeAfterBackground(
+    Future<void>? pause,
+    int playIntent,
+  ) async {
+    try {
+      if (pause != null) await pause;
+      if (!mounted ||
+          playIntent != plPlayerController.playIntent ||
+          !_canResumePlayback) {
+        return;
+      }
+
+      final refreshResult =
+          await widget.videoDetailController?.refreshExpiredPlayUrl();
+      if (!mounted ||
+          playIntent != plPlayerController.playIntent ||
+          !_ownsCurrentPlayer) {
+        return;
+      }
+      if (refreshResult == false) {
+        plPlayerController.deferAutoplay();
+        return;
+      }
+      if (!_canResumePlayback) return;
+
+      await plPlayerController.videoPlayerController?.play();
+      if (!mounted || !_ownsCurrentPlayer) return;
+      if (playIntent != plPlayerController.playIntent) {
+        if (!plPlayerController.wantsPlayback) {
+          await plPlayerController.videoPlayerController?.pause();
+        }
+        return;
+      }
+      if (!plPlayerController.continuePlayInBackground.value &&
+          WidgetsBinding.instance.lifecycleState != .resumed) {
+        await plPlayerController.videoPlayerController?.pause();
+      } else if (_backgroundPause == null) {
+        _resumeOnForeground = false;
+      }
+    } catch (e, s) {
+      if (kDebugMode) debugPrint('resume after background failed: $e\n$s');
     }
   }
 

--- a/lib/plugin/pl_player/view/view.dart
+++ b/lib/plugin/pl_player/view/view.dart
@@ -360,6 +360,7 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
 
     final player = plPlayerController.videoPlayerController;
     if (const <AppLifecycleState>[
+      .hidden,
       .paused,
       .detached,
     ].contains(state)) {

--- a/lib/services/shutdown_timer_service.dart
+++ b/lib/services/shutdown_timer_service.dart
@@ -83,6 +83,9 @@ class ShutdownTimerService {
         late final player = PlPlayerController.instance;
         final isPlaying =
             this.isPlaying?.call() ?? player?.playerStatus.isPlaying ?? false;
+        if (!_waitUntilCompleted && !isPlaying && onPause == null) {
+          player?.cancelAutoResume();
+        }
         if (isPlaying) {
           if (_waitUntilCompleted) {
             _isWaiting = true;


### PR DESCRIPTION
### 现象

关闭后台播放后，应用返回前台偶尔无法继续播放；应用进入 `hidden` 状态时也可能继续播放。
关联 orz12/PiliPalaX#150，参考 #2446。

### 方案

- 为网络流启用 FFmpeg reconnect
- 仅在播放地址过期或即将过期时重新请求
- URL 请求只提交最新结果，播放器换源串行执行
- 恢复前检查当前播放源和用户播放意图
- 后台播放关闭时，在 `hidden`、`paused`、`detached` 状态暂停
- 不根据 NAL/EOF 日志自动重载播放器