### PR TITLE
feat: 评论树状显示

### DIFF
--- a/lib/grpc/reply.dart
+++ b/lib/grpc/reply.dart
@@ -89,6 +89,7 @@ abstract final class ReplyGrpc {
     required int rpid,
     required Mode mode,
     required String? offset,
+    Map<Int64, ReplyInfo>? removedOut, // 收集被屏蔽评论（树模式保留其数据）
   }) async {
     final res = await GrpcReq.request(
       GrpcUrl.detailList,
@@ -103,7 +104,11 @@ abstract final class ReplyGrpc {
       ),
       DetailListReply.fromBuffer,
     );
-    return res..dataOrNull?.root.replies.removeWhere(needRemoveGrpc);
+    return res..dataOrNull?.root.replies.removeWhere((reply) {
+      final removed = needRemoveGrpc(reply);
+      if (removed) removedOut?[reply.id] = reply;
+      return removed;
+    });
   }
 
   static Future<LoadingState<DialogListReply>> dialogList({

--- a/lib/pages/dynamics_mention/view.dart
+++ b/lib/pages/dynamics_mention/view.dart
@@ -45,12 +45,20 @@ class DynMentionPanel extends StatefulWidget {
         minChildSize: 0,
         maxChildSize: 1,
         initialChildSize: offset == 0 ? 0.65 : 1,
-        initialScrollOffset: offset,
         snapSizes: const [0.65],
-        builder: (context, scrollController) => DynMentionPanel(
-          scrollController: scrollController,
-          onCachePos: onCachePos,
-        ),
+        builder: (context, scrollController) {
+          if (offset > 0) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (scrollController.hasClients) {
+                scrollController.jumpTo(offset);
+              }
+            });
+          }
+          return DynMentionPanel(
+            scrollController: scrollController,
+            onCachePos: onCachePos,
+          );
+        },
       ),
     );
   }

--- a/lib/pages/dynamics_select_topic/view.dart
+++ b/lib/pages/dynamics_select_topic/view.dart
@@ -40,12 +40,20 @@ class SelectTopicPanel extends StatefulWidget {
         minChildSize: 0,
         maxChildSize: 1,
         initialChildSize: offset == 0 ? 0.65 : 1,
-        initialScrollOffset: offset,
         snapSizes: const [0.65],
-        builder: (context, scrollController) => SelectTopicPanel(
-          scrollController: scrollController,
-          onCachePos: onCachePos,
-        ),
+        builder: (context, scrollController) {
+          if (offset > 0) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (scrollController.hasClients) {
+                scrollController.jumpTo(offset);
+              }
+            });
+          }
+          return SelectTopicPanel(
+            scrollController: scrollController,
+            onCachePos: onCachePos,
+          );
+        },
       ),
     );
   }

--- a/lib/pages/setting/models/extra_settings.dart
+++ b/lib/pages/setting/models/extra_settings.dart
@@ -140,6 +140,23 @@ List<SettingsModel> get extraSettings => [
     defaultVal: true,
   ),
   const SwitchModel(
+    title: '树状显示评论回复',
+    subtitle: '根据回复关系整理楼中楼，按层级缩进显示，支持折叠',
+    leading: Icon(Icons.account_tree_outlined),
+    setKey: SettingBoxKey.replyTreeEnabled,
+    defaultVal: true,
+  ),
+  NormalModel(
+    title: '树状评论最大深度',
+    subtitle: '超过此深度的回复将显示"继续此讨论串"',
+    leading: const Icon(Icons.format_indent_increase),
+    getTrailing: (theme) => Text(
+      '${Pref.replyTreeMaxDepth}层',
+      style: theme.textTheme.titleSmall,
+    ),
+    onTap: _showReplyTreeDepthDialog,
+  ),
+  const SwitchModel(
     title: '默认展开视频简介',
     leading: Icon(Icons.expand_more),
     setKey: SettingBoxKey.alwaysExpandIntroPanel,
@@ -1202,4 +1219,27 @@ void _showCacheDialog(BuildContext context, VoidCallback setState) {
       ],
     ),
   );
+}
+
+Future<void> _showReplyTreeDepthDialog(
+  BuildContext context,
+  VoidCallback setState,
+) async {
+  final res = await showDialog<int>(
+    context: context,
+    builder: (context) => SelectDialog<int>(
+      title: '树状评论最大深度',
+      value: Pref.replyTreeMaxDepth,
+      values: const [
+        (2, '2层'),
+        (3, '3层'),
+        (4, '4层'),
+        (5, '5层'),
+      ],
+    ),
+  );
+  if (res != null) {
+    await GStorage.setting.put(SettingBoxKey.replyTreeMaxDepth, res);
+    setState();
+  }
 }

