### PR TITLE
Add separate Chromecast casting button

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -46,6 +46,13 @@
         <meta-data
             android:name="io.flutter.embedding.android.EnableImpeller"
             android:value="false" />
+        <meta-data
+            android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
+            android:value="com.felnanuke.google_cast.GoogleCastOptionsProvider" />
+        <service
+            android:name="com.google.android.gms.cast.framework.media.MediaNotificationService"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback" />
         <activity
             android:name=".MainActivity"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -137,6 +137,8 @@
 		<array>
 			<string>_ssdp._udp</string>
 			<string>_upnp._tcp</string>
+			<string>_googlecast._tcp</string>
+			<string>_CC1AD845._googlecast._tcp</string>
 			<string>_http._tcp</string>
 		</array>
 		<key>ITSAppUsesNonExemptEncryption</key>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,6 +39,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_displaymode/flutter_displaymode.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
+import 'package:PiliPlus/services/chromecast_service.dart';
 import 'package:get/get.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:media_kit/media_kit.dart';
@@ -111,6 +112,13 @@ void main() async {
     ..lazyPut(AccountService.new)
     ..lazyPut(DownloadService.new);
   HttpOverrides.global = _CustomHttpOverrides();
+  if (ChromecastService.supported) {
+    try {
+      await ChromecastService.initialize();
+    } catch (e) {
+      if (kDebugMode) debugPrint('Chromecast initialization failed: $e');
+    }
+  }
 
   if (PlatformUtils.isMobile) {
     if (Platform.isAndroid) MaxScreenSize.init();

--- a/lib/pages/chromecast/view.dart
+++ b/lib/pages/chromecast/view.dart
@@ -1,0 +1,119 @@
+import 'dart:async';
+
+import 'package:PiliPlus/common/widgets/loading_widget/http_error.dart';
+import 'package:PiliPlus/common/widgets/loading_widget/loading_widget.dart';
+import 'package:PiliPlus/common/widgets/scaffold/simple_scaffold.dart';
+import 'package:PiliPlus/common/widgets/view_sliver_safe_area.dart';
+import 'package:PiliPlus/services/chromecast_service.dart';
+import 'package:flutter_chrome_cast/discovery.dart';
+import 'package:flutter_chrome_cast/entities.dart';
+import 'package:get/get.dart';
+import 'package:material_ui/material_ui.dart';
+
+class ChromecastPage extends StatefulWidget {
+  const ChromecastPage({super.key});
+
+  @override
+  State<ChromecastPage> createState() => _ChromecastPageState();
+}
+
+class _ChromecastPageState extends State<ChromecastPage> {
+  final _devices = <String, GoogleCastDevice>{};
+  late final _url = Get.parameters['url']!;
+  late final _title = Get.parameters['title'];
+  StreamSubscription<List<GoogleCastDevice>>? _subscription;
+  bool _searching = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _search();
+  }
+
+  Future<void> _search() async {
+    if (_searching) return;
+    _searching = true;
+    _devices.clear();
+    if (mounted) setState(() {});
+    try {
+      await ChromecastService.startDiscovery();
+      final manager = GoogleCastDiscoveryManager.instance;
+      _subscription ??= manager.devicesStream.listen((devices) {
+        if (!mounted) return;
+        setState(() {
+          for (final device in devices) {
+            _devices[device.deviceID] = device;
+          }
+        });
+      });
+      await Future<void>.delayed(const Duration(seconds: 15));
+    } catch (e) {
+      if (mounted) SmartDialog.showToast('Chromecast 搜索失败：$e');
+    } finally {
+      await ChromecastService.stopDiscovery();
+      if (mounted) setState(() => _searching = false);
+    }
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    ChromecastService.stopDiscovery();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SimpleScaffold(
+      appBar: AppBar(
+        title: const Text('Chromecast'),
+        actions: [
+          IconButton(
+            tooltip: '搜索',
+            onPressed: _search,
+            icon: const Icon(Icons.refresh),
+          ),
+        ],
+      ),
+      body: CustomScrollView(
+        slivers: [
+          if (_searching) linearLoading,
+          ViewSliverSafeArea(sliver: _buildBody()),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBody() {
+    if (!_searching && _devices.isEmpty) {
+      return HttpError(errMsg: '没有 Chromecast 设备', onReload: _search);
+    }
+    final devices = _devices.values.toList();
+    return SliverList.builder(
+      itemCount: devices.length,
+      itemBuilder: (context, index) {
+        final device = devices[index];
+        return ListTile(
+          leading: const Icon(Icons.cast),
+          title: Text(device.friendlyName),
+          subtitle: Text(device.modelName ?? 'Google Cast'),
+          onTap: () async {
+            try {
+              SmartDialog.showLoading();
+              await ChromecastService.cast(
+                device: device,
+                url: _url,
+                title: _title,
+              );
+              SmartDialog.dismiss();
+              SmartDialog.showToast('已开始 Chromecast 投屏');
+            } catch (e) {
+              SmartDialog.dismiss();
+              SmartDialog.showToast('Chromecast 播放失败：$e');
+            }
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/pages/video/controller.dart
+++ b/lib/pages/video/controller.dart
@@ -47,6 +47,7 @@ import 'package:PiliPlus/pages/video/note/view.dart';
 import 'package:PiliPlus/pages/video/post_panel/view.dart';
 import 'package:PiliPlus/pages/video/send_danmaku/view.dart';
 import 'package:PiliPlus/pages/video/widgets/header_control.dart';
+import 'package:PiliPlus/services/chromecast_service.dart';
 import 'package:PiliPlus/plugin/pl_player/controller.dart';
 import 'package:PiliPlus/plugin/pl_player/models/data_source.dart';
 import 'package:PiliPlus/plugin/pl_player/models/heart_beat_type.dart';
@@ -1607,6 +1608,41 @@ class VideoDetailController extends GetxController
           'title': ?title,
         },
       );
+    } else {
+      res.toast();
+    }
+  }
+
+  @pragma('vm:notify-debugger-on-exception')
+  Future<void> onChromecast() async {
+    if (!ChromecastService.supported) {
+      SmartDialog.showToast('当前平台不支持 Chromecast');
+      return;
+    }
+    SmartDialog.showLoading();
+    final res = await VideoHttp.tvPlayUrl(
+      cid: cid.value,
+      objectId: epId ?? aid,
+      playurlType: epId != null ? 2 : 1,
+      qn: currentVideoQa.value?.code,
+    );
+    SmartDialog.dismiss();
+    if (res case Success(:final response)) {
+      final first = response.durl?.firstOrNull;
+      if (first == null || first.playUrls.isEmpty) {
+        SmartDialog.showToast('不支持 Chromecast 投屏');
+        return;
+      }
+      String? title;
+      try {
+        title = isUgc
+            ? Get.find<UgcIntroController>(tag: heroTag).videoDetail.value.title
+            : Get.find<PgcIntroController>(tag: heroTag).videoDetail.value.title;
+      } catch (_) {}
+      Get.toNamed('/chromecast', parameters: {
+        'url': VideoUtils.getCdnUrl(first.playUrls),
+        'title': ?title,
+      });
     } else {
       res.toast();
     }

--- a/lib/pages/video/widgets/header_control.dart
+++ b/lib/pages/video/widgets/header_control.dart
@@ -1818,7 +1818,7 @@ class HeaderControlState extends State<HeaderControl>
                   width: btnWidth,
                   height: btnHeight,
                   child: IconButton(
-                    tooltip: '投屏',
+                    tooltip: 'DLNA 投屏',
                     style: btnStyle,
                     onPressed: videoDetailCtr.onCast,
                     icon: const Icon(
@@ -1828,6 +1828,21 @@ class HeaderControlState extends State<HeaderControl>
                     ),
                   ),
                 ),
+                if (!PlatformUtils.isDesktop)
+                  SizedBox(
+                    width: btnWidth,
+                    height: btnHeight,
+                    child: IconButton(
+                      tooltip: 'Chromecast 投屏',
+                      style: btnStyle,
+                      onPressed: videoDetailCtr.onChromecast,
+                      icon: const Icon(
+                        Icons.cast_connected,
+                        size: 19,
+                        color: Colors.white,
+                      ),
+                    ),
+                  ),
               ],
               if (plPlayerController.enableSponsorBlock)
                 SizedBox(

--- a/lib/router/app_pages.dart
+++ b/lib/router/app_pages.dart
@@ -4,6 +4,7 @@ import 'package:PiliPlus/pages/audio/view.dart';
 import 'package:PiliPlus/pages/blacklist/view.dart';
 import 'package:PiliPlus/pages/bubble/view.dart';
 import 'package:PiliPlus/pages/danmaku_block/view.dart';
+import 'package:PiliPlus/pages/chromecast/view.dart';
 import 'package:PiliPlus/pages/dlna/view.dart';
 import 'package:PiliPlus/pages/download/view.dart';
 import 'package:PiliPlus/pages/dynamics/view.dart';
@@ -172,6 +173,7 @@ class Routes {
     GetPage(name: '/sameFollowing', page: () => const FollowSamePage()),
     GetPage(name: '/download', page: () => const DownloadPage()),
     GetPage(name: '/dlna', page: () => const DLNAPage()),
+    GetPage(name: '/chromecast', page: () => const ChromecastPage()),
     GetPage(name: '/myReply', page: () => const MyReply()),
     GetPage(name: '/videoWeb', page: () => const MemberVideoWeb()),
     GetPage(name: '/ssWeb', page: () => const MemberSSWeb()),

--- a/lib/services/chromecast_service.dart
+++ b/lib/services/chromecast_service.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+
+import 'package:flutter_chrome_cast/cast_context.dart';
+import 'package:flutter_chrome_cast/discovery.dart';
+import 'package:flutter_chrome_cast/entities.dart';
+import 'package:flutter_chrome_cast/enums.dart';
+import 'package:flutter_chrome_cast/media.dart';
+import 'package:flutter_chrome_cast/models.dart';
+import 'package:flutter_chrome_cast/session.dart';
+
+abstract final class ChromecastService {
+  static const appId = GoogleCastDiscoveryCriteria.kDefaultApplicationId;
+  static bool _initialized = false;
+
+  static bool get supported => Platform.isAndroid || Platform.isIOS;
+
+  static Future<void> initialize() async {
+    if (!supported || _initialized) return;
+    final options = Platform.isAndroid
+        ? GoogleCastOptionsAndroid(appId: appId)
+        : IOSGoogleCastOptions(
+            GoogleCastDiscoveryCriteriaInitialize.initWithApplicationID(appId),
+          );
+    await GoogleCastContext.instance.setSharedInstanceWithOptions(options);
+    _initialized = true;
+  }
+
+  static Future<void> startDiscovery() async {
+    await initialize();
+    await GoogleCastDiscoveryManager.instance.startDiscovery();
+  }
+
+  static Future<void> stopDiscovery() async {
+    if (!supported || !_initialized) return;
+    await GoogleCastDiscoveryManager.instance.stopDiscovery();
+  }
+
+  static Future<void> cast({
+    required GoogleCastDevice device,
+    required String url,
+    String? title,
+  }) async {
+    await initialize();
+    await GoogleCastSessionManager.instance.startSessionWithDevice(device);
+    final mediaInfo = GoogleCastMediaInformation(
+      contentId: url,
+      contentUrl: Uri.parse(url),
+      streamType: CastMediaStreamType.buffered,
+      contentType: 'video/mp4',
+      metadata: GoogleCastMovieMediaMetadata(title: title),
+    );
+    await GoogleCastRemoteMediaClient.instance.loadMedia(mediaInfo);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,6 +67,7 @@ dependencies:
   collection: ^1.19.1
   connectivity_plus: ^7.1.1
   cookie_jar: ^4.0.8
+  flutter_chrome_cast: ^1.4.8
   crypto: ^3.0.6
   cupertino_ui: ^1.0.0
   desktop_webview_window:


### PR DESCRIPTION
## Summary

Add a dedicated Chromecast casting entry point alongside the existing DLNA casting feature.

## Changes

- Add `flutter_chrome_cast` integration for Android and iOS.
- Initialize Google Cast context on supported mobile platforms.
- Add a dedicated Chromecast device discovery page.
- Add a separate Chromecast button in the video header; keep the existing DLNA button unchanged.
- Add Android Cast Framework metadata/service configuration.
- Add iOS Bonjour declarations for Google Cast discovery.
- Reuse the existing Bilibili TV playback URL for the initial Cast media load.
- Hide the Chromecast button on desktop platforms, where this plugin is not supported.

## Testing

- `git diff --check` passes.
- Verified the plugin API and Android/iOS integration against `flutter_chrome_cast` 1.4.8.
- Local Flutter SDK is unavailable in the aarch64 sandbox, so `flutter pub get`, analyzer, and APK build could not be run here.
- Real Chromecast playback still needs validation with a Chromecast/Google TV device; Bilibili CDN request-header compatibility may require a later proxy/fallback change.
