### PR TITLE
opt: mpv args & native event loop

### DIFF
--- a/lib/plugin/pl_player/widgets/mpv_convert_webp.dart
+++ b/lib/plugin/pl_player/widgets/mpv_convert_webp.dart
@@ -44,6 +44,7 @@ class MpvConvertWebp {
       _mpv,
       _onEvent,
       options: {
+        'idle': 'once',
         'o': outFile,
         'start': start.toStringAsFixed(3),
         'end': (start + duration).toStringAsFixed(3),
@@ -54,6 +55,11 @@ class MpvConvertWebp {
         if (enableHA) 'vo': 'gpu',
         if (enableHA) 'hwdec': '${Pref.hardwareDecoding},auto-copy', // transcode only support copy
       },
+    );
+    _mpv.mpv_request_event(
+      _ctx,
+      generated.mpv_event_id.MPV_EVENT_VIDEO_RECONFIG,
+      0,
     );
     NativePlayer.setHeader(
       _mpv,
@@ -105,8 +111,7 @@ class MpvConvertWebp {
           _success = false;
         }
         break;
-      case generated.mpv_event_id.MPV_EVENT_END_FILE ||
-          generated.mpv_event_id.MPV_EVENT_SHUTDOWN:
+      case generated.mpv_event_id.MPV_EVENT_SHUTDOWN:
         progress?.value = 1;
         _completer.complete(_success);
         dispose();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1169,27 +1169,27 @@ packages:
     dependency: "direct main"
     description:
       path: media_kit
-      ref: "version_1.2.5"
-      resolved-ref: "08b7b9410968fa39ae2fc814d57f9f889079afc9"
-      url: "https://github.com/bggRGjQaUbCoE/media-kit.git"
+      ref: native
+      resolved-ref: "8eee5044af9232ce54b94b963646b4532b328df7"
+      url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
     version: "1.1.11"
   media_kit_libs_android_video:
     dependency: "direct overridden"
     description:
       path: "libs/android/media_kit_libs_android_video"
-      ref: "version_1.2.5"
-      resolved-ref: "08b7b9410968fa39ae2fc814d57f9f889079afc9"
-      url: "https://github.com/bggRGjQaUbCoE/media-kit.git"
+      ref: native
+      resolved-ref: "8eee5044af9232ce54b94b963646b4532b328df7"
+      url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
     version: "1.3.7"
   media_kit_libs_ios_video:
     dependency: "direct overridden"
     description:
       path: "libs/ios/media_kit_libs_ios_video"
-      ref: "version_1.2.5"
-      resolved-ref: "08b7b9410968fa39ae2fc814d57f9f889079afc9"
-      url: "https://github.com/bggRGjQaUbCoE/media-kit.git"
+      ref: native
+      resolved-ref: "8eee5044af9232ce54b94b963646b4532b328df7"
+      url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
     version: "1.1.4"
   media_kit_libs_linux:
@@ -1212,36 +1212,36 @@ packages:
     dependency: "direct main"
     description:
       path: "libs/universal/media_kit_libs_video"
-      ref: "version_1.2.5"
-      resolved-ref: "08b7b9410968fa39ae2fc814d57f9f889079afc9"
-      url: "https://github.com/bggRGjQaUbCoE/media-kit.git"
+      ref: native
+      resolved-ref: "8eee5044af9232ce54b94b963646b4532b328df7"
+      url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
     version: "1.0.5"
   media_kit_libs_windows_video:
     dependency: "direct overridden"
     description:
       path: "libs/windows/media_kit_libs_windows_video"
-      ref: "version_1.2.5"
-      resolved-ref: "08b7b9410968fa39ae2fc814d57f9f889079afc9"
-      url: "https://github.com/bggRGjQaUbCoE/media-kit.git"
+      ref: native
+      resolved-ref: "8eee5044af9232ce54b94b963646b4532b328df7"
+      url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
     version: "1.0.10"
   media_kit_native_event_loop:
     dependency: "direct overridden"
     description:
       path: media_kit_native_event_loop
-      ref: "version_1.2.5"
-      resolved-ref: "08b7b9410968fa39ae2fc814d57f9f889079afc9"
-      url: "https://github.com/bggRGjQaUbCoE/media-kit.git"
+      ref: native
+      resolved-ref: "8eee5044af9232ce54b94b963646b4532b328df7"
+      url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
     version: "1.0.9"
   media_kit_video:
     dependency: "direct main"
     description:
       path: media_kit_video
-      ref: "version_1.2.5"
-      resolved-ref: "08b7b9410968fa39ae2fc814d57f9f889079afc9"
-      url: "https://github.com/bggRGjQaUbCoE/media-kit.git"
+      ref: native
+      resolved-ref: "8eee5044af9232ce54b94b963646b4532b328df7"
+      url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
     version: "1.2.5"
   menu_base:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1170,7 +1170,7 @@ packages:
     description:
       path: media_kit
       ref: native
-      resolved-ref: "8eee5044af9232ce54b94b963646b4532b328df7"
+      resolved-ref: "73771ec38176be2d984a3049c28177bce23b54a0"
       url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
     version: "1.1.11"
@@ -1179,7 +1179,7 @@ packages:
     description:
       path: "libs/android/media_kit_libs_android_video"
       ref: native
-      resolved-ref: "8eee5044af9232ce54b94b963646b4532b328df7"
+      resolved-ref: "73771ec38176be2d984a3049c28177bce23b54a0"
       url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
     version: "1.3.7"
@@ -1188,7 +1188,7 @@ packages:
     description:
       path: "libs/ios/media_kit_libs_ios_video"
       ref: native
-      resolved-ref: "8eee5044af9232ce54b94b963646b4532b328df7"
+      resolved-ref: "73771ec38176be2d984a3049c28177bce23b54a0"
       url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
     version: "1.1.4"
@@ -1213,7 +1213,7 @@ packages:
     description:
       path: "libs/universal/media_kit_libs_video"
       ref: native
-      resolved-ref: "8eee5044af9232ce54b94b963646b4532b328df7"
+      resolved-ref: "73771ec38176be2d984a3049c28177bce23b54a0"
       url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
     version: "1.0.5"
@@ -1222,7 +1222,7 @@ packages:
     description:
       path: "libs/windows/media_kit_libs_windows_video"
       ref: native
-      resolved-ref: "8eee5044af9232ce54b94b963646b4532b328df7"
+      resolved-ref: "73771ec38176be2d984a3049c28177bce23b54a0"
       url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
     version: "1.0.10"
@@ -1231,7 +1231,7 @@ packages:
     description:
       path: media_kit_native_event_loop
       ref: native
-      resolved-ref: "8eee5044af9232ce54b94b963646b4532b328df7"
+      resolved-ref: "73771ec38176be2d984a3049c28177bce23b54a0"
       url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
     version: "1.0.9"
@@ -1240,7 +1240,7 @@ packages:
     description:
       path: media_kit_video
       ref: native
-      resolved-ref: "8eee5044af9232ce54b94b963646b4532b328df7"
+      resolved-ref: "73771ec38176be2d984a3049c28177bce23b54a0"
       url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
     version: "1.2.5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -188,39 +188,39 @@ dependency_overrides:
       ref: v6.1.5
   media_kit:
     git:
-      url: https://github.com/bggRGjQaUbCoE/media-kit.git
+      url: https://github.com/My-Responsitories/media-kit.git
       path: media_kit
-      ref: version_1.2.5
+      ref: native
   media_kit_libs_android_video:
     git:
-      url: https://github.com/bggRGjQaUbCoE/media-kit.git
+      url: https://github.com/My-Responsitories/media-kit.git
       path: libs/android/media_kit_libs_android_video
-      ref: version_1.2.5
+      ref: native
   media_kit_libs_ios_video:
     git:
-      url: https://github.com/bggRGjQaUbCoE/media-kit.git
+      url: https://github.com/My-Responsitories/media-kit.git
       path: libs/ios/media_kit_libs_ios_video
-      ref: version_1.2.5
+      ref: native
   media_kit_libs_video:
     git:
-      url: https://github.com/bggRGjQaUbCoE/media-kit.git
+      url: https://github.com/My-Responsitories/media-kit.git
       path: libs/universal/media_kit_libs_video
-      ref: version_1.2.5
+      ref: native
   media_kit_libs_windows_video:
     git:
-      url: https://github.com/bggRGjQaUbCoE/media-kit.git
+      url: https://github.com/My-Responsitories/media-kit.git
       path: libs/windows/media_kit_libs_windows_video
-      ref: version_1.2.5
+      ref: native
   media_kit_native_event_loop:
     git:
-      url: https://github.com/bggRGjQaUbCoE/media-kit.git
+      url: https://github.com/My-Responsitories/media-kit.git
       path: media_kit_native_event_loop
-      ref: version_1.2.5
+      ref: native
   media_kit_video:
     git:
-      url: https://github.com/bggRGjQaUbCoE/media-kit.git
+      url: https://github.com/My-Responsitories/media-kit.git
       path: media_kit_video
-      ref: version_1.2.5
+      ref: native
   cached_network_image_ce:
     git:
       url: https://github.com/My-Responsitories/flutter_cached_network_image_ce.git


### PR DESCRIPTION
详细改动见: https://github.com/My-Responsitories/media-kit/commit/9cb11e61ff756a645d4cfa8678c2fdc6b45097f8

通过在native端模拟`NativeCallable.listener`, 使用`mpv_set_wakeup_callback`, 尝试实现media-kit1.2.x特性. 这或许可以避免`NativeCallable`的问题