--- a/lib/pages/video/reply/widgets/reply_item_grpc.dart
+++ b/lib/pages/video/reply/widgets/reply_item_grpc.dart
@@ -67,6 +67,7 @@ class ReplyItemGrpc extends StatelessWidget {
     required this.replyLevel,
     this.replyReply,
     this.needDivider = true,
+    this.enableViewDialogue = true,
     this.onReply,
     this.onDelete,
     this.upMid,
@@ -81,6 +82,7 @@ class ReplyItemGrpc extends StatelessWidget {
   final int replyLevel;
   final Function(ReplyInfo replyItem, int? rpid)? replyReply;
   final bool needDivider;
+  final bool enableViewDialogue;
   final ValueChanged<ReplyInfo>? onReply;
   final Function(ReplyInfo replyItem, int? subIndex)? onDelete;
   final Int64? upMid;
@@ -488,7 +490,10 @@ class ReplyItemGrpc extends StatelessWidget {
     );
 
     Widget? dialogBtn;
-    if (replyLevel == 2 && needDivider && replyItem.id != replyItem.dialog) {
+    if (replyLevel == 2 &&
+        needDivider &&
+        enableViewDialogue &&
+        replyItem.id != replyItem.dialog) {
       dialogBtn = SizedBox(
         height: 32,
         child: TextButton(

--- a/lib/pages/video/reply_reply/controller.dart
+++ b/lib/pages/video/reply_reply/controller.dart
@@ -5,6 +5,7 @@ import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/pages/common/publish/publish_route.dart';
 import 'package:PiliPlus/pages/common/reply_controller.dart';
 import 'package:PiliPlus/pages/video/reply_new/view.dart';
+import 'package:PiliPlus/pages/video/reply_reply/reply_tree.dart';
 import 'package:PiliPlus/utils/id_utils.dart';
 import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:extended_nested_scroll_view/extended_nested_scroll_view.dart';
@@ -23,6 +24,9 @@ class VideoReplyReplyController extends ReplyController
     required this.rpid,
     required this.dialog,
     required this.replyType,
+    this.seedReplies,
+    this.seedRootId,
+    this.seedOffset,
   });
   final int? dialog;
   int? id;
@@ -32,12 +36,49 @@ class VideoReplyReplyController extends ReplyController
   int rpid;
   int replyType;
 
+  // seed 模式：复用父面板已加载数据，不再请求深层评论
+  final List<ReplyInfo>? seedReplies;
+  final int? seedRootId;
+  final String? seedOffset;
+  bool get isSeedMode => seedReplies != null;
+  Worker? _seedCountWorker;
+
+  /// seed 模式下过滤为深层评论的子树（不含其自身），否则返回原数据
+  List<ReplyInfo> get subtreeData {
+    final data = loadingState.value.data;
+    if (!isSeedMode || data == null) return data ?? const [];
+    return extractSubtree(data, Int64(rpid));
+  }
+
+  /// 树输入：有效 flat（保留被屏蔽 + 合成缺失父）+ suppressed 映射
+  ({List<ReplyInfo> flat, Map<Int64, ReplySuppressReason> suppressed})
+      get treeInput => buildTreeInput(
+            replies: subtreeData,
+            removed: _removedReplies,
+            rootId: Int64(rpid),
+          );
+
   bool hasRoot = false;
   final firstFloor = Rxn<ReplyInfo>();
 
   final index = RxnInt();
 
   final listController = ListController();
+
+  /// 树状模式下的折叠节点 rpid 集合
+  final collapsedRpids = <Int64>{}.obs;
+
+  /// 当前悬停的引导线所属节点 rpid（整条线跨行高亮）；null = 无
+  final hoveredLine = Rxn<Int64>();
+
+  /// detailList 过滤掉的被屏蔽评论（rpid → ReplyInfo），树模式保留其数据
+  final _removedReplies = <Int64, ReplyInfo>{};
+
+  void toggleCollapse(Int64 rpid) {
+    if (!collapsedRpids.remove(rpid)) {
+      collapsedRpids.add(rpid);
+    }
+  }
 
   AnimationController? _controller;
   AnimationController get animController => _controller ??= AnimationController(
@@ -56,7 +97,23 @@ class VideoReplyReplyController extends ReplyController
     final cacheSortType = Pref.reply2SortType;
     sortType.value = cacheSortType;
     mode = cacheSortType == .time ? Mode.MAIN_LIST_TIME : Mode.MAIN_LIST_HOT;
-    queryData();
+    if (isSeedMode) {
+      // seed 模式：直接用父面板已加载数据，跳过 DetailList(root=深层评论)（该请求必然返回空）
+      loadingState.value = Success(seedReplies);
+      isEnd = seedOffset == null;
+      _refreshSeedCount();
+      // 每次数据变化后重算子树计数（增量续拉追加后）
+      _seedCountWorker = ever(loadingState, (_) => _refreshSeedCount());
+    } else {
+      queryData();
+    }
+  }
+
+  void _refreshSeedCount() {
+    final data = loadingState.value.data;
+    if (data != null) {
+      count.value = extractSubtree(data, Int64(rpid)).length;
+    }
   }
 
   @override
@@ -75,7 +132,14 @@ class VideoReplyReplyController extends ReplyController
 
     // reply2Reply // isDialogue.not
     if (data is DetailListReply) {
-      count.value = data.root.count.toInt();
+      if (isRefresh) {
+        collapsedRpids.clear();
+        _removedReplies.clear();
+      }
+      // seed 模式的 count 由子树大小决定（见 _refreshSeedCount），不覆盖
+      if (!isSeedMode) {
+        count.value = data.root.count.toInt();
+      }
       if (isRefresh && !hasRoot) {
         firstFloor.value ??= data.root;
       }
@@ -89,6 +153,29 @@ class VideoReplyReplyController extends ReplyController
   }
 
   bool setIndexById(Int64 id64, [List<ReplyInfo>? replies]) {
+    final useTree = dialog == null && Pref.replyTreeEnabled;
+    if (useTree) {
+      final input = buildTreeInput(
+        replies: replies ?? subtreeData,
+        removed: _removedReplies,
+        rootId: Int64(rpid),
+      );
+      final rows = buildReplyTree(
+        flat: input.flat,
+        rootId: Int64(rpid),
+        collapsed: collapsedRpids,
+        maxDepth: Pref.replyTreeMaxDepth,
+      );
+      final index = rows.indexWhere(
+        (row) => row is ReplyTreeItem && row.reply.id == id64,
+      );
+      if (index != -1) {
+        this.index.value = index;
+        jumpToItem(index);
+        return true;
+      }
+      return false;
+    }
     final index = (replies ?? loadingState.value.data!).indexWhere(
       (item) => item.id == id64,
     );
@@ -121,29 +208,87 @@ class VideoReplyReplyController extends ReplyController
   }
 
   @override
-  Future<LoadingState> customGetData() => dialog != null
-      ? ReplyGrpc.dialogList(
-          type: replyType,
-          oid: oid,
-          root: rpid,
-          dialog: dialog!,
-          offset: paginationReply?.nextOffset,
-        )
-      : ReplyGrpc.detailList(
-          type: replyType,
-          oid: oid,
-          root: rpid,
-          rpid: id ?? 0,
-          mode: mode,
-          offset: paginationReply?.nextOffset,
-        );
+  Future<LoadingState> customGetData() {
+    if (isSeedMode) {
+      return ReplyGrpc.detailList(
+        type: replyType,
+        oid: oid,
+        root: seedRootId ?? 0,
+        rpid: 0,
+        mode: mode,
+        offset: paginationReply?.nextOffset ?? seedOffset,
+        removedOut: _removedReplies,
+      );
+    }
+    return dialog != null
+        ? ReplyGrpc.dialogList(
+            type: replyType,
+            oid: oid,
+            root: rpid,
+            dialog: dialog!,
+            offset: paginationReply?.nextOffset,
+          )
+        : ReplyGrpc.detailList(
+            type: replyType,
+            oid: oid,
+            root: rpid,
+            rpid: id ?? 0,
+            mode: mode,
+            offset: paginationReply?.nextOffset,
+            removedOut: _removedReplies,
+          );
+  }
+
+  @override
+  void checkIsEnd(int length) {
+    if (isSeedMode) return; // seed 模式以 API cursor.isEnd 为准
+    super.checkIsEnd(length);
+  }
+
+  @override
+  Future<void> onRefresh() {
+    if (isSeedMode) return _continueSeedLoad();
+    return super.onRefresh();
+  }
+
+  @override
+  Future<void> onLoadMore() {
+    if (isSeedMode) return _continueSeedLoad();
+    return super.onLoadMore();
+  }
+
+  /// seed 模式增量续拉：从 seedOffset 起连续翻页，直到 isEnd 或无新数据
+  Future<void> _continueSeedLoad() async {
+    if (isLoading || isEnd) return;
+    var guard = 0;
+    while (!isEnd && guard < 50) {
+      guard++;
+      final before = loadingState.value.data?.length ?? 0;
+      await queryData(false);
+      final after = loadingState.value.data?.length ?? 0;
+      if (after <= before) break; // 无新数据，避免死循环
+    }
+  }
 
   @override
   Future<void> onReload() {
+    if (isSeedMode) {
+      // seed 模式重新展示 seed 数据，避免 Loading 骨架卡死（排序对子树视图无意义）
+      index.value = null;
+      loadingState.value = Success(seedReplies);
+      _refreshSeedCount();
+      return Future.value();
+    }
     if (loadingState.value.isSuccess) {
       index.value = null;
     }
     return super.onReload();
+  }
+
+  @override
+  void queryBySort() {
+    if (isSeedMode) return; // 排序对 seed 子树视图无意义
+    super.queryBySort();
   }
 
   @override
@@ -204,6 +349,7 @@ class VideoReplyReplyController extends ReplyController
 
   @override
   void onClose() {
+    _seedCountWorker?.dispose();
     _controller?.dispose();
     _controller = null;
     super.dispose();

--- a/lib/pages/video/reply_reply/controller.dart
+++ b/lib/pages/video/reply_reply/controller.dart
@@ -27,6 +27,7 @@ class VideoReplyReplyController extends ReplyController
     this.seedReplies,
     this.seedRootId,
     this.seedOffset,
+    this.removedReplies,
   });
   final int? dialog;
   int? id;
@@ -35,6 +36,9 @@ class VideoReplyReplyController extends ReplyController
   // rpid 请求楼中楼回复
   int rpid;
   int replyType;
+
+  /// 继承自父面板（seed 模式）的被屏蔽评论数据（rpid → ReplyInfo）
+  final Map<Int64, ReplyInfo>? removedReplies;
 
   // seed 模式：复用父面板已加载数据，不再请求深层评论
   final List<ReplyInfo>? seedReplies;
@@ -57,6 +61,9 @@ class VideoReplyReplyController extends ReplyController
             removed: _removedReplies,
             rootId: Int64(rpid),
           );
+
+  /// 已收集的被屏蔽评论（rpid → ReplyInfo），供子面板 seed 模式继承
+  Map<Int64, ReplyInfo> get blockedReplies => _removedReplies;
 
   bool hasRoot = false;
   final firstFloor = Rxn<ReplyInfo>();
@@ -97,6 +104,10 @@ class VideoReplyReplyController extends ReplyController
     final cacheSortType = Pref.reply2SortType;
     sortType.value = cacheSortType;
     mode = cacheSortType == .time ? Mode.MAIN_LIST_TIME : Mode.MAIN_LIST_HOT;
+    // seed 模式：父面板已过滤掉被屏蔽评论，这里继承其收集结果以重建占位
+    if (removedReplies case final removedReplies?) {
+      _removedReplies.addAll(removedReplies);
+    }
     if (isSeedMode) {
       // seed 模式：直接用父面板已加载数据，跳过 DetailList(root=深层评论)（该请求必然返回空）
       loadingState.value = Success(seedReplies);
@@ -134,7 +145,6 @@ class VideoReplyReplyController extends ReplyController
     if (data is DetailListReply) {
       if (isRefresh) {
         collapsedRpids.clear();
-        _removedReplies.clear();
       }
       // seed 模式的 count 由子树大小决定（见 _refreshSeedCount），不覆盖
       if (!isSeedMode) {
@@ -248,6 +258,8 @@ class VideoReplyReplyController extends ReplyController
   @override
   Future<void> onRefresh() {
     if (isSeedMode) return _continueSeedLoad();
+    // 刷新前清空上一轮收集的被屏蔽评论，请求返回后 detailList 重新收集
+    _removedReplies.clear();
     return super.onRefresh();
   }
 

--- a/lib/pages/video/reply_reply/reply_tree.dart
+++ b/lib/pages/video/reply_reply/reply_tree.dart
@@ -1,0 +1,375 @@
+import 'package:PiliPlus/grpc/bilibili/main/community/reply/v1.pb.dart'
+    show ReplyInfo, Content, Member;
+import 'package:fixnum/fixnum.dart';
+import 'dart:math' as math;
+
+/// 树渲染的扁平行：Item = 实际回复；DeepLink = 深度截断占位行
+sealed class ReplyTreeRow {
+  ReplyTreeRow({
+    required this.depth,
+    this.ancestors = const [],
+    this.lastAtLevel = const [],
+    this.lineAtLevel = const [],
+  });
+  final int depth;
+
+  /// 各级祖先 rpids，供点击引导线时折叠对应子树。由 buildReplyTree 填充。
+  final List<Int64> ancestors;
+
+  /// lineAtLevel[k]：第 k 层引导线在本行是否绘制；lastAtLevel[k]：本行是否为其最后一个直接子节点。
+  List<bool> lastAtLevel;
+  List<bool> lineAtLevel;
+}
+
+class ReplyTreeItem extends ReplyTreeRow {
+  ReplyTreeItem({
+    required super.depth,
+    required this.flatIndex,
+    required this.reply,
+    required this.hasChildren,
+    super.ancestors = const [],
+    super.lastAtLevel = const [],
+    super.lineAtLevel = const [],
+  });
+  final int flatIndex;
+  final ReplyInfo reply;
+  final bool hasChildren;
+}
+
+class ReplyTreeDeepLink extends ReplyTreeRow {
+  ReplyTreeDeepLink({
+    required super.depth,
+    required this.rpid,
+    required this.count,
+    super.ancestors = const [],
+    super.lastAtLevel = const [],
+    super.lineAtLevel = const [],
+  });
+  final Int64 rpid;
+  final int count;
+}
+
+class _Node {
+  _Node(this.reply);
+  final ReplyInfo reply;
+  final List<_Node> children = [];
+}
+
+/// 由扁平子回复列表构建树并扁平化为行序列。
+///
+/// - parent == rootId → 本线程根节点（depth 0）
+/// - parent 不在集合中（被删 / 未加载 / 自引用）→ 升级为根节点
+/// - 每层按 ctime 升序；DFS 保证父行紧跟其子树
+/// - 命中 collapsed 的节点折叠整棵子树：只输出该节点自身，不输出任何子行
+/// - 深度 >= maxDepth 且有子节点时输出 ReplyTreeDeepLink 占位行，截断子树
+/// - 每行附带 lineAtLevel（该层竖线在本行是否绘制）/ lastAtLevel（该层竖线在本行收尾）
+///   与 ancestors（供点击折叠）
+List<ReplyTreeRow> buildReplyTree({
+  required List<ReplyInfo> flat,
+  required Int64 rootId,
+  required Set<Int64> collapsed,
+  required int maxDepth,
+}) {
+  final map = <Int64, _Node>{};
+  final indexMap = <Int64, int>{};
+  for (var i = 0; i < flat.length; i++) {
+    map[flat[i].id] = _Node(flat[i]);
+    indexMap[flat[i].id] = i;
+  }
+
+  final roots = <_Node>[];
+  for (final reply in flat) {
+    final node = map[reply.id]!;
+    final parent = reply.parent != rootId ? map[reply.parent] : null;
+    if (parent != null && parent != node) {
+      parent.children.add(node);
+    } else {
+      roots.add(node);
+    }
+  }
+
+  int cmp(_Node a, _Node b) => a.reply.ctime.compareTo(b.reply.ctime);
+  void sortNode(_Node node) {
+    node.children.sort(cmp);
+    for (final child in node.children) {
+      sortNode(child);
+    }
+  }
+
+  roots.sort(cmp);
+  for (final root in roots) {
+    sortNode(root);
+  }
+
+  int subtreeSize(_Node node) =>
+      1 + node.children.fold(0, (sum, c) => sum + subtreeSize(c));
+
+  final rows = <ReplyTreeRow>[];
+  final visited = <Int64>{};
+  final rowIndex = <Int64, int>{}; // 节点 id -> 其 Item 行下标
+  final nodesInOrder = <_Node>[]; // 按行序收集的节点
+  final truncated = <Int64>{}; // 被深度截断的节点 id
+  var lastDepth0Row = 0; // 最后一个 depth-0 行下标（主引导线终点）
+
+  void walk(_Node node, int depth, List<Int64> ancestors) {
+    if (!visited.add(node.reply.id)) return; // 环保护
+    final idx = rows.length;
+    rowIndex[node.reply.id] = idx;
+    nodesInOrder.add(node);
+    if (depth == 0) {
+      lastDepth0Row = idx;
+    }
+    rows.add(
+      ReplyTreeItem(
+        depth: depth,
+        flatIndex: indexMap[node.reply.id]!,
+        reply: node.reply,
+        hasChildren: node.children.isNotEmpty,
+        ancestors: List.of(ancestors),
+      ),
+    );
+    final path = [...ancestors, node.reply.id];
+    if (collapsed.contains(node.reply.id) && node.children.isNotEmpty) {
+      return; // 折叠：不输出子树
+    }
+    if (depth >= maxDepth && node.children.isNotEmpty) {
+      truncated.add(node.reply.id);
+      rows.add(
+        ReplyTreeDeepLink(
+          depth: depth + 1,
+          rpid: node.reply.id,
+          count: subtreeSize(node) - 1,
+          ancestors: path,
+        ),
+      );
+      return;
+    }
+    for (final child in node.children) {
+      walk(child, depth + 1, path);
+    }
+  }
+
+  for (final root in roots) {
+    walk(root, 0, const []);
+  }
+
+  // 不可达节点（循环引用等）追加为根节点，避免丢失
+  final reachable = <Int64>{};
+  void markReachable(_Node node) {
+    if (!reachable.add(node.reply.id)) return;
+    for (final child in node.children) {
+      markReachable(child);
+    }
+  }
+  for (final root in roots) {
+    markReachable(root);
+  }
+  final extraRoots = map.values
+      .where((node) => !reachable.contains(node.reply.id))
+      .toList()
+    ..sort(cmp);
+  for (final root in extraRoots) {
+    walk(root, 0, const []);
+  }
+
+  // 每个节点最后一个直接子节点的行下标，决定其引导线的终止位置
+  final lastChildRow = <Int64, int>{};
+  for (final node in nodesInOrder) {
+    if (node.children.isEmpty) continue;
+    if (collapsed.contains(node.reply.id) || truncated.contains(node.reply.id)) {
+      continue; // 子节点未被 walk，无直接子节点行
+    }
+    final lastChild = node.children.last;
+    final idx = rowIndex[lastChild.reply.id];
+    if (idx != null) {
+      lastChildRow[node.reply.id] = idx;
+    }
+  }
+
+  // 填充每行的 lineAtLevel / lastAtLevel：
+  // 第 k 层线属于 ancestors[k-1]（k>=1）或头部评论（k=0），终止于其最后直接子节点。
+  List<bool> lineFlags(int i, int depth, List<Int64> ancestors) =>
+      List.generate(depth + 1, (k) {
+        if (k == 0) return i <= lastDepth0Row;
+        if (k == depth && rows[i] is ReplyTreeDeepLink) {
+          return true; // 截断节点的线延伸到按钮行
+        }
+        return i <= (lastChildRow[ancestors[k - 1]] ?? -1);
+      });
+  List<bool> lastFlags(int i, int depth, List<Int64> ancestors) =>
+      List.generate(depth + 1, (k) {
+        if (k == 0) return i == lastDepth0Row;
+        if (k == depth && rows[i] is ReplyTreeDeepLink) {
+          return true;
+        }
+        return i == (lastChildRow[ancestors[k - 1]] ?? -2);
+      });
+  for (var i = 0; i < rows.length; i++) {
+    final item = rows[i];
+    item
+      ..lineAtLevel = lineFlags(i, item.depth, item.ancestors)
+      ..lastAtLevel = lastFlags(i, item.depth, item.ancestors);
+  }
+
+  return rows;
+}
+
+/// 从扁平列表中提取以 rootId 为根的子树的全部节点（含间接后代，不含 rootId 自身）。
+///
+/// 用于「继续此讨论串」：父面板已加载整棵楼中楼的扁平列表，
+/// 从中提取深层评论的子树作为新面板的数据源。
+/// 保持原列表顺序，供 flatIndex 使用。
+List<ReplyInfo> extractSubtree(List<ReplyInfo> flat, Int64 rootId) {
+  final children = <Int64, List<ReplyInfo>>{};
+  for (final r in flat) {
+    (children[r.parent] ??= []).add(r);
+  }
+
+  final result = <ReplyInfo>[];
+  final visited = <Int64>{rootId};
+  final stack = <Int64>[rootId];
+  while (stack.isNotEmpty) {
+    final pid = stack.removeLast();
+    for (final child in children[pid] ?? const <ReplyInfo>[]) {
+      if (visited.add(child.id)) {
+        result.add(child);
+        stack.add(child.id);
+      }
+    }
+  }
+  return result;
+}
+
+/// 无法显示父评论的原因分类
+enum ReplySuppressReason { deleted, blocked }
+
+/// 子回复前导 @ 提及的正则
+final _mentionRe = RegExp(r'^@([^@\s：:，,]+)');
+
+/// 从回复的 @提及提取 (名字, 头像, mid)。
+/// 前导 `@名字` 查 `content.members`（含 face）；mid 优先取 `atNameToMid`；
+/// 皆无则回退 members 首项；空则返回 null。
+(String name, String? face, Int64 mid)? extractMention(ReplyInfo reply) {
+  final content = reply.content;
+  final match = _mentionRe.firstMatch(content.message);
+  final lead = match?.group(1);
+  if (lead != null) {
+    final member = content.members[lead];
+    final mid = content.atNameToMid[lead];
+    if (member != null) return (member.name, member.face, mid ?? member.mid);
+    if (mid != null) return (lead, null, mid);
+  }
+  if (content.members.isNotEmpty) {
+    final m = content.members.values.first;
+    return (m.name, m.face, m.mid);
+  }
+  if (content.atNameToMid.isNotEmpty) {
+    final name = content.atNameToMid.keys.first;
+    return (name, null, content.atNameToMid[name]!);
+  }
+  return null;
+}
+
+/// 树输入派生：保留被屏蔽评论 + 合成缺失父占位。
+///
+/// 返回 (有效 flat, suppressed 映射) 供 `buildReplyTree` 与视图渲染使用。
+/// - `removed`：detailList 过滤掉的被屏蔽评论，仅保留「是某条真实回复祖先」者
+///   （沿 parent 链自底向上）；被屏蔽叶评论不保留、不渲染。
+/// - 缺失父（≠ rootId、不在 flat）合成一条「已删除」占位：第一条引用它的子评论
+///   加载后即形成，父稍后加载时自愈为真实评论。ctime 取子评论最小 ctime，
+///   名字/头像/mid 取自子回复 @提及。
+({List<ReplyInfo> flat, Map<Int64, ReplySuppressReason> suppressed}) buildTreeInput({
+  required List<ReplyInfo> replies,
+  required Map<Int64, ReplyInfo> removed,
+  required Int64 rootId,
+}) {
+  final suppressed = <Int64, ReplySuppressReason>{};
+  final flat = <ReplyInfo>[...replies];
+  final idSet = <Int64>{}..addAll(flat.map((r) => r.id));
+
+  // 1) 保留「是某条真实回复祖先」的被屏蔽评论（沿 parent 链自底向上）
+  final kept = <Int64, ReplyInfo>{};
+  for (final r in replies) {
+    var cur = r.parent;
+    while (cur != rootId &&
+        !idSet.contains(cur) &&
+        removed.containsKey(cur) &&
+        !kept.containsKey(cur)) {
+      kept[cur] = removed[cur]!;
+      cur = removed[cur]!.parent;
+    }
+  }
+  flat.addAll(kept.values);
+  for (final k in kept.keys) {
+    suppressed[k] = ReplySuppressReason.blocked;
+    idSet.add(k);
+  }
+
+  // 2) 对缺失父合成「已删除」占位（第一条引用它的子评论加载后即形成；父稍后加载则自愈）
+  final toAdd = <Int64, ReplyInfo>{};
+  for (final r in List.of(flat)) {
+    final p = r.parent;
+    if (p == rootId || idSet.contains(p)) {
+      continue;
+    }
+    final children = flat.where((c) => c.parent == p).toList();
+    if (children.isEmpty) continue;
+    (String, String?, Int64)? mention;
+    for (final c in children) {
+      final m = extractMention(c);
+      if (m != null) {
+        mention = m;
+        break;
+      }
+    }
+    var minCtime = Int64.MAX_VALUE;
+    for (final c in children) {
+      if (c.ctime < minCtime) minCtime = c.ctime;
+    }
+    final syn = ReplyInfo()
+      ..id = p
+      ..parent = rootId
+      ..root = rootId
+      ..ctime = minCtime
+      ..content = Content();
+    if (mention != null) {
+      syn
+        ..mid = mention.$3
+        ..member = (Member()
+          ..mid = mention.$3
+          ..name = mention.$1
+          ..face = mention.$2 ?? '');
+    }
+    toAdd[p] = syn;
+    suppressed[p] = ReplySuppressReason.deleted;
+    idSet.add(p);
+  }
+  flat.addAll(toAdd.values);
+
+  return (flat: flat, suppressed: suppressed);
+}
+
+/// 逐级递减缩进：第 k 级步进 = base·decay^k（下限 minStep），
+/// indentAt(k) 为前 k 级累积偏移。纯几何，无像素常量。
+class ReplyTreeIndent {
+  ReplyTreeIndent({
+    required this.base,
+    this.decay = 0.85,
+    this.minStep = 22,
+  });
+  final double base;
+  final double decay;
+  final double minStep;
+
+  /// 第 k 级自身步进（受 minStep 下限约束）。
+  double stepAt(int k) => math.max(base * math.pow(decay, k), minStep);
+
+  /// 前 k 级累积偏移；indentAt(0) == 0。
+  double indentAt(int k) {
+    var s = 0.0;
+    for (var i = 0; i < k; i++) {
+      s += stepAt(i);
+    }
+    return s;
+  }
+}

--- a/lib/pages/video/reply_reply/reply_tree.dart
+++ b/lib/pages/video/reply_reply/reply_tree.dart
@@ -243,12 +243,13 @@ List<ReplyInfo> extractSubtree(List<ReplyInfo> flat, Int64 rootId) {
 /// 无法显示父评论的原因分类
 enum ReplySuppressReason { deleted, blocked }
 
-/// 子回复前导 @ 提及的正则
-final _mentionRe = RegExp(r'^@([^@\s：:，,]+)');
+/// 回复消息中的 @提及正则（支持「回复 @xx : …」等非前缀位置）
+final _mentionRe = RegExp(r'@([^@\s：:，,]+)');
 
 /// 从回复的 @提及提取 (名字, 头像, mid)。
-/// 前导 `@名字` 查 `content.members`（含 face）；mid 优先取 `atNameToMid`；
-/// 皆无则回退 members 首项；空则返回 null。
+/// 消息文本里的 `@名字` 优先查 `content.members`（含 face）、`atNameToMid`；
+/// 改名/失效的提及未解析为成员时，回退只取文本中的名字（无头像无 mid）；
+/// 消息无 @ 时回退 members / atNameToMid 首项；皆空则返回 null。
 (String name, String? face, Int64 mid)? extractMention(ReplyInfo reply) {
   final content = reply.content;
   final match = _mentionRe.firstMatch(content.message);
@@ -258,6 +259,7 @@ final _mentionRe = RegExp(r'^@([^@\s：:，,]+)');
     final mid = content.atNameToMid[lead];
     if (member != null) return (member.name, member.face, mid ?? member.mid);
     if (mid != null) return (lead, null, mid);
+    return (lead, null, Int64.ZERO); // 提及未解析为成员：名字仅取自文本
   }
   if (content.members.isNotEmpty) {
     final m = content.members.values.first;
@@ -287,8 +289,9 @@ final _mentionRe = RegExp(r'^@([^@\s：:，,]+)');
   final flat = <ReplyInfo>[...replies];
   final idSet = <Int64>{}..addAll(flat.map((r) => r.id));
 
-  // 1) 保留「是某条真实回复祖先」的被屏蔽评论（沿 parent 链自底向上）
+  // 1) 保留「是某条真实回复祖先」或被删父级引用的被屏蔽评论
   final kept = <Int64, ReplyInfo>{};
+  // 1a) 沿真实回复的 parent 链自底向上保留被屏蔽祖先
   for (final r in replies) {
     var cur = r.parent;
     while (cur != rootId &&
@@ -297,6 +300,18 @@ final _mentionRe = RegExp(r'^@([^@\s：:，,]+)');
         !kept.containsKey(cur)) {
       kept[cur] = removed[cur]!;
       cur = removed[cur]!.parent;
+    }
+  }
+  // 1b) 保留「父级缺失」的被屏蔽评论：父既非真实回复、也非被屏蔽评论
+  //     （父被删/未加载 → 将被合成为 deleted 占位，屏蔽评论作为锚点，
+  //     避免「父删 + 子屏」时整条链丢失；父为被屏蔽叶评论则不保留）
+  final realIds = Set<Int64>.of(idSet);
+  for (final entry in removed.entries) {
+    final b = entry.value;
+    if (kept.containsKey(b.id)) continue;
+    final bp = b.parent;
+    if (bp != rootId && !realIds.contains(bp) && !removed.containsKey(bp)) {
+      kept[b.id] = b;
     }
   }
   flat.addAll(kept.values);
@@ -343,6 +358,20 @@ final _mentionRe = RegExp(r'^@([^@\s：:，,]+)');
     toAdd[p] = syn;
     suppressed[p] = ReplySuppressReason.deleted;
     idSet.add(p);
+  }
+
+  // 3) dialog 分组启发式：被删占位挂到已知对话祖先之下（深度取浅收紧）
+  for (final p in toAdd.keys) {
+    Int64? anchor;
+    for (final c in flat) {
+      if (c.parent != p) continue;
+      final d = c.dialog;
+      if (!d.isZero && d != p && idSet.contains(d)) {
+        anchor = d;
+        break;
+      }
+    }
+    if (anchor != null) toAdd[p]!.parent = anchor;
   }
   flat.addAll(toAdd.values);
 

--- a/lib/pages/video/reply_reply/view.dart
+++ b/lib/pages/video/reply_reply/view.dart
@@ -1,9 +1,12 @@
+import 'dart:math' as math;
+
 import 'package:PiliPlus/common/skeleton/video_reply.dart';
 import 'package:PiliPlus/common/sliver_single_child_delegate.dart';
 import 'package:PiliPlus/common/style.dart';
 import 'package:PiliPlus/common/widgets/colored_box_transition.dart';
 import 'package:PiliPlus/common/widgets/flutter/refresh_indicator.dart';
 import 'package:PiliPlus/common/widgets/loading_widget/http_error.dart';
+import 'package:PiliPlus/common/widgets/pendant_avatar.dart';
 import 'package:PiliPlus/common/widgets/scaffold/mini_scaffold.dart';
 import 'package:PiliPlus/common/widgets/scaffold/simple_scaffold.dart';
 import 'package:PiliPlus/common/widgets/simple_colored_box.dart';
@@ -15,13 +18,17 @@ import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/pages/common/slide/common_slide_page.dart';
 import 'package:PiliPlus/pages/video/reply/widgets/reply_item_grpc.dart';
 import 'package:PiliPlus/pages/video/reply_reply/controller.dart';
+import 'package:PiliPlus/pages/video/reply_reply/reply_tree.dart';
 import 'package:PiliPlus/utils/app_scheme.dart';
 import 'package:PiliPlus/utils/extension/widget_ext.dart';
+import 'package:PiliPlus/utils/feed_back.dart';
 import 'package:PiliPlus/utils/num_utils.dart';
 import 'package:PiliPlus/utils/parse_string.dart';
+import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:PiliPlus/utils/utils.dart';
 import 'package:extended_nested_scroll_view/extended_nested_scroll_view.dart';
 import 'package:fixnum/fixnum.dart' show Int64;
+import 'package:flutter/gestures.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:get/get.dart';
 import 'package:material_ui/material_ui.dart';
@@ -36,6 +43,9 @@ class VideoReplyReplyPanel extends CommonSlidePage {
     required this.rpid,
     this.dialog,
     this.firstFloor,
+    this.seedReplies,
+    this.seedRootId,
+    this.seedOffset,
     required this.isVideoDetail,
     required this.replyType,
     this.isNested = false,
@@ -46,6 +56,9 @@ class VideoReplyReplyPanel extends CommonSlidePage {
   final int rpid;
   final int? dialog;
   final ReplyInfo? firstFloor;
+  final List<ReplyInfo>? seedReplies;
+  final int? seedRootId;
+  final String? seedOffset;
   final bool isVideoDetail;
   final int replyType;
   final bool isNested;
@@ -130,6 +143,9 @@ class _VideoReplyReplyPanelState extends State<VideoReplyReplyPanel>
         rpid: widget.rpid,
         dialog: widget.dialog,
         replyType: widget.replyType,
+        seedReplies: widget.seedReplies,
+        seedRootId: widget.seedRootId,
+        seedOffset: widget.seedOffset,
       ),
       tag: _tag,
     );
@@ -209,10 +225,29 @@ class _VideoReplyReplyPanelState extends State<VideoReplyReplyPanel>
                 }
                 return _header(theme, firstFloor);
               }),
-            _sortWidget(theme.colorScheme),
+            Obx(() {
+              // 整树折叠时不显示分隔行
+              _controller.collapsedRpids.length;
+              return _sortWidget(
+                theme.colorScheme,
+                hide: Pref.replyTreeEnabled &&
+                    _controller.collapsedRpids.contains(Int64(widget.rpid)),
+              );
+            }),
           ],
           Obx(
-            () => _buildBody(theme.colorScheme, _controller.loadingState.value),
+            () {
+              final state = _controller.loadingState.value;
+              // 订阅折叠状态变化，避免嵌套 Obx 导致生命周期冲突
+              _controller.collapsedRpids.length;
+              // 整树折叠：不渲染任何树行
+              if (!isDialogue &&
+                  Pref.replyTreeEnabled &&
+                  _controller.collapsedRpids.contains(Int64(widget.rpid))) {
+                return const SliverToBoxAdapter();
+              }
+              return _buildBody(theme.colorScheme, state);
+            },
           ),
         ],
       ),
