### PR TITLE
新增动态转发详情并完善 macOS 开发支持

### DIFF
--- a/lib/http/api.dart
+++ b/lib/http/api.dart
@@ -532,6 +532,10 @@ abstract final class Api {
   // features=itemOpusStyle
   static const String dynamicDetail = '/x/polymer/web-dynamic/v1/detail';
 
+  // 获取动态转发列表
+  static const String dynamicForward =
+      '/x/polymer/web-dynamic/v1/detail/forward';
+
   // AI总结
   /// https://api.bilibili.com/x/web-interface/view/conclusion/get?
   /// bvid=BV1ju4y1s7kn&

--- a/lib/http/dynamics.dart
+++ b/lib/http/dynamics.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:PiliPlus/common/constants.dart';
 import 'package:PiliPlus/common/widgets/pair.dart';
 import 'package:PiliPlus/http/api.dart';
+import 'package:PiliPlus/http/browser_ua.dart';
 import 'package:PiliPlus/http/constants.dart';
 import 'package:PiliPlus/http/error_msg.dart';
 import 'package:PiliPlus/http/init.dart';
@@ -19,6 +20,7 @@ import 'package:PiliPlus/models_new/article/article_view/data.dart';
 import 'package:PiliPlus/models_new/bubble/data.dart';
 import 'package:PiliPlus/models_new/dynamic/dyn_mention/data.dart';
 import 'package:PiliPlus/models_new/dynamic/dyn_mention/group.dart';
+import 'package:PiliPlus/models_new/dynamic/dyn_forward/data.dart';
 import 'package:PiliPlus/models_new/dynamic/dyn_reaction/data.dart';
 import 'package:PiliPlus/models_new/dynamic/dyn_reserve/data.dart';
 import 'package:PiliPlus/models_new/dynamic/dyn_reserve_info/data.dart';
@@ -869,6 +871,44 @@ abstract final class DynamicsHttp {
       return Success(DynReactionData.fromJson(res.data['data']));
     } else {
       return Error(res.data['message']);
+    }
+  }
+
+  /// 获取动态的转发列表。
+  static Future<LoadingState<DynForwardData>> dynForward({
+    required Object id,
+    String? offset,
+  }) async {
+    final res = await Request().get(
+      Api.dynamicForward,
+      queryParameters: {
+        'timezone_offset': -480,
+        'id': id,
+        'offset': ?offset,
+        'web_location': 333.1330,
+      },
+      options: Options(
+        headers: {
+          'origin': HttpString.dynamicShareBaseUrl,
+          'referer': '${HttpString.dynamicShareBaseUrl}/$id',
+          'user-agent': BrowserUa.pc,
+        },
+      ),
+    );
+    if (res.data['code'] == 0) {
+      try {
+        return Success(
+          DynForwardData.fromJson(
+            (res.data['data'] as Map?) == null
+                ? const <String, dynamic>{}
+                : Map<String, dynamic>.from(res.data['data'] as Map),
+          ),
+        );
+      } catch (e, s) {
+        return Error('$e\n\n$s');
+      }
+    } else {
+      return Error(res.data['message'], code: res.data['code']);
     }
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -74,7 +74,10 @@ Future<void> _initDownPath() async {
   } else if (Platform.isAndroid) {
     final externalStorageDirPath = (await getExternalStorageDirectory())?.path;
     downloadPath = externalStorageDirPath != null
-        ? path.join(externalStorageDirPath, PathUtils.downloadDir)
+        ? path.join(
+            PathUtils.withDataSuffix(externalStorageDirPath),
+            PathUtils.downloadDir,
+          )
         : defDownloadPath;
   } else {
     downloadPath = defDownloadPath;
@@ -82,11 +85,17 @@ Future<void> _initDownPath() async {
 }
 
 Future<void> _initTmpPath() async {
-  tmpDirPath = (await getTemporaryDirectory()).path;
+  tmpDirPath = PathUtils.withDataSuffix(
+    (await getTemporaryDirectory()).path,
+  );
+  await Directory(tmpDirPath).create(recursive: true);
 }
 
 Future<void> _initAppPath() async {
-  appSupportDirPath = (await getApplicationSupportDirectory()).path;
+  appSupportDirPath = PathUtils.withDataSuffix(
+    (await getApplicationSupportDirectory()).path,
+  );
+  await Directory(appSupportDirPath).create(recursive: true);
 }
 
 void main() async {

--- a/lib/models_new/dynamic/dyn_forward/data.dart
+++ b/lib/models_new/dynamic/dyn_forward/data.dart
@@ -1,0 +1,35 @@
+import 'package:PiliPlus/models_new/dynamic/dyn_forward/item.dart';
+import 'package:PiliPlus/utils/parse_int.dart';
+
+class DynForwardData {
+  bool? hasMore;
+  List<DynForwardItem>? items;
+  String? offset;
+  int total;
+
+  DynForwardData({
+    this.hasMore,
+    this.items,
+    this.offset,
+    this.total = 0,
+  });
+
+  factory DynForwardData.fromJson(Map<String, dynamic> json) {
+    final items = json['items'];
+    return DynForwardData(
+      hasMore: json['has_more'] as bool?,
+      items: items is List
+          ? items
+                .whereType<Map>()
+                .map(
+                  (e) => DynForwardItem.fromJson(
+                    Map<String, dynamic>.from(e),
+                  ),
+                )
+                .toList()
+          : null,
+      offset: json['offset']?.toString(),
+      total: safeToInt(json['total']) ?? 0,
+    );
+  }
+}

--- a/lib/models_new/dynamic/dyn_forward/item.dart
+++ b/lib/models_new/dynamic/dyn_forward/item.dart
@@ -1,0 +1,23 @@
+import 'package:PiliPlus/models/dynamics/result.dart';
+
+class DynForwardItem {
+  String? idStr;
+  String? pubTime;
+  DynamicDescModel? desc;
+  ModuleAuthorModel? user;
+
+  DynForwardItem.fromJson(Map<String, dynamic> json) {
+    idStr = json['id_str']?.toString();
+    pubTime = json['pub_time']?.toString();
+
+    final desc = json['desc'];
+    if (desc is Map) {
+      this.desc = DynamicDescModel.fromJson(Map<String, dynamic>.from(desc));
+    }
+
+    final user = json['user'];
+    if (user is Map) {
+      this.user = ModuleAuthorModel.fromJson(Map<String, dynamic>.from(user));
+    }
+  }
+}

--- a/lib/pages/common/dyn/common_dyn_page.dart
+++ b/lib/pages/common/dyn/common_dyn_page.dart
@@ -28,7 +28,8 @@ import 'package:material_ui/material_ui.dart';
 
 enum DynType implements EnumWithLabel {
   reply('评论'),
-  reaction('赞与转发');
+  reaction('赞与转发'),
+  forward('转发详情');
 
   @override
   final String label;

--- a/lib/pages/dynamics_detail/view.dart
+++ b/lib/pages/dynamics_detail/view.dart
@@ -27,6 +27,8 @@ import 'package:PiliPlus/pages/dynamics/widgets/author_panel.dart';
 import 'package:PiliPlus/pages/dynamics/widgets/dynamic_panel.dart';
 import 'package:PiliPlus/pages/dynamics_create/view.dart';
 import 'package:PiliPlus/pages/dynamics_detail/controller.dart';
+import 'package:PiliPlus/pages/dynamics_forward/controller.dart';
+import 'package:PiliPlus/pages/dynamics_forward/view.dart';
 import 'package:PiliPlus/pages/dynamics_repost/view.dart';
 import 'package:PiliPlus/utils/extension/get_ext.dart';
 import 'package:PiliPlus/utils/extension/theme_ext.dart';
@@ -58,6 +60,7 @@ class _DynamicDetailPageState
   @override
   late final DynamicDetailController controller;
   late final DynReactController _reactController;
+  late final DynForwardController _forwardController;
 
   late final RxBool _isRefreshing = false.obs;
 
@@ -92,6 +95,13 @@ class _DynamicDetailPageState
         count: (stat?.like?.count ?? -1) + (stat?.forward?.count ?? -1),
       ),
       tag: id,
+    );
+    _forwardController = Get.putOrFind(
+      () => DynForwardController(
+        id,
+        count: stat?.forward?.count ?? -1,
+      ),
+      tag: 'dynamicForward-$id',
     );
   }
 
@@ -288,49 +298,66 @@ class _DynamicDetailPageState
   Widget _buildTabBar() {
     return SizedBox(
       height: 40,
-      child: TabBar(
-        padding: .zero,
-        isScrollable: true,
-        indicatorSize: .tab,
-        tabAlignment: .start,
-        controller: tabController,
-        labelPadding: const .symmetric(horizontal: 12),
-        dividerColor: theme.colorScheme.outline.withValues(alpha: 0.1),
-        onTap: (value) {
-          if (!tabController.indexIsChanging) {
-            final positions = PrimaryScrollController.of(context).positions;
-            if (positions.length == 1) {
-              final postion = positions.single;
-              if (postion.pixels >= postion.maxScrollExtent) {
-                postion.jumpTo(postion.pixels);
-              }
-              switch (value) {
-                case 0:
-                  _onRefresh(controller.onRefresh());
-                case 1:
-                  _onRefresh(_reactController.onRefresh());
-              }
-            } else if (positions.length > 1) {
-              positions.elementAt(1).jumpTo(0);
-            }
-          }
-        },
-        tabs: [
-          Tab(
-            child: Obx(() {
-              final count = controller.count.value;
-              return Text(
-                '${DynType.reply.label}${count < 0 ? '' : ' ${NumUtils.numFormat(count)}'}',
-              );
-            }),
-          ),
-          Tab(
-            child: Obx(() {
-              final count = _reactController.count.value;
-              return Text(
-                '${DynType.reaction.label}${count < 0 ? '' : ' ${NumUtils.numFormat(count)}'}',
-              );
-            }),
+      child: Row(
+        children: [
+          Expanded(
+            child: TabBar(
+              padding: .zero,
+              isScrollable: true,
+              indicatorSize: .tab,
+              tabAlignment: .start,
+              controller: tabController,
+              labelPadding: const .symmetric(horizontal: 12),
+              dividerColor: theme.colorScheme.outline.withValues(alpha: 0.1),
+              onTap: (value) {
+                if (!tabController.indexIsChanging) {
+                  final positions = PrimaryScrollController.of(context)
+                      .positions;
+                  if (positions.length == 1) {
+                    final postion = positions.single;
+                    if (postion.pixels >= postion.maxScrollExtent) {
+                      postion.jumpTo(postion.pixels);
+                    }
+                    switch (value) {
+                      case 0:
+                        _onRefresh(controller.onRefresh());
+                      case 1:
+                        _onRefresh(_reactController.onRefresh());
+                      case 2:
+                        _onRefresh(_forwardController.onRefresh());
+                    }
+                  } else if (positions.length > 1) {
+                    positions.elementAt(1).jumpTo(0);
+                  }
+                }
+              },
+              tabs: [
+                Tab(
+                  child: Obx(() {
+                    final count = controller.count.value;
+                    return Text(
+                      '${DynType.reply.label}${count < 0 ? '' : ' ${NumUtils.numFormat(count)}'}',
+                    );
+                  }),
+                ),
+                Tab(
+                  child: Obx(() {
+                    final count = _reactController.count.value;
+                    return Text(
+                      '${DynType.reaction.label}${count < 0 ? '' : ' ${NumUtils.numFormat(count)}'}',
+                    );
+                  }),
+                ),
+                Tab(
+                  child: Obx(() {
+                    final count = _forwardController.count.value;
+                    return Text(
+                      '${DynType.forward.label}${count < 0 ? '' : ' ${NumUtils.numFormat(count)}'}',
+                    );
+                  }),
+                ),
+              ],
+            ),
           ),
         ],
       ),
@@ -360,6 +387,10 @@ class _DynamicDetailPageState
           isPortrait: isPortrait,
           id: controller.dynItem.idStr,
           controller: _reactController,
+        ),
+        DynForwardPage(
+          controller: _forwardController,
+          embedded: true,
         ),
       ],
     );

--- a/lib/pages/dynamics_forward/controller.dart
+++ b/lib/pages/dynamics_forward/controller.dart
@@ -1,0 +1,51 @@
+import 'package:PiliPlus/http/dynamics.dart';
+import 'package:PiliPlus/http/loading_state.dart';
+import 'package:PiliPlus/models_new/dynamic/dyn_forward/data.dart';
+import 'package:PiliPlus/models_new/dynamic/dyn_forward/item.dart';
+import 'package:PiliPlus/pages/common/common_list_controller.dart';
+import 'package:get/get.dart';
+
+class DynForwardController
+    extends CommonListController<DynForwardData, DynForwardItem> {
+  DynForwardController(this.id, {int count = -1}) : count = RxInt(count);
+
+  final String id;
+  final RxInt count;
+  String? _offset;
+
+  @override
+  void onInit() {
+    super.onInit();
+    queryData();
+  }
+
+  @override
+  List<DynForwardItem>? getDataList(DynForwardData response) {
+    _offset = response.offset;
+    if (response.hasMore != true || response.offset?.isNotEmpty != true) {
+      isEnd = true;
+    }
+    return response.items;
+  }
+
+  @override
+  bool customHandleResponse(
+    bool isRefresh,
+    Success<DynForwardData> response,
+  ) {
+    if (isRefresh) {
+      count.value = response.response.total;
+    }
+    return false;
+  }
+
+  @override
+  Future<LoadingState<DynForwardData>> customGetData() =>
+      DynamicsHttp.dynForward(id: id, offset: _offset);
+
+  @override
+  Future<void> onRefresh() {
+    _offset = null;
+    return super.onRefresh();
+  }
+}

--- a/lib/pages/dynamics_forward/view.dart
+++ b/lib/pages/dynamics_forward/view.dart
@@ -1,0 +1,136 @@
+import 'package:PiliPlus/common/widgets/flutter/refresh_indicator.dart';
+import 'package:PiliPlus/common/widgets/loading_widget/http_error.dart';
+import 'package:PiliPlus/common/widgets/loading_widget/loading_widget.dart';
+import 'package:PiliPlus/common/widgets/scaffold/simple_scaffold.dart';
+import 'package:PiliPlus/http/loading_state.dart';
+import 'package:PiliPlus/models_new/dynamic/dyn_forward/item.dart';
+import 'package:PiliPlus/pages/dynamics_forward/controller.dart';
+import 'package:PiliPlus/pages/dynamics_forward/widgets/item.dart';
+import 'package:PiliPlus/utils/extension/get_ext.dart';
+import 'package:PiliPlus/utils/num_utils.dart';
+import 'package:get/get.dart';
+import 'package:material_ui/material_ui.dart';
+
+class DynForwardPage extends StatefulWidget {
+  const DynForwardPage({
+    super.key,
+    this.controller,
+    this.embedded = false,
+  });
+
+  final DynForwardController? controller;
+  final bool embedded;
+
+  @override
+  State<DynForwardPage> createState() => _DynForwardPageState();
+}
+
+class _DynForwardPageState extends State<DynForwardPage> {
+  late final DynForwardController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    final controller = widget.controller;
+    if (controller != null) {
+      _controller = controller;
+      return;
+    }
+
+    final arguments = Get.arguments;
+    final argumentId = arguments is Map ? arguments['id'] : null;
+    final id = Get.parameters['id'] ?? argumentId?.toString() ?? '';
+    _controller = Get.putOrFind(
+      () => DynForwardController(id),
+      tag: 'dynamicForward-$id',
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    final padding = MediaQuery.viewPaddingOf(context);
+    return Padding(
+      padding: EdgeInsets.only(left: padding.left, right: padding.right),
+      child: refreshIndicator(
+        onRefresh: _controller.onRefresh,
+        child: CustomScrollView(
+          controller: _controller.scrollController,
+          physics: const AlwaysScrollableScrollPhysics(),
+          slivers: [
+            SliverPadding(
+              padding: EdgeInsets.only(bottom: padding.bottom + 100),
+              sliver: Obx(
+                () => _buildBody(_controller.loadingState.value),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final body = _buildContent(context);
+    if (widget.embedded) {
+      return body;
+    }
+
+    return SimpleScaffold(
+      appBar: AppBar(
+        title: Obx(() {
+          final count = _controller.count.value;
+          return Text(
+            count < 0 ? '转发详情' : '转发详情 ${NumUtils.numFormat(count)}',
+          );
+        }),
+      ),
+      body: body,
+    );
+  }
+
+  Widget _buildBody(LoadingState<List<DynForwardItem>?> state) {
+    switch (state) {
+      case Loading():
+        return const SliverFillRemaining(child: m3eLoading);
+      case Success(:final response):
+        if (response != null && response.isNotEmpty) {
+          return SliverList.separated(
+            itemCount: response.length + 1,
+            itemBuilder: (context, index) {
+              if (index == response.length) {
+                _controller.onLoadMore();
+                return SizedBox(
+                  height: 72,
+                  child: Center(
+                    child: Text(
+                      _controller.isEnd ? '没有更多了' : '加载中...',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: Theme.of(context).colorScheme.outline,
+                      ),
+                    ),
+                  ),
+                );
+              }
+              return DynForwardItemWidget(item: response[index]);
+            },
+            separatorBuilder: (context, index) => Divider(
+              height: 1,
+              indent: 70,
+              endIndent: 16,
+              color: Theme.of(context).dividerColor.withValues(alpha: 0.1),
+            ),
+          );
+        }
+        return HttpError(
+          errMsg: '还没有人转发',
+          onReload: _controller.onReload,
+        );
+      case Error(:final errMsg):
+        return HttpError(
+          errMsg: errMsg,
+          onReload: _controller.onReload,
+        );
+    }
+  }
+}

--- a/lib/pages/dynamics_forward/widgets/item.dart
+++ b/lib/pages/dynamics_forward/widgets/item.dart
@@ -1,0 +1,203 @@
+import 'package:PiliPlus/common/widgets/flutter/list_tile.dart';
+import 'package:PiliPlus/common/widgets/gesture/tap_gesture_recognizer.dart';
+import 'package:PiliPlus/common/widgets/image/network_img_layer.dart';
+import 'package:PiliPlus/common/widgets/pendant_avatar.dart';
+import 'package:PiliPlus/models_new/dynamic/dyn_forward/item.dart';
+import 'package:PiliPlus/utils/page_utils.dart';
+import 'package:get/get.dart';
+import 'package:material_ui/material_ui.dart' hide ListTile;
+
+class DynForwardItemWidget extends StatelessWidget {
+  const DynForwardItemWidget({
+    super.key,
+    required this.item,
+  });
+
+  final DynForwardItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final user = item.user;
+    final mid = user?.mid;
+    final openUser = mid == null ? null : () => Get.toNamed('/member?mid=$mid');
+    final dynamicId = item.idStr;
+    final openDynamic = dynamicId?.isNotEmpty == true
+        ? () => PageUtils.pushDynFromId(id: dynamicId)
+        : null;
+    final pubTime = item.pubTime?.isNotEmpty == true
+        ? item.pubTime
+        : user?.pubTime;
+
+    Widget userName = Text(
+      user?.name ?? '未知用户',
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: TextStyle(
+        color: theme.colorScheme.primary,
+        fontSize: 14,
+      ),
+    );
+    if (openUser != null) {
+      userName = GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: openUser,
+        child: userName,
+      );
+    }
+
+    final description = _buildDescription(theme);
+    return ListTile(
+      dense: true,
+      safeArea: false,
+      visualDensity: .standard,
+      titleAlignment: .top,
+      onTap: openDynamic,
+      leading: PendantAvatar(
+        user?.face,
+        size: 36,
+        badgeSize: 14,
+        vipStatus: user?.vip?.status,
+        officialType: user?.officialVerify?.type,
+        pendantImage: user?.pendant?.image,
+        onTap: openUser,
+      ),
+      title: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Expanded(child: userName),
+          if (pubTime?.isNotEmpty == true) ...[
+            const SizedBox(width: 8),
+            Text(
+              pubTime!,
+              style: TextStyle(
+                color: theme.colorScheme.outline,
+                fontSize: 12,
+              ),
+            ),
+          ],
+        ],
+      ),
+      subtitle: description == null
+          ? null
+          : Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: description,
+            ),
+    );
+  }
+
+  Widget? _buildDescription(ThemeData theme) {
+    final desc = item.desc;
+    final nodes = desc?.richTextNodes;
+    if (nodes == null || nodes.isEmpty) {
+      final text = desc?.text;
+      return text?.isNotEmpty == true
+          ? Text(
+              text!,
+              style: TextStyle(
+                fontSize: 15,
+                height: 1.55,
+                color: theme.colorScheme.onSurface,
+              ),
+            )
+          : null;
+    }
+
+    final spans = <InlineSpan>[];
+    for (final node in nodes) {
+      final text = node.origText ?? node.text ?? '';
+      switch (node.type) {
+        case 'RICH_TEXT_NODE_TYPE_EMOJI':
+          final emoji = node.emoji;
+          final url = emoji?.url;
+          if (url?.isNotEmpty == true) {
+            spans.add(
+              WidgetSpan(
+                alignment: PlaceholderAlignment.middle,
+                rawText: text,
+                child: NetworkImgLayer(
+                  src: url,
+                  type: .emote,
+                  width: 20,
+                  height: 20,
+                ),
+              ),
+            );
+          } else if (text.isNotEmpty) {
+            spans.add(TextSpan(text: text));
+          }
+          break;
+        case 'RICH_TEXT_NODE_TYPE_AT':
+          spans.add(
+            TextSpan(
+              text: text,
+              style: TextStyle(color: theme.colorScheme.primary),
+              recognizer: node.rid?.isNotEmpty == true
+                  ? (NoDeadlineTapGestureRecognizer()
+                      ..onTap = () => Get.toNamed('/member?mid=${node.rid}'))
+                  : null,
+            ),
+          );
+          break;
+        case 'RICH_TEXT_NODE_TYPE_TOPIC':
+          final canOpenTopic =
+              text.length > 2 && text.startsWith('#') && text.endsWith('#');
+          spans.add(
+            TextSpan(
+              text: text,
+              style: TextStyle(color: theme.colorScheme.primary),
+              recognizer: canOpenTopic
+                  ? (NoDeadlineTapGestureRecognizer()
+                      ..onTap = () => Get.toNamed(
+                        '/searchResult',
+                        parameters: {
+                          'keyword': text.substring(1, text.length - 1),
+                        },
+                      ))
+                  : null,
+            ),
+          );
+          break;
+        case 'RICH_TEXT_NODE_TYPE_WEB':
+          spans.add(
+            TextSpan(
+              text: node.text ?? text,
+              style: TextStyle(color: theme.colorScheme.primary),
+              recognizer: node.jumpUrl?.isNotEmpty == true
+                  ? (NoDeadlineTapGestureRecognizer()
+                      ..onTap = () => PageUtils.handleWebview(node.jumpUrl!))
+                  : null,
+            ),
+          );
+          break;
+        default:
+          spans.add(
+            TextSpan(
+              text: node.text ?? text,
+              style: node.jumpUrl?.isNotEmpty == true
+                  ? TextStyle(color: theme.colorScheme.primary)
+                  : null,
+              recognizer: node.jumpUrl?.isNotEmpty == true
+                  ? (NoDeadlineTapGestureRecognizer()
+                      ..onTap = () => PageUtils.handleWebview(node.jumpUrl!))
+                  : null,
+            ),
+          );
+      }
+    }
+
+    if (spans.isEmpty) return null;
+
+    return Text.rich(
+      TextSpan(children: spans),
+      style: TextStyle(
+        fontSize: 15,
+        height: 1.55,
+        color: theme.colorScheme.onSurface,
+      ),
+      maxLines: 8,
+      overflow: TextOverflow.ellipsis,
+    );
+  }
+}

--- a/lib/router/app_pages.dart
+++ b/lib/router/app_pages.dart
@@ -9,6 +9,7 @@ import 'package:PiliPlus/pages/download/view.dart';
 import 'package:PiliPlus/pages/dynamics/view.dart';
 import 'package:PiliPlus/pages/dynamics_create_vote/view.dart';
 import 'package:PiliPlus/pages/dynamics_detail/view.dart';
+import 'package:PiliPlus/pages/dynamics_forward/view.dart';
 import 'package:PiliPlus/pages/dynamics_topic/view.dart';
 import 'package:PiliPlus/pages/dynamics_topic_rcmd/view.dart';
 import 'package:PiliPlus/pages/fan/view.dart';
@@ -99,6 +100,8 @@ class Routes {
     GetPage(name: '/dynamics', page: () => const DynamicsPage()),
     // 动态详情
     GetPage(name: '/dynamicDetail', page: () => const DynamicDetailPage()),
+    // 动态转发详情
+    GetPage(name: '/dynamicForward', page: () => const DynForwardPage()),
     // 关注
     GetPage(name: '/follow', page: () => const FollowPage()),
     // 粉丝

--- a/lib/services/logger.dart
+++ b/lib/services/logger.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:PiliPlus/utils/json_file_handler.dart';
+import 'package:PiliPlus/utils/path_utils.dart';
 import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:catcher_2/utils/log_printer.dart';
 import 'package:flutter/foundation.dart';
@@ -22,7 +23,9 @@ abstract final class LoggerUtils {
   static Future<File> getLogsPath() async {
     if (_logFile != null) return _logFile!;
 
-    String dir = (await getApplicationDocumentsDirectory()).path;
+    final String dir = PathUtils.withDataSuffix(
+      (await getApplicationDocumentsDirectory()).path,
+    );
     final String filename = p.join(dir, '.pili_logs.json');
     final File file = File(filename);
     if (!file.existsSync()) {

--- a/lib/utils/cache_manager.dart
+++ b/lib/utils/cache_manager.dart
@@ -1,5 +1,6 @@
 import 'dart:io' show Directory, File;
 
+import 'package:PiliPlus/utils/path_utils.dart';
 import 'package:PiliPlus/utils/platform_utils.dart';
 import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:cached_network_image_ce/cached_network_image.dart';
@@ -9,8 +10,14 @@ import 'package:path_provider/path_provider.dart';
 abstract final class CacheManager {
   static late final DefaultCacheManager manager;
 
+  static Future<Directory> _cacheDirectoryProvider() async {
+    final tempDirectory = await getTemporaryDirectory();
+    return Directory(PathUtils.withDataSuffix(tempDirectory.path));
+  }
+
   static Future<void> ensureInitialized() => DefaultCacheManager.init(
     maxNrOfCacheLength: Pref.maxCacheSize.toInt(),
+    cacheDirectoryProvider: _cacheDirectoryProvider,
   ).then((i) => manager = i);
 
   // 获取缓存目录
@@ -21,7 +28,7 @@ abstract final class CacheManager {
         return manager.getTotalLength();
       }
 
-      final Directory tempDirectory = await getTemporaryDirectory();
+      final tempDirectory = Directory(tmpDirPath);
       if (tempDirectory.existsSync()) {
         return await getTotalSizeOfFilesInDir(tempDirectory);
       }
@@ -70,7 +77,7 @@ abstract final class CacheManager {
       await manager.emptyCache();
       if (PlatformUtils.isDesktop) return;
 
-      final tempDirectory = await getTemporaryDirectory();
+      final tempDirectory = Directory(tmpDirPath);
       if (tempDirectory.existsSync()) {
         await for (final file in tempDirectory.list(recursive: false)) {
           if (file is Directory && path.equals(file.path, manager.cacheDir)) {

--- a/lib/utils/path_utils.dart
+++ b/lib/utils/path_utils.dart
@@ -12,6 +12,11 @@ String get defDownloadPath =>
     path.join(appSupportDirPath, PathUtils.downloadDir);
 
 abstract final class PathUtils {
+  // Pass --dart-define=pili.dataSuffix=test to keep a development instance
+  // separate from the default instance. An empty value preserves old paths.
+  static const _rawDataSuffix = String.fromEnvironment('pili.dataSuffix');
+  static final dataSuffix = _sanitizeDataSuffix(_rawDataSuffix);
+
   static const videoNameType1 = '0.mp4';
   static const _fileExt = '.m4s';
   static const audioNameType2 = 'audio$_fileExt';
@@ -19,6 +24,17 @@ abstract final class PathUtils {
   static const coverName = 'cover.jpg';
   static const danmakuName = 'danmaku.pb';
   static const downloadDir = 'download';
+
+  static String withDataSuffix(String basePath) {
+    if (dataSuffix.isEmpty) return basePath;
+    return path.join(basePath, 'profiles', dataSuffix);
+  }
+
+  static String _sanitizeDataSuffix(String value) {
+    final suffix = value.trim();
+    if (suffix.isEmpty) return '';
+    return suffix.replaceAll(RegExp(r'[^A-Za-z0-9_-]'), '_');
+  }
 
   static String buildShadersAbsolutePath(
     String baseDirectory,

--- a/macos/Flutter/Flutter-Debug.xcconfig
+++ b/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/Flutter-Release.xcconfig
+++ b/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.14'
+platform :osx, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,72 +1,30 @@
 PODS:
-  - connectivity_plus (0.0.1):
+  - flutter_inappwebview_macos (0.0.1):
     - FlutterMacOS
-    - ReachabilitySwift
-  - device_info_plus (0.0.1):
-    - FlutterMacOS
-  - dynamic_color (0.0.2):
-    - FlutterMacOS
-  - flutter_volume_controller (0.0.1):
-    - FlutterMacOS
+    - OrderedSet (~> 6.0.3)
   - FlutterMacOS (1.0.0)
-  - FMDB (2.7.5):
-    - FMDB/standard (= 2.7.5)
-  - FMDB/standard (2.7.5)
   - media_kit_libs_macos_video (1.0.4):
     - FlutterMacOS
   - media_kit_native_event_loop (1.0.0):
     - FlutterMacOS
   - media_kit_video (0.0.1):
     - FlutterMacOS
-  - package_info_plus (0.0.1):
-    - FlutterMacOS
-  - path_provider_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - ReachabilitySwift (5.0.0)
-  - screen_brightness_macos (0.1.0):
-    - FlutterMacOS
-  - share_plus (0.0.1):
-    - FlutterMacOS
-  - sqflite (0.0.2):
-    - FlutterMacOS
-    - FMDB (>= 2.7.5)
-  - url_launcher_macos (0.0.1):
-    - FlutterMacOS
-  - wakelock_plus (0.0.1):
-    - FlutterMacOS
+  - OrderedSet (6.0.3)
 
 DEPENDENCIES:
-  - connectivity_plus (from `Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos`)
-  - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
-  - dynamic_color (from `Flutter/ephemeral/.symlinks/plugins/dynamic_color/macos`)
-  - flutter_volume_controller (from `Flutter/ephemeral/.symlinks/plugins/flutter_volume_controller/macos`)
+  - flutter_inappwebview_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_inappwebview_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - media_kit_libs_macos_video (from `Flutter/ephemeral/.symlinks/plugins/media_kit_libs_macos_video/macos`)
   - media_kit_native_event_loop (from `Flutter/ephemeral/.symlinks/plugins/media_kit_native_event_loop/macos`)
   - media_kit_video (from `Flutter/ephemeral/.symlinks/plugins/media_kit_video/macos`)
-  - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
-  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
-  - screen_brightness_macos (from `Flutter/ephemeral/.symlinks/plugins/screen_brightness_macos/macos`)
-  - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
-  - sqflite (from `Flutter/ephemeral/.symlinks/plugins/sqflite/macos`)
-  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
-  - wakelock_plus (from `Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos`)
 
 SPEC REPOS:
   trunk:
-    - FMDB
-    - ReachabilitySwift
+    - OrderedSet
 
 EXTERNAL SOURCES:
-  connectivity_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos
-  device_info_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos
-  dynamic_color:
-    :path: Flutter/ephemeral/.symlinks/plugins/dynamic_color/macos
-  flutter_volume_controller:
-    :path: Flutter/ephemeral/.symlinks/plugins/flutter_volume_controller/macos
+  flutter_inappwebview_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_inappwebview_macos/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
   media_kit_libs_macos_video:
@@ -75,40 +33,15 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/media_kit_native_event_loop/macos
   media_kit_video:
     :path: Flutter/ephemeral/.symlinks/plugins/media_kit_video/macos
-  package_info_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
-  path_provider_foundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
-  screen_brightness_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/screen_brightness_macos/macos
-  share_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
-  sqflite:
-    :path: Flutter/ephemeral/.symlinks/plugins/sqflite/macos
-  url_launcher_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
-  wakelock_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/wakelock_plus/macos
 
 SPEC CHECKSUMS:
-  connectivity_plus: 18d3c32514c886e046de60e9c13895109866c747
-  device_info_plus: 5401765fde0b8d062a2f8eb65510fb17e77cf07f
-  dynamic_color: 2eaa27267de1ca20d879fbd6e01259773fb1670f
-  flutter_volume_controller: 25d09126b0d695560f11c80b1311d5063fed882f
-  FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
-  media_kit_libs_macos_video: b3e2bbec2eef97c285f2b1baa7963c67c753fb82
-  media_kit_native_event_loop: 81fd5b45192b72f8b5b69eaf5b540f45777eb8d5
-  media_kit_video: c75b07f14d59706c775778e4dd47dd027de8d1e5
-  package_info_plus: 02d7a575e80f194102bef286361c6c326e4c29ce
-  path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
-  ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
-  screen_brightness_macos: 2d6d3af2165592d9a55ffcd95b7550970e41ebda
-  share_plus: 76dd39142738f7a68dd57b05093b5e8193f220f7
-  sqflite: a5789cceda41d54d23f31d6de539d65bb14100ea
-  url_launcher_macos: d2691c7dd33ed713bf3544850a623080ec693d95
-  wakelock_plus: 4783562c9a43d209c458cb9b30692134af456269
+  flutter_inappwebview_macos: c2d68649f9f8f1831bfcd98d73fd6256366d9d1d
+  FlutterMacOS: c232990155153907050900a2e175c7773903ba4e
+  media_kit_libs_macos_video: 85a23e549b5f480e72cae3e5634b5514bc692f65
+  media_kit_native_event_loop: a80d071c835c612fd80173e79390a50ec409f1b1
+  media_kit_video: fa6564e3799a0a28bff39442334817088b7ca758
+  OrderedSet: e539b66b644ff081c73a262d24ad552a69be3a94
 
-PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7
+PODFILE CHECKSUM: 505596d150d38022472859d890f709281982e016
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.17.0

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
 		70B7435992536DF7EF916102 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BA6434EEFB6EABF56163956B /* Pods_Runner.framework */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -73,6 +74,7 @@
 		A5BA27756D8018CEC961D98E /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		BA6434EEFB6EABF56163956B /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7AC3B7DF8D09FAFBD7AC6AD /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,6 +82,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				70B7435992536DF7EF916102 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -131,6 +134,7 @@
 		33CEB47122A05771004F2AC0 /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */,
 				33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */,
 				33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */,
@@ -175,6 +179,9 @@
 
 /* Begin PBXNativeTarget section */
 		33CC10EC2044A3C60003C045 /* Runner */ = {
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
@@ -200,10 +207,13 @@
 
 /* Begin PBXProject section */
 		33CC10E52044A3C60003C045 /* Project object */ = {
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
+			);
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					33CC10EC2044A3C60003C045 = {
@@ -405,7 +415,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -484,7 +494,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -531,7 +541,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -628,6 +638,18 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 33CC10E52044A3C60003C045 /* Project object */;
 }

--- a/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,10 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Prepare Flutter Framework Script"
+               scriptText = "&quot;$FLUTTER_ROOT&quot;/packages/flutter_tools/bin/macos_assemble.sh prepare&#10;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "33CC10EC2044A3C60003C045"
+                     BuildableName = "piliplus.app"
+                     BlueprintName = "Runner"
+                     ReferencedContainer = "container:Runner.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -48,6 +66,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -315,10 +315,10 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "762c99f890ca8bf87f7337236f99edd42793843bc6c3631da294a76653a54bd0"
+      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.1"
+    version: "6.1.5"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,7 +65,8 @@ dependencies:
       path: packages/chat_bottom_container
       ref: dev
   collection: ^1.19.1
-  connectivity_plus: ^7.1.1
+  # 7.x requires the macOS 26 SDK; keep 6.x for macOS 15/Xcode 16 builds.
+  connectivity_plus: 6.1.5
   cookie_jar: ^4.0.8
   crypto: ^3.0.6
   cupertino_ui: ^1.0.0


### PR DESCRIPTION
## 变更内容

- 新增动态转发列表 API、数据模型、分页控制器和详情页面。
- 将“转发详情”与评论、赞与转发统一为动态详情页 Tab；宽屏时显示在右侧面板。
- 统一转发列表项样式，头像顶部对齐，支持富文本、用户、话题和动态跳转。
- 增加 `pili.dataSuffix` 数据目录隔离能力，便于同时运行测试实例。
- 将 `connectivity_plus` 固定为 `6.1.5`，兼容 macOS 15 / Xcode 16。
- 更新 macOS Flutter/Xcode 生成配置。

## 验证

- `fvm flutter analyze` 通过。
- `fvm flutter test` 通过（2 项）。
- Xcode 16.4 下 `fvm flutter build macos --release` 成功。