@@ -220,17 +255,28 @@ class _VideoReplyReplyPanelState extends State<VideoReplyReplyPanel>
   }
 
   Widget _header(ThemeData theme, ReplyInfo firstFloor) {
+    final colorScheme = theme.colorScheme;
+    final replyItem = ReplyItemGrpc(
+      replyItem: firstFloor,
+      replyLevel: 2,
+      needDivider: false,
+      onReply: (replyItem) => _controller.onReply(replyItem, index: -1),
+      upMid: widget.upMid ?? _controller.upMid,
+      onCheckReply: (item) => _controller.onCheckReply(item, isManual: true),
+    );
     return SliverMainAxisGroup(
       slivers: [
         SliverToBoxAdapter(
-          child: ReplyItemGrpc(
-            replyItem: firstFloor,
-            replyLevel: 2,
-            needDivider: false,
-            onReply: (replyItem) => _controller.onReply(replyItem, index: -1),
-            upMid: widget.upMid ?? _controller.upMid,
-            onCheckReply: _controller.onCheckReply,
-          ),
+          child: Pref.replyTreeEnabled
+              ? _HeaderGuide(
+                  headerRpid: widget.rpid,
+                  colorScheme: colorScheme,
+                  collapsedRpids: _controller.collapsedRpids,
+                  onToggleCollapse: _controller.toggleCollapse,
+                  hoveredLine: _controller.hoveredLine,
+                  child: replyItem,
+                )
+              : replyItem,
         ),
         SliverToBoxAdapter(
           child: Divider(
@@ -243,39 +289,54 @@ class _VideoReplyReplyPanelState extends State<VideoReplyReplyPanel>
     );
   }
 
-  Widget _sortWidget(ColorScheme colorScheme) {
-    return SliverPinnedHeader(
-      backgroundColor: colorScheme.surface,
-      child: Padding(
-        padding: const .fromLTRB(12, 2.5, 6, 2.5),
-        child: Row(
-          mainAxisAlignment: .spaceBetween,
-          children: [
-            Obx(
-              () {
-                final count = _controller.count.value;
-                return count != -1
-                    ? Text(
-                        '相关回复共${NumUtils.numFormat(count)}条',
-                        style: const TextStyle(fontSize: 13),
-                      )
-                    : const SizedBox.shrink();
-              },
-            ),
-            TextButton.icon(
-              style: Style.buttonStyle,
-              onPressed: _controller.queryBySort,
-              icon: Icon(Icons.sort, size: 16, color: colorScheme.secondary),
-              label: Obx(
-                () => Text(
-                  _controller.sortType.value.label,
-                  style: TextStyle(fontSize: 13, color: colorScheme.secondary),
-                ),
+  Widget _sortWidget(ColorScheme colorScheme, {required bool hide}) {
+    if (hide) {
+      return const SliverToBoxAdapter();
+    }
+    final tree = Pref.replyTreeEnabled;
+    // 树模式下文本右移到与 depth-0 回复内容对齐（indentAt(1)=base），避开 x=29 主引导线；flat 模式保持原 x=12
+    final leftPad = tree
+        ? (MediaQuery.sizeOf(context).width <= 640 ? 40.0 : 44.0)
+        : 12.0;
+    final padding = Padding(
+      padding: EdgeInsets.fromLTRB(leftPad, 2.5, 6, 2.5),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Obx(() {
+            final count = _controller.count.value;
+            return count != -1
+                ? Text(
+                    '相关回复共${NumUtils.numFormat(count)}条',
+                    style: const TextStyle(fontSize: 13),
+                  )
+                : const SizedBox.shrink();
+          }),
+          TextButton.icon(
+            style: Style.buttonStyle,
+            onPressed: _controller.queryBySort,
+            icon: Icon(Icons.sort, size: 16, color: colorScheme.secondary),
+            label: Obx(
+              () => Text(
+                _controller.sortType.value.label,
+                style: TextStyle(fontSize: 13, color: colorScheme.secondary),
               ),
             ),
-          ],
-        ),
+          ),
+        ],
       ),
+    );
+    return SliverPinnedHeader(
+      backgroundColor: colorScheme.surface,
+      child: tree
+          ? _SortStripGuide(
+              headerRpid: widget.rpid,
+              colorScheme: colorScheme,
+              onToggleCollapse: _controller.toggleCollapse,
+              hoveredLine: _controller.hoveredLine,
+              child: padding,
+            )
+          : padding,
     );
   }
 
@@ -283,7 +344,6 @@ class _VideoReplyReplyPanelState extends State<VideoReplyReplyPanel>
     ColorScheme colorScheme,
     LoadingState<List<ReplyInfo>?> loadingState,
   ) {
-    final jumpIndex = _controller.index.value;
     return switch (loadingState) {
       Loading() => const SliverPrototypeExtentList(
         prototypeItem: VideoReplySkeleton(),
@@ -292,42 +352,7 @@ class _VideoReplyReplyPanelState extends State<VideoReplyReplyPanel>
           child: VideoReplySkeleton(),
         ),
       ),
-      Success(:final response!) => SuperSliverList.builder(
-        listController: _controller.listController,
-        itemBuilder: (context, index) {
-          if (index == response.length) {
-            _controller.onLoadMore();
-            return Container(
-              height: 125,
-              alignment: Alignment.center,
-              margin: .only(bottom: MediaQuery.viewPaddingOf(context).bottom),
-              child: Text(
-                _controller.isEnd ? '没有更多了' : '加载中...',
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  fontSize: 12,
-                  color: colorScheme.outline,
-                ),
-              ),
-            );
-          }
-          final child = _replyItem(context, response[index], index);
-          if (jumpIndex == index) {
-            return ColoredBoxTransition(
-              color: _colorAnimation ??= _controller.animController.drive(
-                ColorTween(
-                  begin: colorScheme.onInverseSurface,
-                  end: colorScheme.surface,
-                  // 前0.8s不变, 后0.2s开始动画
-                ).chain(CurveTween(curve: const Interval(0.8, 1.0))),
-              ),
-              child: child,
-            );
-          }
-          return child;
-        },
-        itemCount: response.length + 1,
-      ),
+      Success(:final response!) => _buildReplyList(colorScheme, response),
       Error(:final errMsg) => HttpError(
         errMsg: errMsg,
         onReload: _controller.onReload,
@@ -335,10 +360,144 @@ class _VideoReplyReplyPanelState extends State<VideoReplyReplyPanel>
     };
   }
 
+  Widget _buildReplyList(ColorScheme colorScheme, List<ReplyInfo> response) {
+    final availableWidth = MediaQuery.sizeOf(context).width;
+    final indent = ReplyTreeIndent(base: availableWidth <= 640 ? 40 : 44);
+    final treeMaxDepth = Pref.replyTreeMaxDepth;
+    final jumpIndex = _controller.index.value;
+    // seed 模式：只显示深层评论的子树（父面板数据已含整棵楼中楼）
+    final list = _controller.isSeedMode
+        ? extractSubtree(response, Int64(widget.rpid))
+        : response;
+    final useTree = !isDialogue && Pref.replyTreeEnabled;
+    // 树输入：有效 flat（保留被屏蔽 + 合成缺失父）+ suppressed 映射
+    final input = _controller.treeInput;
+    final wholeTreeCollapsed = useTree &&
+        _controller.collapsedRpids.contains(Int64(widget.rpid));
+    final rows = !useTree
+        ? <ReplyTreeRow>[
+            for (var i = 0; i < list.length; i++)
+              ReplyTreeItem(
+                depth: 0,
+                flatIndex: i,
+                reply: list[i],
+                hasChildren: false,
+              ),
+          ]
+        : wholeTreeCollapsed
+        ? const <ReplyTreeRow>[]
+        : buildReplyTree(
+            flat: input.flat,
+            rootId: Int64(widget.rpid),
+            collapsed: _controller.collapsedRpids,
+            maxDepth: treeMaxDepth,
+          );
+    return SuperSliverList.builder(
+      listController: _controller.listController,
+      itemBuilder: (context, index) {
+        if (index == rows.length) {
+          _controller.onLoadMore();
+          return Container(
+            height: 125,
+            alignment: Alignment.center,
+            margin: EdgeInsets.only(
+              bottom: MediaQuery.viewPaddingOf(context).bottom,
+            ),
+            child: Text(
+              _controller.isEnd ? '没有更多了' : '加载中...',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 12, color: colorScheme.outline),
+            ),
+          );
+        }
+        final Widget child = switch (rows[index]) {
+          ReplyTreeItem(
+            :final reply,
+            :final flatIndex,
+          ) =>
+            !useTree
+                ? _replyItem(context, reply, flatIndex)
+                : _TreeRow(
+                    row: rows[index] as ReplyTreeItem,
+                    replyWidget: input.suppressed[reply.id] != null
+                        ? _placeholderContent(
+                            reply,
+                            input.suppressed[reply.id]!,
+                          )
+                        : _replyItem(context, reply, flatIndex),
+                    indent: indent,
+                    colorScheme: colorScheme,
+                    headerRpid: widget.rpid,
+                    collapsedRpids: _controller.collapsedRpids,
+                    onToggleCollapse: _controller.toggleCollapse,
+                    hoveredLine: _controller.hoveredLine,
+                  ),
+          ReplyTreeDeepLink(:final depth, :final rpid, :final count) =>
+            _DeepLinkRow(
+              depth: depth,
+              rpid: rpid,
+              count: count,
+              ancestors: (rows[index] as ReplyTreeDeepLink).ancestors,
+              lastAtLevel: (rows[index] as ReplyTreeDeepLink).lastAtLevel,
+              lineAtLevel: (rows[index] as ReplyTreeDeepLink).lineAtLevel,
+              indent: indent,
+              colorScheme: colorScheme,
+              headerRpid: widget.rpid,
+              collapsedRpids: _controller.collapsedRpids,
+              onToggleCollapse: _controller.toggleCollapse,
+              hoveredLine: _controller.hoveredLine,
+              onOpen: () {
+                final seedList = _controller.loadingState.value.data;
+                ReplyInfo? target;
+                if (seedList != null) {
+                  for (final r in seedList) {
+                    if (r.id == rpid) {
+                      target = r;
+                      break;
+                    }
+                  }
+                }
+                MiniScaffold.of(context).showBottomSheet(
+                  constraints: const BoxConstraints(),
+                  (context) => VideoReplyReplyPanel(
+                    oid: widget.oid,
+                    rpid: rpid.toInt(),
+                    firstFloor: target,
+                    seedReplies: seedList == null ? null : List.of(seedList),
+                    seedRootId: widget.rpid,
+                    seedOffset: _controller.paginationReply?.nextOffset,
+                    replyType: widget.replyType,
+                    isVideoDetail: true,
+                    isNested: widget.isNested,
+                  ),
+                );
+              },
+            ),
+        };
+        if (jumpIndex == index) {
+          return ColoredBoxTransition(
+            color: _colorAnimation ??= _controller.animController.drive(
+              ColorTween(
+                begin: colorScheme.onInverseSurface,
+                end: colorScheme.surface,
+                // 前0.8s不变, 后0.2s开始动画
+              ).chain(CurveTween(curve: const Interval(0.8, 1.0))),
+            ),
+            child: child,
+          );
+        }
+        return child;
+      },
+      itemCount: rows.length + 1,
+    );
+  }
+
   Widget _replyItem(BuildContext context, ReplyInfo replyItem, int index) {
     return ReplyItemGrpc(
       replyItem: replyItem,
       replyLevel: isDialogue ? 3 : 2,
+      // 树状模式下「查看对话」已冗余（完整对话树可见），屏蔽其入口
+      enableViewDialogue: !(Pref.replyTreeEnabled && !isDialogue),
       onReply: (replyItem) => _controller.onReply(replyItem, index: index),
       onDelete: (item, subIndex) => _controller.onRemove(index, item, null),
       upMid: _controller.upMid,
@@ -361,4 +520,848 @@ class _VideoReplyReplyPanelState extends State<VideoReplyReplyPanel>
       onCheckReply: _controller.onCheckReply,
     );
   }
+
+  /// 无法显示父评论的占位行：头像 + 名字 + 分类文本。
+  /// 有有效 mid 时可点击进入主页（手型光标）；折叠/引导线由外层 _TreeRow 提供。
+  Widget _placeholderContent(ReplyInfo reply, ReplySuppressReason reason) {
+    final colorScheme = ColorScheme.of(context);
+    final text = switch (reason) {
+      ReplySuppressReason.deleted => '已删除',
+      ReplySuppressReason.blocked => '已屏蔽',
+    };
+    final mid = reply.mid;
+    final content = Padding(
+      padding: const EdgeInsets.fromLTRB(12, 14, 8, 5),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          PendantAvatar(reply.member.face, size: 34),
+          const SizedBox(width: 12),
+          Flexible(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (reply.member.name.isNotEmpty)
+                  Text(
+                    reply.member.name,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(fontSize: 13, color: colorScheme.outline),
+                  ),
+                Text(
+                  text,
+                  style: TextStyle(fontSize: 12, color: colorScheme.outline),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+    if (mid == Int64.ZERO) return content;
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () {
+          feedBack();
+          Get.toNamed('/member?mid=${mid.toInt()}');
+        },
+        child: content,
+      ),
+    );
+  }
+}
+
+/// 点 p 是否落在圆心 center、半径 radius 的圆内
+bool _inCircle(Offset center, double radius, Offset p) {
+  final dx = p.dx - center.dx;
+  final dy = p.dy - center.dy;
+  return dx * dx + dy * dy <= radius * radius;
+}
+
+class _TreeRow extends StatefulWidget {
+  const _TreeRow({
+    required this.row,
+    required this.replyWidget,
+    required this.indent,
+    required this.colorScheme,
+    required this.headerRpid,
+    required this.collapsedRpids,
+    required this.onToggleCollapse,
+    required this.hoveredLine,
+  });
+  final ReplyTreeItem row;
+  final Widget replyWidget;
+  final ReplyTreeIndent indent;
+  final ColorScheme colorScheme;
+  final int headerRpid;
+  final Set<Int64> collapsedRpids;
+  final ValueChanged<Int64> onToggleCollapse;
+  final Rxn<Int64> hoveredLine;
+
+  @override
+  State<_TreeRow> createState() => _TreeRowState();
+}
+
+class _TreeRowState extends State<_TreeRow> {
+  static const double _hitHalf = 14;
+  int? _hovered;
+  Offset? _down; // 原始指针按下位置（Listener 手动识别点击）
+  DateTime? _downTime;
+
+  double _lineX(int k) =>
+      ReplyTreeGuidePainter.avatarCenter + widget.indent.indentAt(k);
+
+  /// 返回 local 坐标命中的引导线级别（0=主引导线，1..depth=祖先线，depth+1=自己的线），未命中返回 null。
+  /// 仅在实际绘制引导线的范围内命中：祖先线受 lineAtLevel/lastAtLevel 约束，自己的线避开按钮圆空角。
+  int? _levelAt(Offset local) {
+    const double aY = ReplyTreeGuidePainter.avatarY;
+    const double aR = ReplyTreeGuidePainter.avatarRadius;
+    final d = widget.row.depth;
+    final double arcR = ReplyTreeGuidePainter.arcRadiusAt(widget.indent, d);
+    final dy = local.dy;
+    final dx = local.dx;
+    // 入弧区
+    if (dy >= aY - arcR - 4 &&
+        dy <= aY + 4 &&
+        dx >= _lineX(d) - 2 &&
+        dx <= _lineX(d + 1) - aR) {
+      return d;
+    }
+    // 祖先线 k=0..d：仅本行绘制该层线且落在线纵向范围内
+    for (var k = 0; k <= d; k++) {
+      if (widget.row.lineAtLevel.isNotEmpty && !widget.row.lineAtLevel[k]) {
+        continue;
+      }
+      if ((dx - _lineX(k)).abs() > _hitHalf) continue;
+      final last = widget.row.lastAtLevel.isNotEmpty &&
+          widget.row.lastAtLevel[k];
+      final yEnd = last ? (k == d ? aY - arcR : aY) : double.infinity;
+      if (dy <= yEnd) return k;
+    }
+    // 自己的线（d+1）：stub 段 + 按钮圆 + 展开态下段
+    if (widget.row.hasChildren) {
+      final x = _lineX(d + 1);
+      if ((dx - x).abs() <= _hitHalf) {
+        const by = ReplyTreeGuidePainter.buttonY;
+        const bR = ReplyTreeGuidePainter.buttonRadius;
+        if (dy >= aY + aR && dy <= by - bR) return d + 1; // stub 段
+        if (_inCircle(Offset(x, by), bR, local)) return d + 1; // 按钮圆内
+        if (!widget.collapsedRpids.contains(widget.row.reply.id) &&
+            dy >= by + bR) {
+          return d + 1; // 展开态下段
+        }
+      }
+    }
+    return null;
+  }
+
+  void _toggle(int k) {
+    final Int64 rpid;
+    if (k == 0) {
+      rpid = Int64(widget.headerRpid);
+    } else if (k <= widget.row.depth) {
+      rpid = widget.row.ancestors[k - 1];
+    } else {
+      rpid = widget.row.reply.id;
+    }
+    widget.onToggleCollapse(rpid);
+  }
+
+  /// 引导线级别 k 在本行对应节点（线的 OWNER）rpid：0=头部评论，1..depth=祖先，depth+1=本行自己的线。
+  Int64? _lineKey(int? k) {
+    if (k == null) return null;
+    if (k == 0) return Int64(widget.headerRpid);
+    if (k <= widget.row.depth) return widget.row.ancestors[k - 1];
+    return widget.row.reply.id; // 自己的线
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final row = widget.row;
+    return MouseRegion(
+      cursor: _hovered != null ? SystemMouseCursors.click : MouseCursor.defer,
+      onHover: (e) {
+        final k = _levelAt(e.localPosition);
+        final key = _lineKey(k);
+        if (key != null) {
+          if (key != widget.hoveredLine.value) {
+            widget.hoveredLine.value = key;
+          }
+        } else {
+          if (widget.hoveredLine.value != null) {
+            widget.hoveredLine.value = null;
+          }
+        }
+        if (k != _hovered) setState(() => _hovered = k);
+      },
+      onExit: (_) {
+        widget.hoveredLine.value = null;
+        setState(() => _hovered = null);
+      },
+      child: Listener(
+        onPointerDown: (e) {
+          _down = e.localPosition;
+          _downTime = DateTime.now();
+        },
+        onPointerUp: (e) {
+          final k = _levelAt(e.localPosition);
+          final down = _down;
+          final t = _downTime;
+          _down = null;
+          _downTime = null;
+          if (k == null || down == null || t == null) return;
+          final moved = (e.localPosition - down).distance;
+          if (moved < kTouchSlop &&
+              DateTime.now().difference(t).inMilliseconds < 300) {
+            _toggle(k);
+          }
+        },
+        child: Obx(() {
+          final hovered = widget.hoveredLine.value;
+          final levels = <int>{};
+          if (hovered != null) {
+            for (var k = 0; k <= row.depth; k++) {
+              if (_lineKey(k) == hovered) levels.add(k);
+            }
+          }
+          final own = row.hasChildren && hovered == row.reply.id;
+          return CustomPaint(
+            painter: ReplyTreeGuidePainter(
+              depth: row.depth,
+              indent: widget.indent,
+              color: widget.colorScheme.outline.withValues(alpha: 0.3),
+              highlightColor: widget.colorScheme.primary,
+              lastAtLevel: row.lastAtLevel,
+              lineAtLevel: row.lineAtLevel,
+              hasOwnLine: row.hasChildren,
+              collapsed: widget.collapsedRpids.contains(row.reply.id),
+              highlightLevels: levels,
+              highlightOwn: own,
+            ),
+            child: Padding(
+              padding: EdgeInsets.only(
+                left: widget.indent.indentAt(row.depth + 1),
+              ),
+              child: widget.replyWidget,
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _DeepLinkRow extends StatefulWidget {
+  const _DeepLinkRow({
+    required this.depth,
+    required this.rpid,
+    required this.count,
+    required this.ancestors,
+    required this.lastAtLevel,
+    required this.lineAtLevel,
+    required this.indent,
+    required this.colorScheme,
+    required this.headerRpid,
+    required this.collapsedRpids,
+    required this.onToggleCollapse,
+    required this.onOpen,
+    required this.hoveredLine,
+  });
+  final int depth;
+  final Int64 rpid;
+  final int count;
+  final List<Int64> ancestors;
+  final List<bool> lastAtLevel;
+  final List<bool> lineAtLevel;
+  final ReplyTreeIndent indent;
+  final ColorScheme colorScheme;
+  final int headerRpid;
+  final Set<Int64> collapsedRpids;
+  final ValueChanged<Int64> onToggleCollapse;
+  final VoidCallback onOpen;
+  final Rxn<Int64> hoveredLine;
+
+  @override
+  State<_DeepLinkRow> createState() => _DeepLinkRowState();
+}
+
+class _DeepLinkRowState extends State<_DeepLinkRow> {
+  static const double _hitHalf = 14;
+  int? _hovered;
+  Offset? _down;
+  DateTime? _downTime;
+
+  double _lineX(int k) =>
+      ReplyTreeGuidePainter.avatarCenter + widget.indent.indentAt(k);
+
+  /// 深链接行仅绘制祖先线：受 lineAtLevel/lastAtLevel 约束，最深一层收尾于行中部（terminalY）。
+  int? _levelAt(Offset local) {
+    final h = context.size?.height ?? 0;
+    final double terminalY = h / 2;
+    final double arcR = ReplyTreeGuidePainter.arcRadiusAt(
+      widget.indent,
+      widget.depth,
+    );
+    final dy = local.dy;
+    for (var k = 0; k <= widget.depth; k++) {
+      if (widget.lineAtLevel.isNotEmpty && !widget.lineAtLevel[k]) continue;
+      if ((local.dx - _lineX(k)).abs() > _hitHalf) continue;
+      final last = widget.lastAtLevel.isNotEmpty && widget.lastAtLevel[k];
+      final yEnd = last
+          ? (k == widget.depth ? terminalY - arcR : terminalY)
+          : double.infinity;
+      if (dy <= yEnd) return k;
+    }
+    return null;
+  }
+
+  void _toggle(int k) {
+    final Int64 rpid = k == 0
+        ? Int64(widget.headerRpid)
+        : widget.ancestors[k - 1];
+    widget.onToggleCollapse(rpid);
+  }
+
+  /// 引导线级别 k 在本行对应节点（线的 OWNER）rpid：0=头部评论，1..depth=祖先（无自己的线）。
+  Int64? _lineKey(int? k) {
+    if (k == null) return null;
+    return k == 0 ? Int64(widget.headerRpid) : widget.ancestors[k - 1];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      cursor: _hovered != null ? SystemMouseCursors.click : MouseCursor.defer,
+      onHover: (e) {
+        final k = _levelAt(e.localPosition);
+        final key = _lineKey(k);
+        if (key != null) {
+          if (key != widget.hoveredLine.value) {
+            widget.hoveredLine.value = key;
+          }
+        } else {
+          if (widget.hoveredLine.value != null) {
+            widget.hoveredLine.value = null;
+          }
+        }
+        if (k != _hovered) setState(() => _hovered = k);
+      },
+      onExit: (_) {
+        widget.hoveredLine.value = null;
+        setState(() => _hovered = null);
+      },
+      // Listener 识别祖先引导线点击；按钮的 InkWell 不受影响
+      child: Listener(
+        onPointerDown: (e) {
+          _down = e.localPosition;
+          _downTime = DateTime.now();
+        },
+        onPointerUp: (e) {
+          final k = _levelAt(e.localPosition);
+          final down = _down;
+          final t = _downTime;
+          _down = null;
+          _downTime = null;
+          if (k == null || down == null || t == null) return;
+          final moved = (e.localPosition - down).distance;
+          if (moved < kTouchSlop &&
+              DateTime.now().difference(t).inMilliseconds < 300) {
+            _toggle(k);
+          }
+        },
+        child: Obx(() {
+          final hovered = widget.hoveredLine.value;
+          final levels = <int>{};
+          if (hovered != null) {
+            for (var k = 0; k <= widget.depth; k++) {
+              if (_lineKey(k) == hovered) levels.add(k);
+            }
+          }
+          return CustomPaint(
+            painter: ReplyTreeGuidePainter(
+              depth: widget.depth,
+              indent: widget.indent,
+              color: widget.colorScheme.outline.withValues(alpha: 0.3),
+              highlightColor: widget.colorScheme.primary,
+              lastAtLevel: widget.lastAtLevel,
+              lineAtLevel: widget.lineAtLevel,
+              hasOwnLine: false,
+              collapsed: false,
+              isDeepLink: true,
+              highlightLevels: levels,
+              highlightOwn: false,
+            ),
+            child: InkWell(
+              onTap: widget.onOpen,
+              child: Padding(
+                padding: EdgeInsets.only(
+                  left: widget.indent.indentAt(widget.depth + 1) + 12,
+                  top: 6,
+                  bottom: 6,
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      Icons.subdirectory_arrow_right,
+                      size: 18,
+                      color: widget.colorScheme.outline,
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      '继续此讨论串（${widget.count} 条回复）',
+                      style: TextStyle(
+                        fontSize: 13,
+                        color: widget.colorScheme.outline,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        }),
+      ),
+    );
+  }
+}
+
+class _HeaderGuide extends StatefulWidget {
+  const _HeaderGuide({
+    required this.child,
+    required this.headerRpid,
+    required this.colorScheme,
+    required this.collapsedRpids,
+    required this.onToggleCollapse,
+    required this.hoveredLine,
+  });
+  final Widget child;
+  final int headerRpid;
+  final ColorScheme colorScheme;
+  final Set<Int64> collapsedRpids;
+  final ValueChanged<Int64> onToggleCollapse;
+  final Rxn<Int64> hoveredLine;
+
+  @override
+  State<_HeaderGuide> createState() => _HeaderGuideState();
+}
+
+class _HeaderGuideState extends State<_HeaderGuide> {
+  static const double _hitHalf = 14;
+  bool _hovered = false;
+  Offset? _down;
+  DateTime? _downTime;
+
+  /// 主引导线命中范围与渲染一致：上段（头像下沿→按钮上缘）、按钮圆内、展开态下段（按钮下缘→底）。
+  bool _inLine(Offset p) {
+    const double aY = ReplyTreeGuidePainter.avatarY;
+    const double aR = ReplyTreeGuidePainter.avatarRadius;
+    const double bR = ReplyTreeGuidePainter.buttonRadius;
+    const double by = ReplyTreeGuidePainter.buttonY;
+    final double dy = p.dy;
+    if ((p.dx - ReplyTreeGuidePainter.avatarCenter).abs() > _hitHalf) {
+      return false;
+    }
+    if (dy < aY + aR) return false; // 头像下沿以上无线
+    if (dy <= by - bR) return true; // 上段
+    if (dy <= by + bR) {
+      // 按钮圆带：仅圆内命中（圆外空角无线）
+      return _inCircle(
+        const Offset(ReplyTreeGuidePainter.avatarCenter, by),
+        bR,
+        p,
+      );
+    }
+    // 按钮下缘以下：仅展开态有线
+    return !widget.collapsedRpids.contains(Int64(widget.headerRpid));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      cursor: _hovered ? SystemMouseCursors.click : MouseCursor.defer,
+      onHover: (e) {
+        final on = _inLine(e.localPosition);
+        if (on) {
+          final key = Int64(widget.headerRpid);
+          if (key != widget.hoveredLine.value) {
+            widget.hoveredLine.value = key;
+          }
+        } else {
+          if (widget.hoveredLine.value != null) {
+            widget.hoveredLine.value = null;
+          }
+        }
+        if (on != _hovered) setState(() => _hovered = on);
+      },
+      onExit: (_) {
+        widget.hoveredLine.value = null;
+        setState(() => _hovered = false);
+      },
+      // Listener 识别主引导线点击（头部评论的 InkWell 覆盖全块，GestureDetector 会输掉竞技场）
+      child: Listener(
+        onPointerDown: (e) {
+          _down = e.localPosition;
+          _downTime = DateTime.now();
+        },
+        onPointerUp: (e) {
+          final inLine = _inLine(e.localPosition);
+          final down = _down;
+          final t = _downTime;
+          _down = null;
+          _downTime = null;
+          if (!inLine || down == null || t == null) return;
+          final moved = (e.localPosition - down).distance;
+          if (moved < kTouchSlop &&
+              DateTime.now().difference(t).inMilliseconds < 300) {
+            widget.onToggleCollapse(Int64(widget.headerRpid));
+          }
+        },
+        child: Obx(
+          () => CustomPaint(
+            painter: HeaderGuidePainter(
+              color: widget.colorScheme.outline.withValues(alpha: 0.3),
+              highlightColor: widget.colorScheme.primary,
+              collapsed:
+                  widget.collapsedRpids.contains(Int64(widget.headerRpid)),
+              hovered: widget.hoveredLine.value == Int64(widget.headerRpid),
+            ),
+            child: widget.child,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 排序条处的主引导线段：与 header/树行的主引导线共享 hoveredLine，整条线联动高亮；
+/// 点击折叠整树（与 _HeaderGuide 一致）。
+class _SortStripGuide extends StatefulWidget {
+  const _SortStripGuide({
+    required this.child,
+    required this.headerRpid,
+    required this.colorScheme,
+    required this.onToggleCollapse,
+    required this.hoveredLine,
+  });
+  final Widget child;
+  final int headerRpid;
+  final ColorScheme colorScheme;
+  final ValueChanged<Int64> onToggleCollapse;
+  final Rxn<Int64> hoveredLine;
+
+  @override
+  State<_SortStripGuide> createState() => _SortStripGuideState();
+}
+
+class _SortStripGuideState extends State<_SortStripGuide> {
+  static const double _hitHalf = 14;
+  bool _hovered = false;
+  Offset? _down;
+  DateTime? _downTime;
+
+  bool _inLine(Offset p) =>
+      (p.dx - ReplyTreeGuidePainter.avatarCenter).abs() <= _hitHalf;
+
+  @override
+  Widget build(BuildContext context) {
+    return MouseRegion(
+      cursor: _hovered ? SystemMouseCursors.click : MouseCursor.defer,
+      onHover: (e) {
+        final on = _inLine(e.localPosition);
+        final key = Int64(widget.headerRpid);
+        if (on) {
+          if (key != widget.hoveredLine.value) {
+            widget.hoveredLine.value = key;
+          }
+        } else {
+          if (widget.hoveredLine.value != null) {
+            widget.hoveredLine.value = null;
+          }
+        }
+        if (on != _hovered) setState(() => _hovered = on);
+      },
+      onExit: (_) {
+        widget.hoveredLine.value = null;
+        setState(() => _hovered = false);
+      },
+      child: Listener(
+        onPointerDown: (e) {
+          _down = e.localPosition;
+          _downTime = DateTime.now();
+        },
+        onPointerUp: (e) {
+          final down = _down;
+          final t = _downTime;
+          _down = null;
+          _downTime = null;
+          if (!_inLine(e.localPosition) || down == null || t == null) return;
+          final moved = (e.localPosition - down).distance;
+          if (moved < kTouchSlop &&
+              DateTime.now().difference(t).inMilliseconds < 300) {
+            widget.onToggleCollapse(Int64(widget.headerRpid));
+          }
+        },
+        child: Obx(
+          () => CustomPaint(
+            painter: SingleVerticalPainter(
+              color: widget.colorScheme.outline.withValues(alpha: 0.3),
+              highlightColor: widget.colorScheme.primary,
+              hovered:
+                  widget.hoveredLine.value == Int64(widget.headerRpid),
+              x: ReplyTreeGuidePainter.avatarCenter,
+            ),
+            child: widget.child,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class ReplyTreeGuidePainter extends CustomPainter {
+  ReplyTreeGuidePainter({
+    required this.depth,
+    required this.indent,
+    required this.color,
+    required this.highlightColor,
+    required this.lastAtLevel,
+    required this.lineAtLevel,
+    required this.hasOwnLine,
+    required this.collapsed,
+    this.isDeepLink = false,
+    this.highlightLevels = const {},
+    this.highlightOwn = false,
+  });
+
+  static const double avatarCenter = 29; // 主引导线 x（头部评论头像中心距行左）
+  static const double avatarY = 31; // 头像中心距行顶
+  static const double avatarRadius = 17;
+  static const double arcRadius = 12;
+  static const double buttonRadius = 8;
+  static const double buttonY = avatarY + avatarRadius + 16; // 折叠按钮圆心 y
+
+  final int depth;
+  final ReplyTreeIndent indent;
+  final Color color;
+  final Color highlightColor;
+  final List<bool> lastAtLevel;
+  final List<bool> lineAtLevel;
+  final bool hasOwnLine;
+  final bool collapsed;
+  final bool isDeepLink;
+  final Set<int> highlightLevels;
+  final bool highlightOwn;
+
+  double _lineX(int k) => avatarCenter + indent.indentAt(k);
+
+  /// 第 depth 层入弧半径：受该层步进与头像半径约束，兜底 ≥0。
+  static double arcRadiusAt(ReplyTreeIndent indent, int depth) =>
+      math.max(0, math.min(arcRadius, indent.stepAt(depth) - avatarRadius));
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final normal = Paint()
+      ..color = color
+      ..strokeWidth = 1.75
+      // 平头帽：逐行拼接的竖线/入弧在行交界与肘部不产生重叠叠加（圆头帽会叠出暗珠）
+      ..strokeCap = StrokeCap.butt
+      ..style = PaintingStyle.stroke;
+    final hover = Paint()
+      ..color = highlightColor
+      ..strokeWidth = 3
+      ..strokeCap = StrokeCap.butt
+      ..style = PaintingStyle.stroke;
+
+    final terminalY = isDeepLink ? size.height / 2 : avatarY;
+    final arcR = arcRadiusAt(indent, depth);
+    // 祖先竖线 k=0..depth（lineAtLevel 为 false 的行不再绘制该层线）
+    for (var k = 0; k <= depth; k++) {
+      if (lineAtLevel.isNotEmpty && !lineAtLevel[k]) continue;
+      final last = lastAtLevel.isNotEmpty && lastAtLevel[k];
+      final y1 = last
+          ? (k == depth ? terminalY - arcR : terminalY)
+          : size.height;
+      canvas.drawLine(
+        Offset(_lineX(k), 0),
+        Offset(_lineX(k), y1),
+        highlightLevels.contains(k) ? hover : normal,
+      );
+    }
+
+    if (isDeepLink) return; // 按钮行：无线以下、无入弧
+
+    // 入弧：level depth 的线 → 本行头像左缘
+    final arc = Path()
+      ..moveTo(_lineX(depth), avatarY - arcR)
+      ..quadraticBezierTo(
+        _lineX(depth),
+        avatarY,
+        _lineX(depth) + arcR,
+        avatarY,
+      )
+      ..lineTo(_lineX(depth + 1) - avatarRadius, avatarY);
+    canvas.drawPath(arc, highlightLevels.contains(depth) ? hover : normal);
+
+    // 自己的线 / stub + ⊖⊕
+    if (!hasOwnLine) return;
+    final x = _lineX(depth + 1);
+    final p = highlightOwn ? hover : normal;
+    const buttonTop = buttonY - buttonRadius;
+    if (collapsed) {
+      canvas.drawLine(Offset(x, avatarY + avatarRadius), Offset(x, buttonTop), p);
+      paintTreeCollapseButton(
+        canvas,
+        Offset(x, buttonY),
+        plus: true,
+        highlighted: highlightOwn,
+        color: color,
+        highlightColor: highlightColor,
+      );
+    } else {
+      canvas
+        ..drawLine(Offset(x, avatarY + avatarRadius), Offset(x, buttonTop), p)
+        ..drawLine(Offset(x, buttonY + buttonRadius), Offset(x, size.height), p);
+      paintTreeCollapseButton(
+        canvas,
+        Offset(x, buttonY),
+        plus: false,
+        highlighted: highlightOwn,
+        color: color,
+        highlightColor: highlightColor,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant ReplyTreeGuidePainter old) =>
+      old.depth != depth ||
+      old.indent.base != indent.base ||
+      old.indent.decay != indent.decay ||
+      old.indent.minStep != indent.minStep ||
+      old.color != color ||
+      old.highlightColor != highlightColor ||
+      old.lastAtLevel != lastAtLevel ||
+      old.lineAtLevel != lineAtLevel ||
+      old.hasOwnLine != hasOwnLine ||
+      old.collapsed != collapsed ||
+      old.isDeepLink != isDeepLink ||
+      old.highlightLevels != highlightLevels ||
+      old.highlightOwn != highlightOwn;
+}
+
+/// 绘制 ⊖/⊕ 折叠按钮（圆 + 减号/加号）。highlighted 时填充高亮色、符号白色。
+void paintTreeCollapseButton(
+  Canvas canvas,
+  Offset center, {
+  required bool plus,
+  required bool highlighted,
+  required Color color,
+  required Color highlightColor,
+  double radius = ReplyTreeGuidePainter.buttonRadius,
+}) {
+  final fill = Paint()
+    ..color = highlighted ? highlightColor : color.withValues(alpha: 0.15);
+  final stroke = Paint()
+    ..color = highlighted ? Colors.white : color
+    ..strokeWidth = 1.5;
+  canvas
+    ..drawCircle(center, radius, fill)
+    ..drawCircle(center, radius, stroke);
+  final glyph = Paint()
+    ..color = highlighted ? Colors.white : color
+    ..strokeWidth = 2
+    ..strokeCap = StrokeCap.round;
+  final arm = radius - 3;
+  canvas.drawLine(center - Offset(arm, 0), center + Offset(arm, 0), glyph);
+  if (plus) {
+    canvas.drawLine(center - Offset(0, arm), center + Offset(0, arm), glyph);
+  }
+}
+
+/// 主引导线（头部评论头像下方那条）：从头像下沿到 widget 底部；整树折叠时 stub + ⊕。
+class HeaderGuidePainter extends CustomPainter {
+  HeaderGuidePainter({
+    required this.color,
+    required this.highlightColor,
+    required this.collapsed,
+    required this.hovered,
+  });
+  final Color color;
+  final Color highlightColor;
+  final bool collapsed;
+  final bool hovered;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const x = ReplyTreeGuidePainter.avatarCenter;
+    const top = ReplyTreeGuidePainter.avatarY + ReplyTreeGuidePainter.avatarRadius;
+    const by = top + 16;
+    // 线在按钮圆处断开，避免穿过 ⊖/⊕ 圆圈造成符号混淆
+    const buttonTop = by - ReplyTreeGuidePainter.buttonRadius;
+    final p = Paint()
+      ..color = hovered ? highlightColor : color
+      ..strokeWidth = hovered ? 3 : 1.75
+      ..strokeCap = StrokeCap.round;
+    if (collapsed) {
+      canvas.drawLine(const Offset(x, top), const Offset(x, buttonTop), p);
+    } else {
+      canvas
+        ..drawLine(const Offset(x, top), const Offset(x, buttonTop), p)
+        ..drawLine(
+          const Offset(x, by + ReplyTreeGuidePainter.buttonRadius),
+          Offset(x, size.height),
+          p,
+        );
+    }
+    paintTreeCollapseButton(
+      canvas,
+      const Offset(x, by),
+      plus: collapsed,
+      highlighted: hovered,
+      color: color,
+      highlightColor: highlightColor,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant HeaderGuidePainter old) =>
+      old.color != color ||
+      old.highlightColor != highlightColor ||
+      old.collapsed != collapsed ||
+      old.hovered != hovered;
+}
+
+/// 单条竖直引导线（排序条处的主引导线段；hovered 时高亮加粗，联动整条主引导线）。
+class SingleVerticalPainter extends CustomPainter {
+  SingleVerticalPainter({
+    required this.color,
+    required this.x,
+    required this.highlightColor,
+    this.hovered = false,
+  });
+  final Color color;
+  final Color highlightColor;
+  final bool hovered;
+  final double x;
+  @override
+  void paint(Canvas canvas, Size size) {
+    canvas.drawLine(
+      Offset(x, 0),
+      Offset(x, size.height),
+      Paint()
+        ..color = hovered ? highlightColor : color
+        ..strokeWidth = hovered ? 3 : 1.75
+        ..strokeCap = StrokeCap.butt,
+    );
+  }
+  @override
+  bool shouldRepaint(covariant SingleVerticalPainter old) =>
+      old.color != color ||
+      old.x != x ||
+      old.hovered != hovered ||
+      old.highlightColor != highlightColor;
 }

--- a/lib/pages/video/reply_reply/view.dart
+++ b/lib/pages/video/reply_reply/view.dart
@@ -522,7 +522,7 @@ class _VideoReplyReplyPanelState extends State<VideoReplyReplyPanel>
   }
 
   /// 无法显示父评论的占位行：头像 + 名字 + 分类文本。
-  /// 有有效 mid 时可点击进入主页（手型光标）；折叠/引导线由外层 _TreeRow 提供。
+  /// 折叠/引导线由外层 _TreeRow 提供。
   Widget _placeholderContent(ReplyInfo reply, ReplySuppressReason reason) {
     final colorScheme = ColorScheme.of(context);
     final text = switch (reason) {
@@ -530,24 +530,46 @@ class _VideoReplyReplyPanelState extends State<VideoReplyReplyPanel>
       ReplySuppressReason.blocked => '已屏蔽',
     };
     final mid = reply.mid;
-    final content = Padding(
+    final name = reply.member.name;
+
+    Widget memberTap(Widget child) {
+      if (mid == Int64.ZERO) return child;
+      return MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: () {
+            feedBack();
+            Get.toNamed('/member?mid=${mid.toInt()}');
+          },
+          child: child,
+        ),
+      );
+    }
+
+    return Padding(
       padding: const EdgeInsets.fromLTRB(12, 14, 8, 5),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          PendantAvatar(reply.member.face, size: 34),
+          memberTap(PendantAvatar(reply.member.face, size: 34)),
           const SizedBox(width: 12),
           Flexible(
             child: Column(
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                if (reply.member.name.isNotEmpty)
-                  Text(
-                    reply.member.name,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(fontSize: 13, color: colorScheme.outline),
+                if (name.isNotEmpty)
+                  memberTap(
+                    Text(
+                      name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontSize: 13,
+                        color: colorScheme.outline,
+                      ),
+                    ),
                   ),
                 Text(
                   text,
@@ -557,18 +579,6 @@ class _VideoReplyReplyPanelState extends State<VideoReplyReplyPanel>
             ),
           ),
         ],
-      ),
-    );
-    if (mid == Int64.ZERO) return content;
-    return MouseRegion(
-      cursor: SystemMouseCursors.click,
-      child: GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTap: () {
-          feedBack();
-          Get.toNamed('/member?mid=${mid.toInt()}');
-        },
-        child: content,
       ),
     );
   }
@@ -741,11 +751,24 @@ class _TreeRowState extends State<_TreeRow> {
               highlightLevels: levels,
               highlightOwn: own,
             ),
-            child: Padding(
-              padding: EdgeInsets.only(
-                left: widget.indent.indentAt(row.depth + 1),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                // 折叠按钮画在固定 y，短内容行（占位等）需撑到按钮可容纳的高度
+                minHeight: row.hasChildren
+                    ? ReplyTreeGuidePainter.minFoldRowHeight
+                    : 0,
               ),
-              child: widget.replyWidget,
+              // 顶部对齐：minHeight 若传入内层 Row 会把头像垂直居中下移，
+              // 与固定 y=31 的引导线几何错位重叠，这里截断撑高、内容保持贴顶
+              child: Align(
+                alignment: Alignment.topLeft,
+                child: Padding(
+                  padding: EdgeInsets.only(
+                    left: widget.indent.indentAt(row.depth + 1),
+                  ),
+                  child: widget.replyWidget,
+                ),
+              ),
             ),
           );
         }),
@@ -1142,7 +1165,11 @@ class ReplyTreeGuidePainter extends CustomPainter {
   static const double avatarRadius = 17;
   static const double arcRadius = 12;
   static const double buttonRadius = 8;
-  static const double buttonY = avatarY + avatarRadius + 16; // 折叠按钮圆心 y
+  static const double buttonY = avatarY + avatarRadius + 16; // 折叠按钮圆心 y（常规行）
+
+  /// 带折叠按钮行的最小高度：补齐到正常评论行高（ReplyItemGrpc replyLevel=2 约 124px），
+  /// 使紧凑占位行与正常行保持一致的兄弟间距。头像/按钮几何与正常行统一。
+  static const double minFoldRowHeight = 100;
 
   final int depth;
   final ReplyTreeIndent indent;
@@ -1210,12 +1237,13 @@ class ReplyTreeGuidePainter extends CustomPainter {
     if (!hasOwnLine) return;
     final x = _lineX(depth + 1);
     final p = highlightOwn ? hover : normal;
-    const buttonTop = buttonY - buttonRadius;
+    const by = buttonY;
+    const double buttonTop = by - buttonRadius;
     if (collapsed) {
       canvas.drawLine(Offset(x, avatarY + avatarRadius), Offset(x, buttonTop), p);
       paintTreeCollapseButton(
         canvas,
-        Offset(x, buttonY),
+        Offset(x, by),
         plus: true,
         highlighted: highlightOwn,
         color: color,
@@ -1224,10 +1252,10 @@ class ReplyTreeGuidePainter extends CustomPainter {
     } else {
       canvas
         ..drawLine(Offset(x, avatarY + avatarRadius), Offset(x, buttonTop), p)
-        ..drawLine(Offset(x, buttonY + buttonRadius), Offset(x, size.height), p);
+        ..drawLine(Offset(x, by + buttonRadius), Offset(x, size.height), p);
       paintTreeCollapseButton(
         canvas,
-        Offset(x, buttonY),
+        Offset(x, by),
         plus: false,
         highlighted: highlightOwn,
         color: color,

--- a/lib/pages/video/reply_reply/view.dart
+++ b/lib/pages/video/reply_reply/view.dart
@@ -46,6 +46,7 @@ class VideoReplyReplyPanel extends CommonSlidePage {
     this.seedReplies,
     this.seedRootId,
     this.seedOffset,
+    this.removedReplies,
     required this.isVideoDetail,
     required this.replyType,
     this.isNested = false,
@@ -59,6 +60,9 @@ class VideoReplyReplyPanel extends CommonSlidePage {
   final List<ReplyInfo>? seedReplies;
   final int? seedRootId;
   final String? seedOffset;
+
+  /// 继承自父面板的被屏蔽评论数据（rpid → ReplyInfo），seed 模式保留占位
+  final Map<Int64, ReplyInfo>? removedReplies;
   final bool isVideoDetail;
   final int replyType;
   final bool isNested;
@@ -146,6 +150,7 @@ class _VideoReplyReplyPanelState extends State<VideoReplyReplyPanel>
         seedReplies: widget.seedReplies,
         seedRootId: widget.seedRootId,
         seedOffset: widget.seedOffset,
+        removedReplies: widget.removedReplies,
       ),
       tag: _tag,
     );
@@ -466,6 +471,7 @@ class _VideoReplyReplyPanelState extends State<VideoReplyReplyPanel>
                     seedReplies: seedList == null ? null : List.of(seedList),
                     seedRootId: widget.rpid,
                     seedOffset: _controller.paginationReply?.nextOffset,
+                    removedReplies: _controller.blockedReplies,
                     replyType: widget.replyType,
                     isVideoDetail: true,
                     isNested: widget.isNested,

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -84,6 +84,8 @@ abstract final class SettingBoxKey {
       horizontalSeasonPanel = 'horizontalSeasonPanel',
       horizontalMemberPage = 'horizontalMemberPage',
       replyLengthLimit = 'replyLengthLimit',
+      replyTreeEnabled = 'replyTreeEnabled',
+      replyTreeMaxDepth = 'replyTreeMaxDepth',
       showArgueMsg = 'showArgueMsg',
       reverseFromFirst = 'reverseFromFirst',
       badCertificateCallback = 'badCertificateCallback',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -386,6 +386,12 @@ abstract final class Pref {
   static bool get showBangumiReply =>
       _setting.get(SettingBoxKey.showBangumiReply, defaultValue: true);
 
+  static bool get replyTreeEnabled =>
+      _setting.get(SettingBoxKey.replyTreeEnabled, defaultValue: true);
+
+  static int get replyTreeMaxDepth =>
+      _setting.get(SettingBoxKey.replyTreeMaxDepth, defaultValue: 3);
+
   static bool get alwaysExpandIntroPanel =>
       _setting.get(SettingBoxKey.alwaysExpandIntroPanel, defaultValue: false);
 


### PR DESCRIPTION
**https://github.com/bggRGjQaUbCoE/PiliPlus/pull/2483 与最新版已有多处不兼容，故重开PR，跟进了当前的更新**

新增将评论按回复关系树状显示的功能

- 可在“其他设置”中开关功能与设置页面内能显示的最大树深度
<img width="1142" height="172" alt="image" src="https://github.com/user-attachments/assets/6e4492ef-3d68-4264-81c8-444ef8981365" />


- 超过最大树深度的评论会像Reddit一样被折叠，点击“继续此讨论串”后在新打开的页面显示

- 被屏蔽功能屏蔽的评论若有子评论，则仍会在树中原本的位置占有一节点，内容统一为“已屏蔽”

- 被删除的评论若有子评论，则会根据其子评论推断评论者与在树中的位置。

原版：
<img width="793" height="743" alt="屏幕截图 2026-08-08 114809" src="https://github.com/user-attachments/assets/20efe28b-38e4-49e5-b759-a1e68ce88d6c" />

树状评论：
<img width="858" height="896" alt="屏幕截图 2026-08-08 112842" src="https://github.com/user-attachments/assets/f199c51d-1d3a-4953-a95d-de6fe682894d" />

