### PR TITLE
feat: 支持离线空降与番剧片头片尾跳过

### DIFF
--- a/lib/http/download.dart
+++ b/lib/http/download.dart
@@ -7,21 +7,50 @@ import 'package:PiliPlus/models/common/video/video_type.dart';
 import 'package:PiliPlus/models/video/play/url.dart';
 import 'package:PiliPlus/models_new/download/bili_download_entry_info.dart';
 import 'package:PiliPlus/models_new/download/bili_download_media_file_info.dart';
+import 'package:PiliPlus/models_new/sponsor_block/segment_item.dart';
+import 'package:PiliPlus/models_new/sponsor_block/snapshot.dart';
 import 'package:PiliPlus/utils/accounts.dart';
 import 'package:PiliPlus/utils/extension/iterable_ext.dart';
 import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:PiliPlus/utils/video_utils.dart';
 import 'package:collection/collection.dart';
+import 'package:dio/dio.dart';
 
 abstract final class DownloadHttp {
   static const String referer = "https://www.bilibili.com/";
   static const String userAgent = "Bilibili Freedoooooom/MarkII";
+
+  static Future<List<SegmentItemModel>> getPgcSkipSegments(
+    SponsorBlockTarget target,
+    CancelToken cancelToken,
+  ) async {
+    final isLogin = Accounts.get(AccountType.video).isLogin;
+    final result = await VideoHttp.videoUrl(
+      bvid: target.bvid,
+      cid: target.cid,
+      epid: target.epid,
+      seasonId: target.seasonId,
+      qn: VideoQuality.hdrVivid.code,
+      tryLook: !isLogin && Pref.p1080,
+      videoType: target.videoType == .pgc && !isLogin ? .ugc : target.videoType,
+      cancelToken: cancelToken,
+    );
+    return switch (result) {
+      Success(:final response) => response.clipInfoList ?? [],
+      Error(:final code) => throw SponsorBlockFetchException(
+        '获取片头片尾信息失败',
+        code: code,
+      ),
+      _ => throw const SponsorBlockFetchException('获取片头片尾信息失败'),
+    };
+  }
 
   static Future<BiliDownloadMediaInfo> getVideoUrl({
     required BiliDownloadEntryInfo entry,
     SourceInfo? source,
     PageInfo? pageData,
     EpInfo? ep,
+    void Function(List<SegmentItemModel>)? onSkipSegments,
   }) async {
     final isLogin = Accounts.get(AccountType.video).isLogin;
     final res = await VideoHttp.videoUrl(
@@ -39,6 +68,7 @@ abstract final class DownloadHttp {
       },
     );
     if (res case Success(:final response)) {
+      onSkipSegments?.call(response.clipInfoList ?? []);
       final dash = response.dash;
       if (dash != null) {
         final targetVideoQa = response.findAvailableVideoQuality(

--- a/lib/http/sponsor_block.dart
+++ b/lib/http/sponsor_block.dart
@@ -8,6 +8,7 @@ import 'package:PiliPlus/http/sponsor_block_api.dart';
 import 'package:PiliPlus/models/common/sponsor_block/post_segment_model.dart';
 import 'package:PiliPlus/models/common/sponsor_block/segment_type.dart';
 import 'package:PiliPlus/models_new/sponsor_block/segment_item.dart';
+import 'package:PiliPlus/models_new/sponsor_block/snapshot.dart';
 import 'package:PiliPlus/models_new/sponsor_block/user_info.dart';
 import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:PiliPlus/utils/utils.dart';
@@ -53,17 +54,51 @@ abstract final class SponsorBlock {
 
   static String _api(String url) => '$blockServer/api/$url';
 
+  static Future<Response> _getSegments({
+    required String bvid,
+    required int cid,
+    required String server,
+    CancelToken? cancelToken,
+  }) => Request().get(
+    '$server/api/${SponsorBlockApi.skipSegments}',
+    queryParameters: {'videoID': bvid, 'cid': cid},
+    cancelToken: cancelToken,
+    options: options,
+  );
+
+  static Future<List<SegmentItemModel>> getCachedSegments(
+    SponsorBlockTarget target,
+    String server,
+    CancelToken cancelToken,
+  ) async {
+    final response = await _getSegments(
+      bvid: target.bvid,
+      cid: target.cid,
+      server: normalizeSponsorServer(server),
+      cancelToken: cancelToken,
+    );
+    return parseCachedResponse(response);
+  }
+
+  static List<SegmentItemModel> parseCachedResponse(Response response) {
+    if (response.statusCode == 200) {
+      return SponsorBlockSnapshot.parseSegments(response.data);
+    }
+    // 仅接受明确的空数据响应，代理返回的HTML错误页保留为请求失败。
+    if (response case Response(statusCode: 404, data: [])) {
+      return [];
+    }
+    throw SponsorBlockFetchException('获取空降信息失败', code: response.statusCode);
+  }
+
   static Future<LoadingState<List<SegmentItemModel>>> getSkipSegments({
     required String bvid,
     required int cid,
   }) async {
-    final res = await Request().get(
-      _api(SponsorBlockApi.skipSegments),
-      queryParameters: {
-        'videoID': bvid,
-        'cid': cid,
-      },
-      options: options,
+    final res = await _getSegments(
+      bvid: bvid,
+      cid: cid,
+      server: blockServer,
     );
 
     if (res.statusCode == 200) {

--- a/lib/http/video.dart
+++ b/lib/http/video.dart
@@ -208,6 +208,7 @@ abstract final class VideoHttp {
     required VideoType videoType,
     String? language,
     bool voiceBalance = false,
+    CancelToken? cancelToken,
   }) async {
     final dmImgStr = Utils.base64EncodeRandomString(16, 64);
     final dmCoverImgStr = Utils.base64EncodeRandomString(32, 128);
@@ -236,7 +237,11 @@ abstract final class VideoHttp {
     });
 
     try {
-      final res = await Request().get(videoType.api, queryParameters: params);
+      final res = await Request().get(
+        videoType.api,
+        queryParameters: params,
+        cancelToken: cancelToken,
+      );
 
       if (res.data['code'] == 0) {
         late PlayUrlModel data;
@@ -257,7 +262,9 @@ abstract final class VideoHttp {
                   result['play_view_business_info']?['user_status']?['watch_progress']?['current_watch_progress'];
         }
         return Success(data);
-      } else if (epid != null && videoType == .ugc) {
+      } else if (epid != null &&
+          videoType == .ugc &&
+          cancelToken?.isCancelled != true) {
         return await videoUrl(
           avid: avid,
           bvid: bvid,
@@ -267,6 +274,7 @@ abstract final class VideoHttp {
           seasonId: seasonId,
           tryLook: tryLook,
           videoType: .pgc,
+          cancelToken: cancelToken,
         );
       }
       return Error(_parseVideoErr(res.data['code'], res.data['message']));

--- a/lib/models_new/sponsor_block/segment_item.dart
+++ b/lib/models_new/sponsor_block/segment_item.dart
@@ -19,6 +19,16 @@ class SegmentItemModel {
     this.votes,
   });
 
+  Map<String, dynamic> toJson() => {
+    'cid': cid,
+    'category': category,
+    'actionType': actionType,
+    'segment': [for (final value in segment) value / 1000],
+    'UUID': uuid,
+    'videoDuration': videoDuration == null ? null : videoDuration! / 1000,
+    'votes': votes,
+  };
+
   factory SegmentItemModel.fromJson(Map<String, dynamic> json) =>
       SegmentItemModel(
         cid: json["cid"],

--- a/lib/models_new/sponsor_block/snapshot.dart
+++ b/lib/models_new/sponsor_block/snapshot.dart
@@ -1,0 +1,175 @@
+import 'package:PiliPlus/models/common/sponsor_block/action_type.dart';
+import 'package:PiliPlus/models/common/sponsor_block/segment_type.dart';
+import 'package:PiliPlus/models/common/video/video_type.dart';
+import 'package:PiliPlus/models_new/sponsor_block/segment_item.dart';
+
+String normalizeSponsorServer(String server) =>
+    server.trim().replaceFirst(RegExp(r'/+$'), '');
+
+enum SponsorBlockSource { community, pgc }
+
+class SponsorBlockTarget {
+  const SponsorBlockTarget({
+    required this.directory,
+    required this.bvid,
+    required this.cid,
+    required this.durationMs,
+    required this.createdAt,
+    this.source = .community,
+    this.videoType = .ugc,
+    this.epid,
+    this.seasonId,
+  });
+
+  final String directory;
+  final String bvid;
+  final int cid;
+  final int durationMs;
+  final int createdAt;
+  final SponsorBlockSource source;
+  final VideoType videoType;
+  final int? epid;
+  final String? seasonId;
+}
+
+class SponsorBlockSnapshot {
+  const SponsorBlockSnapshot({
+    required this.bvid,
+    required this.cid,
+    required this.server,
+    required this.fetchedAt,
+    required this.mediaDurationMs,
+    required this.segments,
+    this.source = .community,
+  });
+
+  final String bvid;
+  final String cid;
+  final String server;
+  final DateTime fetchedAt;
+  final int mediaDurationMs;
+  final List<SegmentItemModel> segments;
+  final SponsorBlockSource source;
+
+  factory SponsorBlockSnapshot.fromJson(Map<String, dynamic> json) {
+    if (json['schemaVersion'] != 1 ||
+        json['bvid'] is! String ||
+        json['cid'] is! String ||
+        json['server'] is! String ||
+        json['mediaDurationMs'] is! int ||
+        (json['mediaDurationMs'] as int) < 0) {
+      throw const FormatException('空降文件格式不受支持');
+    }
+    return SponsorBlockSnapshot(
+      bvid: json['bvid'],
+      cid: json['cid'],
+      server: json['server'],
+      fetchedAt: DateTime.parse(json['fetchedAt'] as String),
+      mediaDurationMs: json['mediaDurationMs'],
+      segments: parseSegments(json['segments']),
+      source: json['source'] == null
+          ? .community
+          : SponsorBlockSource.values.byName(json['source'] as String),
+    );
+  }
+
+  static List<SegmentItemModel> parseSegments(Object? data) {
+    if (data is! List) throw const FormatException('空降响应应为列表');
+    return data.map((value) {
+      if (value is! Map<String, dynamic>) {
+        throw const FormatException('空降片段格式错误');
+      }
+      final interval = value['segment'];
+      final duration = value['videoDuration'];
+      if (interval is! List ||
+          interval.length != 2 ||
+          interval.any((e) => e is! num || !e.isFinite || e < 0) ||
+          (interval[1] as num) < (interval[0] as num) ||
+          value['category'] is! String ||
+          value['UUID'] is! String ||
+          (value['actionType'] != null && value['actionType'] is! String) ||
+          (value['cid'] != null &&
+              value['cid'] is! String &&
+              value['cid'] is! int) ||
+          (duration != null &&
+              (duration is! num || !duration.isFinite || duration < 0))) {
+        throw const FormatException('空降片段数据无效');
+      }
+      return SegmentItemModel.fromJson({
+        ...value,
+        'cid': value['cid']?.toString(),
+      });
+    }).toList();
+  }
+
+  List<SegmentItemModel> playableSegments(int durationMs) {
+    if (durationMs <= 0) return [];
+    return segments.where((item) {
+      final duration = item.videoDuration;
+      return (item.cid == null || item.cid == cid) &&
+          SegmentType.values.any((e) => e.name == item.category) &&
+          (item.actionType == null ||
+              ActionType.values.any((e) => e.name == item.actionType)) &&
+          item.segment.last <= durationMs &&
+          (duration == null ||
+              duration == 0 ||
+              (duration - durationMs).abs() <= 2000);
+    }).toList();
+  }
+
+  Map<String, dynamic> toJson() => {
+    'schemaVersion': 1,
+    'bvid': bvid,
+    'cid': cid,
+    'server': server,
+    'fetchedAt': fetchedAt.toUtc().toIso8601String(),
+    'mediaDurationMs': mediaDurationMs,
+    'segments': [for (final item in segments) item.toJson()],
+    'source': source.name,
+  };
+}
+
+enum SponsorBlockCacheStatus {
+  ready,
+  missing,
+  invalid,
+  differentSource,
+  failed,
+  cancelled,
+  reused,
+}
+
+class SponsorBlockCacheResult {
+  const SponsorBlockCacheResult(
+    this.status, {
+    this.snapshot,
+    this.message,
+    this.code,
+  });
+
+  final SponsorBlockCacheStatus status;
+  final SponsorBlockSnapshot? snapshot;
+  final String? message;
+  final int? code;
+  bool get isUsable =>
+      status == SponsorBlockCacheStatus.ready ||
+      status == SponsorBlockCacheStatus.reused;
+
+  String get description => switch (status) {
+    .ready || .reused =>
+      snapshot!.segments.isEmpty
+          ? '已查询，当前没有标记'
+          : '已保存 ${snapshot!.segments.length} 个片段',
+    .missing => '尚未保存空降信息',
+    .invalid => '空降文件不可用，可手动更新',
+    .differentSource => '来源与当前设置不同，可手动更新',
+    .failed => message ?? '更新失败，已有空降文件保持原样',
+    .cancelled => '更新已取消',
+  };
+}
+
+class SponsorBlockFetchException implements Exception {
+  const SponsorBlockFetchException(this.message, {this.code});
+  final String message;
+  final int? code;
+}

--- a/lib/pages/download/detail/view.dart
+++ b/lib/pages/download/detail/view.dart
@@ -11,6 +11,7 @@ import 'package:PiliPlus/pages/common/multi_select/base.dart'
     show BaseMultiSelectMixin;
 import 'package:PiliPlus/pages/download/controller.dart';
 import 'package:PiliPlus/pages/download/detail/widgets/item.dart';
+import 'package:PiliPlus/pages/download/widgets/sponsor_block_update.dart';
 import 'package:PiliPlus/services/download/download_service.dart';
 import 'package:PiliPlus/utils/grid.dart';
 import 'package:PiliPlus/utils/storage.dart';
@@ -98,6 +99,15 @@ class _DownloadDetailPageState extends State<DownloadDetailPage>
           appBar: MultiSelectAppBarWidget(
             ctr: this,
             actions: [
+              IconButton(
+                tooltip: '空降信息',
+                icon: const Icon(Icons.shield_outlined),
+                onPressed: () {
+                  final entries = allChecked.toList();
+                  handleSelect();
+                  showSponsorBlockUpdate(context, _downloadService, entries);
+                },
+              ),
               TextButton(
                 style: TextButton.styleFrom(
                   visualDensity: VisualDensity.compact,
@@ -120,7 +130,7 @@ class _DownloadDetailPageState extends State<DownloadDetailPage>
                   }
                 },
                 child: Text(
-                  '更新',
+                  '更新弹幕',
                   style: TextStyle(color: colorScheme.onSurface),
                 ),
               ),

--- a/lib/pages/download/detail/widgets/item.dart
+++ b/lib/pages/download/detail/widgets/item.dart
@@ -13,6 +13,7 @@ import 'package:PiliPlus/models/common/video/video_quality.dart';
 import 'package:PiliPlus/models_new/download/bili_download_entry_info.dart';
 import 'package:PiliPlus/pages/common/multi_select/base.dart';
 import 'package:PiliPlus/pages/download/downloading/view.dart';
+import 'package:PiliPlus/pages/download/widgets/sponsor_block_update.dart';
 import 'package:PiliPlus/services/download/download_service.dart';
 import 'package:PiliPlus/utils/cache_manager.dart';
 import 'package:PiliPlus/utils/duration_utils.dart';
@@ -62,7 +63,7 @@ class DetailItem extends StatelessWidget {
     void onLongPress() => canDel && !enableMultiSelect
         ? showDialog(
             context: context,
-            builder: (context) => SimpleDialog(
+            builder: (_) => SimpleDialog(
               clipBehavior: Clip.hardEdge,
               contentPadding: const EdgeInsets.symmetric(vertical: 12),
               children: [
@@ -92,6 +93,22 @@ class DetailItem extends StatelessWidget {
                   },
                   child: const Text('更新弹幕', style: TextStyle(fontSize: 14)),
                 ),
+                if (DownloadService.sponsorTarget(entry) != null)
+                  DialogOption(
+                    onPressed: () {
+                      Get.back();
+                      showSponsorBlockUpdate(
+                        context,
+                        downloadService,
+                        [entry],
+                        refresh: true,
+                      );
+                    },
+                    child: const Text(
+                      '更新空降信息',
+                      style: TextStyle(fontSize: 14),
+                    ),
+                  ),
               ],
             ),
           )

--- a/lib/pages/download/search/view.dart
+++ b/lib/pages/download/search/view.dart
@@ -4,6 +4,7 @@ import 'package:PiliPlus/models_new/download/bili_download_entry_info.dart';
 import 'package:PiliPlus/pages/common/search/common_search_page.dart';
 import 'package:PiliPlus/pages/download/detail/widgets/item.dart';
 import 'package:PiliPlus/pages/download/search/controller.dart';
+import 'package:PiliPlus/pages/download/widgets/sponsor_block_update.dart';
 import 'package:PiliPlus/services/download/download_service.dart';
 import 'package:PiliPlus/utils/grid.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
@@ -55,6 +56,15 @@ class _DownloadSearchPageState
 
   @override
   List<Widget>? get multiSelectActions => [
+    IconButton(
+      tooltip: '空降信息',
+      icon: const Icon(Icons.shield_outlined),
+      onPressed: () {
+        final entries = controller.allChecked.toList();
+        controller.handleSelect();
+        showSponsorBlockUpdate(context, _downloadService, entries);
+      },
+    ),
     TextButton(
       style: TextButton.styleFrom(visualDensity: VisualDensity.compact),
       onPressed: () async {
@@ -75,7 +85,7 @@ class _DownloadSearchPageState
         }
       },
       child: Text(
-        '更新',
+        '更新弹幕',
         style: TextStyle(color: ColorScheme.of(context).onSurface),
       ),
     ),

--- a/lib/pages/download/view.dart
+++ b/lib/pages/download/view.dart
@@ -16,6 +16,7 @@ import 'package:PiliPlus/pages/download/controller.dart';
 import 'package:PiliPlus/pages/download/detail/view.dart';
 import 'package:PiliPlus/pages/download/detail/widgets/item.dart';
 import 'package:PiliPlus/pages/download/search/view.dart';
+import 'package:PiliPlus/pages/download/widgets/sponsor_block_update.dart';
 import 'package:PiliPlus/services/download/download_service.dart';
 import 'package:PiliPlus/utils/cache_manager.dart';
 import 'package:PiliPlus/utils/grid.dart';
@@ -62,6 +63,17 @@ class _DownloadPageState extends State<DownloadPage> with GridMixin {
           appBar: MultiSelectAppBarWidget(
             ctr: _controller,
             actions: [
+              IconButton(
+                tooltip: '空降信息',
+                icon: const Icon(Icons.shield_outlined),
+                onPressed: () {
+                  final entries = _controller.allChecked
+                      .expand((page) => page.entries)
+                      .toList();
+                  _controller.handleSelect();
+                  showSponsorBlockUpdate(context, _downloadService, entries);
+                },
+              ),
               TextButton(
                 style: TextButton.styleFrom(
                   visualDensity: VisualDensity.compact,
@@ -84,7 +96,7 @@ class _DownloadPageState extends State<DownloadPage> with GridMixin {
                   }
                 },
                 child: Text(
-                  '更新',
+                  '更新弹幕',
                   style: TextStyle(color: theme.colorScheme.onSurface),
                 ),
               ),
@@ -268,6 +280,17 @@ class _DownloadPageState extends State<DownloadPage> with GridMixin {
                     }
                   },
                   child: const Text('更新弹幕', style: TextStyle(fontSize: 14)),
+                ),
+                DialogOption(
+                  onPressed: () {
+                    Get.back();
+                    showSponsorBlockUpdate(
+                      this.context,
+                      _downloadService,
+                      pageInfo.entries,
+                    );
+                  },
+                  child: const Text('更新空降信息', style: TextStyle(fontSize: 14)),
                 ),
               ],
             ),

--- a/lib/pages/download/widgets/sponsor_block_update.dart
+++ b/lib/pages/download/widgets/sponsor_block_update.dart
@@ -1,0 +1,102 @@
+import 'package:PiliPlus/models_new/download/bili_download_entry_info.dart';
+import 'package:PiliPlus/services/download/download_service.dart';
+import 'package:PiliPlus/services/download/sponsor_block_batch.dart';
+import 'package:PiliPlus/utils/storage_pref.dart';
+import 'package:material_ui/material_ui.dart';
+
+Future<void> showSponsorBlockUpdate(
+  BuildContext context,
+  DownloadService service,
+  Iterable<BiliDownloadEntryInfo> entries, {
+  bool refresh = false,
+}) {
+  final targets = [
+    for (final entry in entries)
+      entry.isCompleted ? DownloadService.sponsorTarget(entry) : null,
+  ];
+  return showDialog<void>(
+    context: context,
+    builder: (_) => _UpdateDialog(
+      batch: SponsorBlockBatch(service.sponsorBlockCache, targets),
+      refresh: refresh,
+    ),
+  );
+}
+
+class _UpdateDialog extends StatefulWidget {
+  const _UpdateDialog({required this.batch, required this.refresh});
+  final SponsorBlockBatch batch;
+  final bool refresh;
+
+  @override
+  State<_UpdateDialog> createState() => _UpdateDialogState();
+}
+
+class _UpdateDialogState extends State<_UpdateDialog> {
+  late bool _refresh = widget.refresh;
+
+  @override
+  void dispose() {
+    widget.batch.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => ListenableBuilder(
+    listenable: widget.batch,
+    builder: (context, _) {
+      final batch = widget.batch;
+      return AlertDialog(
+        title: const Text('更新空降信息'),
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('范围：已选择的 ${batch.total} 个视频或剧集'),
+              const Text('番剧启用片头片尾跳过时获取官方信息，其余情况获取社区标记。'),
+              if (!Pref.enableSponsorBlock)
+                const Text('空降助手已关闭，社区标记保存后可启用并重新打开视频使用。'),
+              DropdownButton<bool>(
+                value: _refresh,
+                isExpanded: true,
+                items: const [
+                  DropdownMenuItem(value: false, child: Text('补齐缺失')),
+                  DropdownMenuItem(value: true, child: Text('重新获取')),
+                ],
+                onChanged: batch.running || batch.finished
+                    ? null
+                    : (value) {
+                        if (value != null) setState(() => _refresh = value);
+                      },
+              ),
+              Text(batch.summary),
+              if (batch.running) ...[
+                const SizedBox(height: 12),
+                LinearProgressIndicator(
+                  value: batch.total == 0 ? 0 : batch.processed / batch.total,
+                ),
+              ],
+              if (batch.reason case final reason?) Text(reason),
+              const SizedBox(height: 8),
+              const Text('更新失败时已有空降文件保持原样。重新打开视频后使用更新的信息。'),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: Text(batch.running ? '取消更新' : '关闭'),
+          ),
+          if (!batch.finished)
+            TextButton(
+              onPressed: batch.running || batch.total == batch.unsupported
+                  ? null
+                  : () => batch.run(refresh: _refresh),
+              child: const Text('开始更新'),
+            ),
+        ],
+      );
+    },
+  );
+}

--- a/lib/pages/sponsor_block/block_mixin.dart
+++ b/lib/pages/sponsor_block/block_mixin.dart
@@ -56,15 +56,23 @@ mixin BlockMixin on GetxController {
   bool get isFullScreen => false;
 
   bool get isUgc;
-  late final isBlock = isUgc || !blockConfig.enablePgcSkip;
+  bool get isBlock => isUgc || !blockConfig.enablePgcSkip;
+  bool get allowCommunityRequests => true;
+  String? get blockDetailDescription => null;
+  int _blockGeneration = 0;
+  final _segmentGenerations = Expando<int>();
+  StreamSubscription<bool>? _pendingPlaying;
 
   Future<void> querySponsorBlock({
     required String bvid,
     required int cid,
   }) async {
+    if (!allowCommunityRequests) return;
     resetBlock();
+    final generation = _blockGeneration;
 
     final result = await SponsorBlock.getSkipSegments(bvid: bvid, cid: cid);
+    if (isClosed || generation != _blockGeneration) return;
     switch (result) {
       case Success<List<SegmentItemModel>>(:final response):
         handleSBData(response);
@@ -79,8 +87,10 @@ mixin BlockMixin on GetxController {
   void initSkip() {
     if (isClosed) return;
     if (_segmentList.isNotEmpty) {
+      final generation = _blockGeneration;
       _blockListener?.cancel();
       _blockListener = player?.stream.position.listen((position) {
+        if (isClosed || generation != _blockGeneration) return;
         int currentPos = position.inSeconds;
         if (currentPos != _lastBlockPos) {
           _lastBlockPos = currentPos;
@@ -115,11 +125,18 @@ mixin BlockMixin on GetxController {
     }
   }
 
-  Future<void> handleSBData(List<SegmentItemModel> list) async {
+  Future<void> handleSBData(
+    List<SegmentItemModel> list, {
+    bool deferPlayback = false,
+    int? durationMs,
+  }) async {
     if (list.isNotEmpty) {
       try {
         Future<void>? future;
-        final duration = list.first.videoDuration ?? timeLength!;
+        final generation = _blockGeneration;
+        final duration =
+            durationMs ?? list.first.videoDuration ?? timeLength ?? 0;
+        if (duration <= 0) return;
         // segmentList
         _segmentList.addAll(
           list
@@ -134,12 +151,16 @@ mixin BlockMixin on GetxController {
                     item,
                     isBlock ? blockConfig : null,
                   );
+                  _segmentGenerations[segmentModel] = generation;
                   if (segmentModel.segment == const (0, 0)) {
                     videoLabel?.value +=
                         '${videoLabel!.value.isNotEmpty ? '/' : ''}${segmentModel.segmentType.title}';
                   }
 
-                  if (_blockListener == null && autoPlay && player != null) {
+                  if (!deferPlayback &&
+                      _blockListener == null &&
+                      autoPlay &&
+                      player != null) {
                     final currPos = currPosInMilliseconds;
 
                     if (segmentModel.segment.contains(currPos)) {
@@ -154,13 +175,18 @@ mixin BlockMixin on GetxController {
                               segmentModel,
                             );
                           } else {
-                            player!.stream.playing.firstWhere((e) {
-                              if (e) {
-                                future = onSkip(segmentModel);
-                                return true;
-                              }
-                              return false;
-                            }, orElse: () => false);
+                            _pendingPlaying?.cancel();
+                            _pendingPlaying = player!.stream.playing.listen(
+                              (e) {
+                                if (e &&
+                                    !isClosed &&
+                                    generation == _blockGeneration) {
+                                  _pendingPlaying?.cancel();
+                                  _pendingPlaying = null;
+                                  future = onSkip(segmentModel);
+                                }
+                              },
+                            );
                           }
                           break;
                         case SkipType.skipManually:
@@ -190,8 +216,11 @@ mixin BlockMixin on GetxController {
           }),
         );
 
-        if (_blockListener == null && (autoPlay || preInitPlayer)) {
+        if (!deferPlayback &&
+            _blockListener == null &&
+            (autoPlay || preInitPlayer)) {
           await future;
+          if (isClosed || generation != _blockGeneration) return;
           initSkip();
         }
       } catch (e) {
@@ -246,7 +275,7 @@ mixin BlockMixin on GetxController {
     if (autoPlay && Pref.blockToast) {
       _showBlockToast('已跳过${item.segmentType.shortTitle}片段');
     }
-    if (isBlock && Pref.blockTrack) {
+    if (allowCommunityRequests && isBlock && Pref.blockTrack) {
       SponsorBlock.viewedVideoSponsorTime(item.uuid);
     }
   }
@@ -256,17 +285,21 @@ mixin BlockMixin on GetxController {
     bool isSkip = true,
     bool isSeek = true,
   }) async {
+    if (isClosed || _segmentGenerations[item] != _blockGeneration) return;
+    final generation = _blockGeneration;
     try {
       await seekTo(
         Duration(milliseconds: item.segment.$2),
         isSeek: isSeek,
       );
+      if (isClosed || generation != _blockGeneration) return;
       if (isSkip) {
         _skipToast(item);
       } else {
         _showBlockToast('已跳至${item.segmentType.shortTitle}');
       }
     } catch (e) {
+      if (isClosed || generation != _blockGeneration) return;
       if (kDebugMode) debugPrint('failed to skip: $e');
       if (isSkip) {
         _showBlockToast('${item.segmentType.shortTitle}片段跳过失败');
@@ -284,6 +317,7 @@ mixin BlockMixin on GetxController {
   }
 
   void _showVoteDialog(SegmentModel segment) {
+    if (!allowCommunityRequests || !_segmentList.contains(segment)) return;
     showDialog(
       context: Get.context!,
       builder: (context) => SimpleDialog(
@@ -316,12 +350,15 @@ mixin BlockMixin on GetxController {
     );
   }
 
-  void _doVote(String uuid, int type) => SponsorBlock.voteOnSponsorTime(
-    uuid: uuid,
-    type: type,
-  ).then((i) => SmartDialog.showToast(i.isSuccess ? '投票成功' : '投票失败: $i'));
+  void _doVote(String uuid, int type) {
+    if (!allowCommunityRequests) return;
+    SponsorBlock.voteOnSponsorTime(uuid: uuid, type: type).then(
+      (i) => SmartDialog.showToast(i.isSuccess ? '投票成功' : '投票失败: $i'),
+    );
+  }
 
   void _showCategoryDialog(SegmentModel segment) {
+    if (!allowCommunityRequests || !_segmentList.contains(segment)) return;
     showDialog(
       context: Get.context!,
       builder: (context) => SimpleDialog(
@@ -333,6 +370,10 @@ mixin BlockMixin on GetxController {
                 dense: true,
                 onTap: () {
                   Get.back();
+                  if (!allowCommunityRequests ||
+                      !_segmentList.contains(segment)) {
+                    return;
+                  }
                   SponsorBlock.voteOnSponsorTime(
                     uuid: segment.uuid,
                     category: item,
@@ -377,88 +418,92 @@ mixin BlockMixin on GetxController {
       builder: (context) => SimpleDialog(
         clipBehavior: .hardEdge,
         contentPadding: const .symmetric(vertical: 10),
-        children: _segmentList
-            .map(
-              (item) => ListTile(
-                onTap: () {
-                  Get.back();
-                  if (isBlock) {
-                    _showVoteDialog(item);
-                  }
-                },
-                dense: true,
-                title: Text.rich(
-                  TextSpan(
-                    children: [
-                      WidgetSpan(
-                        alignment: PlaceholderAlignment.middle,
-                        child: Container(
-                          height: 10,
-                          width: 10,
-                          decoration: BoxDecoration(
-                            shape: BoxShape.circle,
-                            color: blockConfig._getColor(item.segmentType),
-                          ),
-                        ),
-                        style: const TextStyle(fontSize: 14, height: 1),
-                      ),
-                      TextSpan(
-                        text: ' ${item.segmentType.title}',
-                        style: const TextStyle(fontSize: 14, height: 1),
-                      ),
-                    ],
-                  ),
-                ),
-                contentPadding: const EdgeInsets.only(left: 16, right: 8),
-                subtitle: Text(
-                  '${DurationUtils.formatDuration(item.segment.$1 / 1000)} 至 ${DurationUtils.formatDuration(item.segment.$2 / 1000)}',
-                  style: const TextStyle(fontSize: 13),
-                ),
-                trailing: Row(
-                  mainAxisSize: MainAxisSize.min,
+        children: [
+          if (blockDetailDescription case final description?)
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Text(description),
+            ),
+          for (final item in _segmentList)
+            ListTile(
+              onTap: () {
+                Get.back();
+                if (allowCommunityRequests && isBlock) {
+                  _showVoteDialog(item);
+                }
+              },
+              dense: true,
+              title: Text.rich(
+                TextSpan(
                   children: [
-                    Text(
-                      item.skipType.label,
-                      style: const TextStyle(fontSize: 13),
-                    ),
-                    if (item.segment.$2 != 0)
-                      SizedBox(
-                        width: 36,
-                        height: 36,
-                        child: IconButton(
-                          tooltip: item.skipType == SkipType.showOnly
-                              ? '跳至此片段'
-                              : '跳过此片段',
-                          onPressed: () {
-                            Get.back();
-                            onSkip(
-                              item,
-                              isSkip: item.skipType != SkipType.showOnly,
-                              isSeek: false,
-                            );
-                          },
-                          style: IconButton.styleFrom(
-                            padding: EdgeInsets.zero,
-                            tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                          ),
-                          icon: Icon(
-                            item.skipType == SkipType.showOnly
-                                ? Icons.my_location
-                                : MdiIcons.debugStepOver,
-                            size: 18,
-                            color: ColorScheme.of(
-                              context,
-                            ).onSurface.withValues(alpha: 0.7),
-                          ),
+                    WidgetSpan(
+                      alignment: PlaceholderAlignment.middle,
+                      child: Container(
+                        height: 10,
+                        width: 10,
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: blockConfig._getColor(item.segmentType),
                         ),
-                      )
-                    else
-                      const SizedBox(width: 10),
+                      ),
+                      style: const TextStyle(fontSize: 14, height: 1),
+                    ),
+                    TextSpan(
+                      text: ' ${item.segmentType.title}',
+                      style: const TextStyle(fontSize: 14, height: 1),
+                    ),
                   ],
                 ),
               ),
-            )
-            .toList(),
+              contentPadding: const EdgeInsets.only(left: 16, right: 8),
+              subtitle: Text(
+                '${DurationUtils.formatDuration(item.segment.$1 / 1000)} 至 ${DurationUtils.formatDuration(item.segment.$2 / 1000)}',
+                style: const TextStyle(fontSize: 13),
+              ),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    item.skipType.label,
+                    style: const TextStyle(fontSize: 13),
+                  ),
+                  if (item.segment.$2 != 0)
+                    SizedBox(
+                      width: 36,
+                      height: 36,
+                      child: IconButton(
+                        tooltip: item.skipType == SkipType.showOnly
+                            ? '跳至此片段'
+                            : '跳过此片段',
+                        onPressed: () {
+                          Get.back();
+                          onSkip(
+                            item,
+                            isSkip: item.skipType != SkipType.showOnly,
+                            isSeek: false,
+                          );
+                        },
+                        style: IconButton.styleFrom(
+                          padding: EdgeInsets.zero,
+                          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                        ),
+                        icon: Icon(
+                          item.skipType == SkipType.showOnly
+                              ? Icons.my_location
+                              : MdiIcons.debugStepOver,
+                          size: 18,
+                          color: ColorScheme.of(
+                            context,
+                          ).onSurface.withValues(alpha: 0.7),
+                        ),
+                      ),
+                    )
+                  else
+                    const SizedBox(width: 10),
+                ],
+              ),
+            ),
+        ],
       ),
     );
   }
@@ -471,7 +516,21 @@ mixin BlockMixin on GetxController {
   }
 
   void resetBlock() {
+    _blockGeneration++;
+    _pendingPlaying?.cancel();
+    _pendingPlaying = null;
     cancelBlockListener();
+    for (var index = listData.length - 1; index >= 0; index--) {
+      final item = listData[index];
+      if (item is SegmentModel) {
+        listData.removeAt(index);
+        listKey.currentState?.removeItem(
+          index,
+          (_, animation) => buildItem(item, animation),
+        );
+      }
+    }
+    if (listData.isEmpty) _stopSkipTimer();
     _lastBlockPos = null;
     videoLabel?.value = '';
     _segmentList.clear();
@@ -481,7 +540,7 @@ mixin BlockMixin on GetxController {
   Duration? getFirstSegment([int pos = 0]) {
     for (var i in _segmentList..sort()) {
       final (start, end) = i.segment;
-      if (start == end) {
+      if (start == end || end <= pos) {
         continue;
       } else if (start - pos < 100) {
         if (switch (i.skipType) {
@@ -489,6 +548,7 @@ mixin BlockMixin on GetxController {
           .skipOnce => !i.hasSkipped,
           _ => false,
         }) {
+          i.hasSkipped = true;
           _skipToast(i);
           pos = math.max(pos, i.segment.$2);
         }
@@ -502,12 +562,20 @@ mixin BlockMixin on GetxController {
     return null;
   }
 
+  void showCurrentManualSegment() {
+    for (final item in _segmentList) {
+      if (item.skipType == SkipType.skipManually &&
+          item.segment.contains(currPosInMilliseconds)) {
+        onAddItem(item);
+        break;
+      }
+    }
+  }
+
   @override
   void onClose() {
     _stopSkipTimer();
-    if (blockConfig.enableBlock) {
-      resetBlock();
-    }
+    resetBlock();
     super.onClose();
   }
 }

--- a/lib/pages/sponsor_block/view.dart
+++ b/lib/pages/sponsor_block/view.dart
@@ -6,7 +6,9 @@ import 'package:PiliPlus/http/sponsor_block.dart';
 import 'package:PiliPlus/models/common/sponsor_block/segment_type.dart';
 import 'package:PiliPlus/models/common/sponsor_block/skip_type.dart';
 import 'package:PiliPlus/models_new/sponsor_block/user_info.dart';
+import 'package:PiliPlus/pages/download/widgets/sponsor_block_update.dart';
 import 'package:PiliPlus/pages/setting/slide_color_picker.dart';
+import 'package:PiliPlus/services/download/download_service.dart';
 import 'package:PiliPlus/utils/accounts/account_manager/account_mgr.dart';
 import 'package:PiliPlus/utils/filtering_text.dart';
 import 'package:PiliPlus/utils/page_utils.dart';
@@ -512,6 +514,33 @@ class _SponsorBlockPageState extends State<SponsorBlockPage> {
           sliverDivider,
           SliverToBoxAdapter(
             child: _blockServerItem(theme, titleStyle, subTitleStyle),
+          ),
+          SliverToBoxAdapter(
+            child: SwitchListTile(
+              title: const Text('缓存视频时保存空降信息'),
+              subtitle: const Text('随视频保存社区标记或番剧片头片尾信息，使用对应的跳过设置。'),
+              value: Pref.cacheSponsorBlock,
+              onChanged: (value) async {
+                await setting.put(SettingBoxKey.cacheSponsorBlock, value);
+                if (mounted) setState(() {});
+              },
+            ),
+          ),
+          SliverToBoxAdapter(
+            child: ListTile(
+              title: const Text('补齐已有缓存的空降信息'),
+              subtitle: const Text('处理当前缓存目录中的全部已完成视频'),
+              onTap: () async {
+                final service = Get.find<DownloadService>();
+                await service.waitForInitialization;
+                if (!context.mounted) return;
+                await showSponsorBlockUpdate(
+                  context,
+                  service,
+                  service.downloadList.toList(),
+                );
+              },
+            ),
           ),
           dividerL,
           SliverToBoxAdapter(child: _aboutItem(titleStyle, subTitleStyle)),

--- a/lib/pages/video/controller.dart
+++ b/lib/pages/video/controller.dart
@@ -29,6 +29,7 @@ import 'package:PiliPlus/models/video/play/url.dart';
 import 'package:PiliPlus/models_new/download/bili_download_entry_info.dart';
 import 'package:PiliPlus/models_new/media_list/media_list.dart';
 import 'package:PiliPlus/models_new/pgc/pgc_info_model/result.dart';
+import 'package:PiliPlus/models_new/sponsor_block/snapshot.dart';
 import 'package:PiliPlus/models_new/video/video_detail/data.dart';
 import 'package:PiliPlus/models_new/video/video_detail/episode.dart' as ugc;
 import 'package:PiliPlus/models_new/video/video_detail/page.dart';
@@ -77,6 +78,7 @@ import 'package:get/get.dart';
 import 'package:hive_ce/hive.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:media_kit/media_kit.dart' hide Subtitle;
+import 'package:synchronized/synchronized.dart';
 
 class VideoDetailController extends GetxController
     with GetTickerProviderStateMixin, BlockMixin {
@@ -102,6 +104,39 @@ class VideoDetailController extends GetxController
   late SourceType sourceType;
   late BiliDownloadEntryInfo entry;
   late bool isFileSource;
+  int _fileGeneration = 0;
+  int _fileBlocksGeneration = -1;
+  Future<SponsorBlockCacheResult>? _fileBlockRead;
+  SponsorBlockCacheResult? _fileBlockResult;
+  final _filePlayerLock = Lock();
+  StreamSubscription<Duration>? _fileDurationSubscription;
+
+  @override
+  bool get allowCommunityRequests => !isFileSource;
+
+  @override
+  bool get isBlock => isFileSource
+      ? entry.ep == null || !blockConfig.enablePgcSkip
+      : super.isBlock;
+
+  @override
+  String? get blockDetailDescription {
+    if (!isFileSource) return null;
+    final result = _fileBlockResult;
+    final snapshot = result?.snapshot;
+    return [
+      result?.description ?? '正在读取空降信息',
+      if (isBlock && !blockConfig.enableSponsorBlock) '空降助手已关闭，启用后重新打开视频生效',
+      if (snapshot != null) ...[
+        '保存时间：${snapshot.fetchedAt.toLocal()}',
+        '来源：${snapshot.source == .pgc ? 'B站片头片尾信息' : snapshot.server}',
+        if (snapshot.segments.isNotEmpty && segmentProgressList.isEmpty)
+          '当前设置或视频时长下没有可用片段',
+      ],
+      '可在离线缓存列表更新；重新打开视频后加载更新的信息。',
+    ].join('\n');
+  }
+
   late bool _mediaDesc = false;
   late final RxList<MediaListItemModel> mediaList = <MediaListItemModel>[].obs;
   late String watchLaterTitle;
@@ -331,6 +366,15 @@ class VideoDetailController extends GetxController
 
   void initFileSource(BiliDownloadEntryInfo entry, {bool isInit = true}) {
     this.entry = entry;
+    _fileGeneration++;
+    _fileBlockResult = null;
+    final target = DownloadService.sponsorTarget(
+      entry,
+      enablePgcSkip: blockConfig.enablePgcSkip,
+    );
+    _fileBlockRead = target == null
+        ? null
+        : Get.find<DownloadService>().sponsorBlockCache.read(target);
     firstVideo = VideoItem(
       id: entry.preferedVideoQuality,
       quality: VideoQuality.fromCode(entry.preferedVideoQuality),
@@ -718,10 +762,77 @@ class VideoDetailController extends GetxController
   Future<void> playerInit({
     bool? autoplay,
     bool autoFullScreenFlag = false,
+  }) {
+    final generation = _fileGeneration;
+    if (!isFileSource) {
+      return _playerInit(
+        autoplay: autoplay,
+        autoFullScreenFlag: autoFullScreenFlag,
+      );
+    }
+    return _filePlayerLock.synchronized(() async {
+      if (isClosed || generation != _fileGeneration) return;
+      await _playerInit(
+        autoplay: autoplay,
+        autoFullScreenFlag: autoFullScreenFlag,
+      );
+    });
+  }
+
+  Future<void> _applyFileBlocks(int generation, int duration) async {
+    if (isClosed ||
+        generation != _fileGeneration ||
+        duration <= 0 ||
+        _fileBlocksGeneration == generation) {
+      return;
+    }
+    _fileBlocksGeneration = generation;
+    resetBlock();
+    if (isBlock && !blockConfig.enableSponsorBlock) return;
+    if (_fileBlockResult?.snapshot case final snapshot?) {
+      await handleSBData(
+        snapshot.playableSegments(duration),
+        deferPlayback: true,
+        durationMs: duration,
+      );
+    }
+  }
+
+  Future<void> _initFileSkip(
+    int generation,
+    int duration, {
+    bool skipCurrent = false,
   }) async {
+    await _applyFileBlocks(generation, duration);
+    if (isClosed || generation != _fileGeneration) return;
+    if (skipCurrent) {
+      final seek = getFirstSegment(currPosInMilliseconds);
+      if (seek != null) await seekTo(seek, isSeek: false);
+      if (isClosed || generation != _fileGeneration) return;
+    }
+    initSkip();
+    showCurrentManualSegment();
+  }
+
+  Future<void> _playerInit({
+    bool? autoplay,
+    bool autoFullScreenFlag = false,
+  }) async {
+    final generation = _fileGeneration;
+    if (isFileSource) {
+      final result = await _fileBlockRead;
+      if (isClosed || generation != _fileGeneration) return;
+      _fileBlockResult = result;
+      await _applyFileBlocks(generation, data.timeLength ?? 0);
+      if (isClosed || generation != _fileGeneration) return;
+    }
     Duration? seek = defaultST ?? playedTime;
     if (seek == .zero) seek = null;
-    seek ??= getFirstSegment();
+    if (isFileSource) {
+      seek = getFirstSegment(seek?.inMilliseconds ?? 0) ?? seek;
+    } else {
+      seek ??= getFirstSegment();
+    }
     await plPlayerController.setDataSource(
       isFileSource
           ? FileSource(
@@ -748,6 +859,7 @@ class VideoDetailController extends GetxController
       pgcType: isUgc ? null : pgcType,
       videoType: videoType,
       onInit: () {
+        if (isClosed || (isFileSource && generation != _fileGeneration)) return;
         videoState.value = true;
         setSubtitle(vttSubtitlesIndex.value);
       },
@@ -757,9 +869,34 @@ class VideoDetailController extends GetxController
       autoFullScreenFlag: autoFullScreenFlag,
     );
 
-    if (isClosed) return;
+    if (isClosed || (isFileSource && generation != _fileGeneration)) return;
 
-    if (!isFileSource) {
+    if (isFileSource) {
+      await _initFileSkip(
+        generation,
+        player?.state.duration.inMilliseconds ?? 0,
+      );
+      if (isClosed || generation != _fileGeneration) return;
+      if (_fileBlocksGeneration != generation) {
+        _fileDurationSubscription?.cancel();
+        _fileDurationSubscription = player?.stream.duration.listen(
+          (duration) async {
+            if (duration.inMilliseconds <= 0 ||
+                isClosed ||
+                generation != _fileGeneration) {
+              return;
+            }
+            _fileDurationSubscription?.cancel();
+            _fileDurationSubscription = null;
+            await _initFileSkip(
+              generation,
+              duration.inMilliseconds,
+              skipCurrent: true,
+            );
+          },
+        );
+      }
+    } else {
       if (plPlayerController.enableBlock) {
         initSkip();
       }
@@ -994,6 +1131,7 @@ class VideoDetailController extends GetxController
 
   late final List<PostSegmentModel> postList = <PostSegmentModel>[];
   void onBlock(BuildContext context) {
+    if (!allowCommunityRequests) return;
     if (postList.isEmpty) {
       postList.add(
         PostSegmentModel(
@@ -1243,6 +1381,8 @@ class VideoDetailController extends GetxController
 
   @override
   void onClose() {
+    _fileGeneration++;
+    _fileDurationSubscription?.cancel();
     cid.close();
     if (isFileSource) {
       cacheLocalProgress();
@@ -1260,6 +1400,10 @@ class VideoDetailController extends GetxController
   }
 
   void onReset({bool isStein = false}) {
+    _fileGeneration++;
+    _fileDurationSubscription?.cancel();
+    _fileDurationSubscription = null;
+    resetBlock();
     if (isFileSource) {
       cacheLocalProgress();
     }
@@ -1290,11 +1434,6 @@ class VideoDetailController extends GetxController
       // view point
       if (plPlayerController.showViewPoints) {
         viewPointList.clear();
-      }
-
-      // sponsor block
-      if (blockConfig.enableBlock) {
-        resetBlock();
       }
 
       // interactive video

--- a/lib/pages/video/widgets/header_control.dart
+++ b/lib/pages/video/widgets/header_control.dart
@@ -1858,6 +1858,21 @@ class HeaderControlState extends State<HeaderControl>
                       : const SizedBox.shrink(),
                 ),
               ],
+              if (isFileSource)
+                SizedBox(
+                  width: btnWidth,
+                  height: btnHeight,
+                  child: IconButton(
+                    tooltip: '空降信息',
+                    style: btnStyle,
+                    onPressed: videoDetailCtr.showSBDetail,
+                    icon: const Icon(
+                      MdiIcons.advertisements,
+                      size: 19,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
               if (!isPortrait || isFullScreen || PlatformUtils.isDesktop) ...[
                 SizedBox(
                   width: btnWidth,

--- a/lib/services/download/download_service.dart
+++ b/lib/services/download/download_service.dart
@@ -5,21 +5,29 @@ import 'dart:io' show Directory, File;
 import 'package:PiliPlus/grpc/dm.dart';
 import 'package:PiliPlus/http/download.dart';
 import 'package:PiliPlus/http/init.dart';
+import 'package:PiliPlus/http/sponsor_block.dart';
+import 'package:PiliPlus/models/common/sponsor_block/skip_type.dart';
 import 'package:PiliPlus/models/common/video/video_quality.dart';
 import 'package:PiliPlus/models_new/download/bili_download_entry_info.dart';
 import 'package:PiliPlus/models_new/download/bili_download_media_file_info.dart';
 import 'package:PiliPlus/models_new/pgc/pgc_info_model/episode.dart' as pgc;
 import 'package:PiliPlus/models_new/pgc/pgc_info_model/result.dart';
+import 'package:PiliPlus/models_new/sponsor_block/segment_item.dart';
+import 'package:PiliPlus/models_new/sponsor_block/snapshot.dart';
 import 'package:PiliPlus/models_new/video/video_detail/data.dart';
 import 'package:PiliPlus/models_new/video/video_detail/episode.dart' as ugc;
 import 'package:PiliPlus/models_new/video/video_detail/page.dart';
 import 'package:PiliPlus/services/download/download_manager.dart';
+import 'package:PiliPlus/services/download/sponsor_block_cache.dart';
 import 'package:PiliPlus/utils/cache_manager.dart';
 import 'package:PiliPlus/utils/danmaku_utils.dart';
 import 'package:PiliPlus/utils/extension/file_ext.dart';
 import 'package:PiliPlus/utils/extension/string_ext.dart';
 import 'package:PiliPlus/utils/id_utils.dart';
 import 'package:PiliPlus/utils/path_utils.dart';
+import 'package:PiliPlus/utils/storage.dart';
+import 'package:PiliPlus/utils/storage_key.dart';
+import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:get/get.dart';
@@ -34,6 +42,39 @@ class DownloadService extends GetxService {
   static const _maxDanmakuConcurrency = 4;
 
   final _lock = Lock();
+  final sponsorBlockCache = SponsorBlockCache(
+    server: () => Pref.blockServer,
+    fetch: (target, server, token) => target.source == .pgc
+        ? DownloadHttp.getPgcSkipSegments(target, token)
+        : SponsorBlock.getCachedSegments(target, server, token),
+  );
+  StreamSubscription<dynamic>? _settingsSubscription;
+  int _prepareGeneration = 0;
+
+  static SponsorBlockTarget? sponsorTarget(
+    BiliDownloadEntryInfo entry, {
+    bool? enablePgcSkip,
+  }) => entry.pageData != null || (entry.ep != null && entry.source != null)
+      ? SponsorBlockTarget(
+          directory: entry.entryDirPath,
+          bvid: entry.bvid,
+          cid: entry.cid,
+          durationMs: entry.totalTimeMilli,
+          createdAt: entry.timeCreateStamp,
+          source:
+              entry.ep != null &&
+                  (enablePgcSkip ?? (Pref.pgcSkipType != SkipType.disable))
+              ? .pgc
+              : .community,
+          videoType: switch (entry.ep?.from) {
+            'pugv' => .pugv,
+            != null => .pgc,
+            _ => .ugc,
+          },
+          epid: entry.ep?.episodeId,
+          seasonId: entry.seasonId,
+        )
+      : null;
 
   final flagNotifier = SetNotifier();
   final waitDownloadQueue = RxList<BiliDownloadEntryInfo>();
@@ -59,9 +100,27 @@ class DownloadService extends GetxService {
   void onInit() {
     super.onInit();
     initDownloadList();
+    _settingsSubscription = GStorage.setting.watch().listen((event) {
+      if (const {
+        SettingBoxKey.blockServer,
+        SettingBoxKey.enableSponsorBlock,
+        SettingBoxKey.cacheSponsorBlock,
+        SettingBoxKey.pgcSkipType,
+      }.contains(event.key)) {
+        sponsorBlockCache.invalidateAll();
+      }
+    });
+  }
+
+  @override
+  void onClose() {
+    _settingsSubscription?.cancel();
+    sponsorBlockCache.invalidateAll();
+    super.onClose();
   }
 
   void initDownloadList() {
+    sponsorBlockCache.invalidateAll();
     waitForInitialization = _readDownloadList();
   }
 
@@ -238,9 +297,13 @@ class DownloadService extends GetxService {
   }
 
   Future<void> _createDownload(BiliDownloadEntryInfo entry) async {
-    final entryDir = await _getDownloadEntryDir(entry);
-    final entryJsonFile = File(path.join(entryDir.path, _entryFile));
-    await entryJsonFile.writeAsString(jsonEncode(entry.toJson()));
+    final entryDir = await sponsorBlockCache.withFiles(() async {
+      final directory = await _getDownloadEntryDir(entry);
+      await File(path.join(directory.path, _entryFile)).writeAsString(
+        jsonEncode(entry.toJson()),
+      );
+      return directory;
+    });
     entry
       ..pageDirPath = entryDir.parent.path
       ..entryDirPath = entryDir.path
@@ -279,7 +342,12 @@ class DownloadService extends GetxService {
   }
 
   Future<void> startDownload(BiliDownloadEntryInfo entry) {
+    final generation = ++_prepareGeneration;
+    if (curDownload.value case final current?) {
+      sponsorBlockCache.cancel(current.entryDirPath);
+    }
     return _lock.synchronized(() async {
+      if (generation != _prepareGeneration) return;
       await _downloadManager?.cancel(isDelete: false);
       await _audioDownloadManager?.cancel(isDelete: false);
       _downloadManager = null;
@@ -293,7 +361,7 @@ class DownloadService extends GetxService {
       _curCid = entry.cid;
       curDownload.value = entry;
       waitDownloadQueue.refresh();
-      await _startDownload(entry);
+      await _startDownload(entry, generation);
     });
   }
 
@@ -369,20 +437,27 @@ class DownloadService extends GetxService {
     }
   }
 
-  Future<void> _startDownload(BiliDownloadEntryInfo entry) async {
+  Future<void> _startDownload(
+    BiliDownloadEntryInfo entry,
+    int generation,
+  ) async {
     try {
       if (!await downloadDanmaku(entry: entry)) {
         return;
       }
+      if (generation != _prepareGeneration) return;
 
       _updateCurStatus(DownloadStatus.getPlayUrl);
 
+      List<SegmentItemModel>? pgcSegments;
       final mediaFileInfo = await DownloadHttp.getVideoUrl(
         entry: entry,
         ep: entry.ep,
         source: entry.source,
         pageData: entry.pageData,
+        onSkipSegments: (segments) => pgcSegments = segments,
       );
+      if (generation != _prepareGeneration) return;
 
       final videoDir = Directory(path.join(entry.entryDirPath, entry.typeTag));
       if (!videoDir.existsSync()) {
@@ -390,12 +465,21 @@ class DownloadService extends GetxService {
       }
 
       final mediaJsonFile = File(path.join(videoDir.path, _indexFile));
+      final target = sponsorTarget(entry);
       await Future.wait([
         mediaJsonFile.writeAsString(jsonEncode(mediaFileInfo.toJson())),
         _downloadCover(entry: entry),
+        if (target != null &&
+            Pref.cacheSponsorBlock &&
+            (target.source == .pgc || Pref.enableSponsorBlock))
+          sponsorBlockCache.update(
+            target,
+            segments: target.source == .pgc ? pgcSegments : null,
+          ),
       ]);
 
-      if (curDownload.value?.cid != entry.cid) {
+      if (generation != _prepareGeneration ||
+          curDownload.value?.cid != entry.cid) {
         return;
       }
 
@@ -438,6 +522,7 @@ class DownloadService extends GetxService {
           break;
       }
     } catch (e) {
+      if (generation != _prepareGeneration) return;
       _updateCurStatus(DownloadStatus.failPlayUrl);
       if (kDebugMode) {
         debugPrint('get download url error: $e');
@@ -544,17 +629,19 @@ class DownloadService extends GetxService {
         downloadNext: downloadNext,
       );
     }
-    final downloadDir = Directory(entry.pageDirPath);
-    if (downloadDir.existsSync()) {
-      if (!await downloadDir.lengthGte(2)) {
-        await downloadDir.tryDel(recursive: true);
-      } else {
-        final entryDir = Directory(entry.entryDirPath);
-        if (entryDir.existsSync()) {
-          await entryDir.tryDel(recursive: true);
+    await sponsorBlockCache.remove(entry.pageDirPath, () async {
+      final downloadDir = Directory(entry.pageDirPath);
+      if (downloadDir.existsSync()) {
+        if (!await downloadDir.lengthGte(2)) {
+          await downloadDir.tryDel(recursive: true);
+        } else {
+          final entryDir = Directory(entry.entryDirPath);
+          if (entryDir.existsSync()) {
+            await entryDir.tryDel(recursive: true);
+          }
         }
       }
-    }
+    });
     if (refresh) {
       flagNotifier.refresh();
     }
@@ -564,7 +651,10 @@ class DownloadService extends GetxService {
     required String pageDirPath,
     bool refresh = true,
   }) async {
-    await Directory(pageDirPath).tryDel(recursive: true);
+    await sponsorBlockCache.remove(
+      pageDirPath,
+      () => Directory(pageDirPath).tryDel(recursive: true),
+    );
     downloadList.removeWhere((e) => e.pageDirPath == pageDirPath);
     if (refresh) {
       flagNotifier.refresh();
@@ -575,6 +665,10 @@ class DownloadService extends GetxService {
     required bool isDelete,
     bool downloadNext = true,
   }) async {
+    _prepareGeneration++;
+    if (curDownload.value case final current?) {
+      sponsorBlockCache.cancel(current.entryDirPath);
+    }
     await _downloadManager?.cancel(isDelete: isDelete);
     await _audioDownloadManager?.cancel(isDelete: isDelete);
     _downloadManager = null;

--- a/lib/services/download/sponsor_block_batch.dart
+++ b/lib/services/download/sponsor_block_batch.dart
@@ -1,0 +1,123 @@
+import 'package:PiliPlus/models_new/sponsor_block/snapshot.dart';
+import 'package:PiliPlus/services/download/sponsor_block_cache.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as path;
+
+class SponsorBlockBatch extends ChangeNotifier {
+  SponsorBlockBatch(this.cache, Iterable<SponsorBlockTarget?> targets) {
+    final seen = <(String, String, int)>{};
+    for (final target in targets) {
+      if (target == null) {
+        unsupported++;
+      } else if (seen.add((
+        path.normalize(path.absolute(target.directory)),
+        target.bvid,
+        target.cid,
+      ))) {
+        _targets.add(target);
+      }
+    }
+  }
+
+  final SponsorBlockCache cache;
+  final _targets = <SponsorBlockTarget>[];
+  CancelToken? _token;
+  bool _disposed = false;
+  bool running = false;
+  bool finished = false;
+  int saved = 0;
+  int empty = 0;
+  int reused = 0;
+  int failed = 0;
+  int unsupported = 0;
+  String? reason;
+  int get total => _targets.length + unsupported;
+  int get processed => saved + empty + reused + failed + unsupported;
+  int get remaining => total - processed;
+  String get summary =>
+      '保存有标记 $saved，保存空标记 $empty，已有有效信息 $reused，'
+      '内容不适用 $unsupported，失败 $failed，尚未处理 $remaining';
+
+  void _notify() {
+    if (!_disposed) notifyListeners();
+  }
+
+  void cancel() => _token?.cancel();
+
+  Future<void> run({required bool refresh}) async {
+    if (running || finished || _disposed) return;
+    if (cache.batchRunning) {
+      reason = '已有空降更新正在进行，请稍后重试';
+      _notify();
+      return;
+    }
+    cache.batchRunning = running = true;
+    final token = _token = CancelToken();
+    final generation = cache.generation;
+    var failures = 0;
+    _notify();
+    try {
+      for (final target in _targets) {
+        if (token.isCancelled || generation != cache.generation) {
+          reason = '更新已取消，已保存的结果保留';
+          break;
+        }
+        // 每个请求单独取消，超时不会取消整批操作。
+        final request = CancelToken();
+        token.whenCancel.then((_) => request.cancel());
+        final result = await cache.update(
+          target,
+          refresh: refresh,
+          cancelToken: request,
+        );
+        if (_disposed) break;
+        switch (result.status) {
+          case .ready:
+            if (result.snapshot!.segments.isEmpty) {
+              empty++;
+            } else {
+              saved++;
+            }
+            failures = 0;
+          case .reused:
+            reused++;
+            failures = 0;
+          case .cancelled:
+            reason = '更新已取消，已保存的结果保留';
+            token.cancel();
+          default:
+            failed++;
+            failures = result.code == -1 || (result.code ?? 0) >= 500
+                ? failures + 1
+                : 0;
+            if (result.code == 429 || failures >= 3) {
+              reason = '服务器限流或连续网络故障，已停止后续请求';
+              token.cancel();
+            }
+        }
+        _notify();
+        if (token.isCancelled) break;
+        if (result.status != SponsorBlockCacheStatus.reused) {
+          await Future.any([
+            Future<void>.delayed(const Duration(milliseconds: 300)),
+            token.whenCancel,
+          ]);
+        }
+      }
+    } finally {
+      cache.batchRunning = running = false;
+      finished = true;
+      // 释放本批请求绑定的取消回调。
+      token.cancel();
+      _notify();
+    }
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    cancel();
+    super.dispose();
+  }
+}

--- a/lib/services/download/sponsor_block_cache.dart
+++ b/lib/services/download/sponsor_block_cache.dart
@@ -1,0 +1,206 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:PiliPlus/models_new/sponsor_block/segment_item.dart';
+import 'package:PiliPlus/models_new/sponsor_block/snapshot.dart';
+import 'package:PiliPlus/utils/path_utils.dart';
+import 'package:dio/dio.dart';
+import 'package:path/path.dart' as path;
+import 'package:synchronized/synchronized.dart';
+
+typedef SponsorBlockFetcher = Future<List<SegmentItemModel>> Function(
+  SponsorBlockTarget target,
+  String server,
+  CancelToken cancelToken,
+);
+
+class SponsorBlockCache {
+  SponsorBlockCache({
+    required this.server,
+    required this.fetch,
+    this.requestTimeout = const Duration(seconds: 5),
+    this.readTimeout = const Duration(seconds: 1),
+    this.replaceFile = _replaceFile,
+  });
+
+  final String Function() server;
+  final SponsorBlockFetcher fetch;
+  final Duration requestTimeout;
+  final Duration readTimeout;
+  final void Function(File source, String destination) replaceFile;
+  final _files = Lock();
+  final _active = <String, CancelToken>{};
+  int _serial = 0;
+  int _generation = 0;
+  int get generation => _generation;
+  bool batchRunning = false;
+
+  static void _replaceFile(File source, String destination) =>
+      source.renameSync(destination);
+
+  String _key(String directory) => path.normalize(path.absolute(directory));
+
+  String _source(SponsorBlockTarget target) => target.source == .pgc
+      ? 'https://www.bilibili.com'
+      : normalizeSponsorServer(server());
+
+  String _fileName(SponsorBlockTarget target) => target.source == .pgc
+      ? PathUtils.pgcSkipName
+      : PathUtils.sponsorBlockName;
+
+  Future<SponsorBlockCacheResult> read(SponsorBlockTarget target) async {
+    final source = _source(target);
+    try {
+      return await _read(target, source).timeout(readTimeout);
+    } catch (_) {
+      return const SponsorBlockCacheResult(.invalid);
+    }
+  }
+
+  Future<SponsorBlockCacheResult> _read(
+    SponsorBlockTarget target,
+    String source,
+  ) async {
+    final file = File(path.join(target.directory, _fileName(target)));
+    try {
+      final snapshot = SponsorBlockSnapshot.fromJson(
+        jsonDecode(await file.readAsString()),
+      );
+      if (snapshot.bvid != target.bvid ||
+          snapshot.cid != target.cid.toString()) {
+        return const SponsorBlockCacheResult(.invalid);
+      }
+      if (snapshot.source != target.source ||
+          normalizeSponsorServer(snapshot.server) != source) {
+        return const SponsorBlockCacheResult(.differentSource);
+      }
+      return SponsorBlockCacheResult(.ready, snapshot: snapshot);
+    } on PathNotFoundException {
+      return const SponsorBlockCacheResult(.missing);
+    } catch (_) {
+      return const SponsorBlockCacheResult(.invalid);
+    }
+  }
+
+  void cancel(String directory) => _active[_key(directory)]?.cancel();
+
+  void invalidateAll() {
+    _generation++;
+    for (final token in _active.values) {
+      token.cancel();
+    }
+  }
+
+  Future<T> withFiles<T>(Future<T> Function() action) =>
+      _files.synchronized(action);
+
+  Future<T> remove<T>(String directory, Future<T> Function() action) {
+    final key = _key(directory);
+    for (final item in _active.entries) {
+      if (item.key == key || path.isWithin(key, item.key)) item.value.cancel();
+    }
+    return withFiles(action);
+  }
+
+  Future<SponsorBlockCacheResult> update(
+    SponsorBlockTarget target, {
+    bool refresh = false,
+    CancelToken? cancelToken,
+    List<SegmentItemModel>? segments,
+  }) async {
+    final key = _key(target.directory);
+    final token = cancelToken ?? CancelToken();
+    _active[key]?.cancel();
+    _active[key] = token;
+    final source = _source(target);
+    final serial = ++_serial;
+    bool valid() =>
+        !token.isCancelled &&
+        identical(_active[key], token) &&
+        source == _source(target);
+    var timedOut = false;
+    final timer = Timer(requestTimeout, () {
+      timedOut = true;
+      token.cancel('获取空降信息超时');
+    });
+    final operation = () async {
+      if (!refresh) {
+        final existing = await read(target);
+        if (!valid()) return const SponsorBlockCacheResult(.cancelled);
+        if (existing.isUsable) {
+          return SponsorBlockCacheResult(.reused, snapshot: existing.snapshot);
+        }
+      }
+      if (!valid()) return const SponsorBlockCacheResult(.cancelled);
+      final items = segments ?? await fetch(target, source, token);
+      // 重新解析确保调用方提供的数据可以完整保存，异常响应不能清除旧文件。
+      final parsedSegments = SponsorBlockSnapshot.parseSegments([
+        for (final item in items) item.toJson(),
+      ]);
+      if (parsedSegments.any(
+        (e) => e.cid != null && e.cid != target.cid.toString(),
+      )) {
+        throw const FormatException('空降响应包含其他视频的片段');
+      }
+      final snapshot = SponsorBlockSnapshot(
+        bvid: target.bvid,
+        cid: target.cid.toString(),
+        server: source,
+        fetchedAt: DateTime.now().toUtc(),
+        mediaDurationMs: target.durationMs,
+        segments: parsedSegments,
+        source: target.source,
+      );
+      return withFiles(() async {
+        if (!valid()) return const SponsorBlockCacheResult(.cancelled);
+        final entry = jsonDecode(
+          await File(path.join(key, 'entry.json')).readAsString(),
+        );
+        if (entry['bvid'] != target.bvid ||
+            (entry['source']?['cid'] ?? entry['page_data']?['cid']) !=
+                target.cid ||
+            entry['ep']?['episode_id'] != target.epid ||
+            entry['time_create_stamp'] != target.createdAt) {
+          return const SponsorBlockCacheResult(.cancelled);
+        }
+        final destination = path.join(key, _fileName(target));
+        final temporary = File('$destination.$serial.tmp');
+        try {
+          if (!valid()) return const SponsorBlockCacheResult(.cancelled);
+          await temporary.writeAsString(
+            jsonEncode(snapshot.toJson()),
+            flush: true,
+          );
+          if (!valid()) return const SponsorBlockCacheResult(.cancelled);
+          // 同步替换与代次检查之间没有异步间隔，删除也使用同一文件锁。
+          replaceFile(temporary, destination);
+          return SponsorBlockCacheResult(.ready, snapshot: snapshot);
+        } finally {
+          if (temporary.existsSync()) {
+            try {
+              await temporary.delete();
+            } catch (_) {}
+          }
+        }
+      });
+    }();
+    try {
+      return await Future.any([
+        operation,
+        token.whenCancel.then(
+          (_) => timedOut
+              ? const SponsorBlockCacheResult(.failed, code: -1)
+              : const SponsorBlockCacheResult(.cancelled),
+        ),
+      ]);
+    } on SponsorBlockFetchException catch (e) {
+      return SponsorBlockCacheResult(.failed, code: e.code);
+    } catch (_) {
+      return const SponsorBlockCacheResult(.failed);
+    } finally {
+      timer.cancel();
+      if (identical(_active[key], token)) _active.remove(key);
+    }
+  }
+}

--- a/lib/utils/path_utils.dart
+++ b/lib/utils/path_utils.dart
@@ -18,6 +18,8 @@ abstract final class PathUtils {
   static const videoNameType2 = 'video$_fileExt';
   static const coverName = 'cover.jpg';
   static const danmakuName = 'danmaku.pb';
+  static const sponsorBlockName = 'sponsor_block.json';
+  static const pgcSkipName = 'pgc_skip.json';
   static const downloadDir = 'download';
 
   static String buildShadersAbsolutePath(

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -182,6 +182,7 @@ abstract final class SettingBoxKey {
       webdavDirectory = 'webdavDirectory';
 
   static const String enableSponsorBlock = 'enableSponsorBlock',
+      cacheSponsorBlock = 'cacheSponsorBlock',
       blockSettings = 'blockSettings',
       blockLimit = 'blockLimit',
       blockColor = 'blockColor',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -782,6 +782,9 @@ abstract final class Pref {
   static bool get enableSponsorBlock =>
       _setting.get(SettingBoxKey.enableSponsorBlock, defaultValue: false);
 
+  static bool get cacheSponsorBlock =>
+      _setting.get(SettingBoxKey.cacheSponsorBlock, defaultValue: true);
+
   static bool get enableHA =>
       _setting.get(SettingBoxKey.enableHA, defaultValue: true);
 

--- a/test/services/download/sponsor_block_cache_test.dart
+++ b/test/services/download/sponsor_block_cache_test.dart
@@ -1,0 +1,67 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:PiliPlus/models_new/sponsor_block/segment_item.dart';
+import 'package:PiliPlus/models_new/sponsor_block/snapshot.dart';
+import 'package:PiliPlus/services/download/sponsor_block_cache.dart';
+import 'package:PiliPlus/utils/path_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as path;
+
+void main() {
+  test('番剧片段可以保存和读取，更新失败时保留已有信息', () async {
+    final directory = await Directory.systemTemp.createTemp('pgc-skip-test-');
+    addTearDown(() => directory.delete(recursive: true));
+    final target = SponsorBlockTarget(
+      directory: directory.path,
+      bvid: 'BV1test',
+      cid: 100,
+      durationMs: 120000,
+      createdAt: 1,
+      source: .pgc,
+      videoType: .pgc,
+      epid: 20,
+    );
+    await File(path.join(directory.path, 'entry.json')).writeAsString(
+      jsonEncode({
+        'bvid': target.bvid,
+        'source': {'cid': target.cid},
+        'ep': {'episode_id': target.epid},
+        'time_create_stamp': target.createdAt,
+      }),
+    );
+    var requests = 0;
+    var server = 'https://community.example';
+    final cache = SponsorBlockCache(
+      server: () => server,
+      fetch: (_, _, _) {
+        requests++;
+        throw const SponsorBlockFetchException('测试请求失败');
+      },
+    );
+    final saved = await cache.update(
+      target,
+      segments: [
+        SegmentItemModel.fromPgcJson({
+          'clipType': 'CLIP_TYPE_OP',
+          'start': 0,
+          'end': 30,
+        }, 120000),
+      ],
+    );
+    expect(saved.isUsable, isTrue);
+    expect(requests, 0);
+
+    server = 'https://another.example';
+    final snapshot = (await cache.read(target)).snapshot!;
+    expect(snapshot.source, SponsorBlockSource.pgc);
+    expect(snapshot.playableSegments(120000).single.segment, [0, 30000]);
+
+    final file = File(path.join(directory.path, PathUtils.pgcSkipName));
+    final original = await file.readAsString();
+    final failed = await cache.update(target, refresh: true);
+    expect(failed.status, SponsorBlockCacheStatus.failed);
+    expect(requests, 1);
+    expect(await file.readAsString(), original);
+  });
+}


### PR DESCRIPTION
关联 #2881。

下载视频时保存社区空降标记或番剧片头片尾信息，使离线播放也能按照现有设置执行自动或手动跳过。已有缓存支持手动补齐信息，重新打开视频后生效。

## 功能

- 新增“缓存视频时保存空降信息”开关，结合现有社区空降和番剧跳过设置保存对应信息。
- 普通投稿按分 P 保存社区标记；番剧复用播放接口返回的片头片尾信息，与社区标记分别保存。
- 本地播放复用现有跳过设置，支持进度条标记、自动跳过、手动跳过和详情查看。
- 缓存列表支持更新单条、整个分组或多选条目，也支持从搜索结果发起更新；设置页提供“补齐已有缓存的空降信息”入口。
- 更新面板提供“补齐缺失”和“重新获取”两种方式，显示处理结果，并支持取消。

## 行为与兼容

- 信息保存在各缓存条目目录中，校验来源、BVID、CID、格式版本和片段时间，避免混用不同分 P 或不同来源的标记。
- 获取信息的请求设有超时限制，失败时保留旧信息，媒体下载继续进行。空降文件缺失或损坏时，视频仍可正常播放。
- 切集、取消任务、删除缓存或修改相关配置时，使旧任务失效，防止延迟返回的结果覆盖当前数据或触发错误跳转。
- 下载或手动更新时查询社区标记；本地播放读取已保存的信息，并禁用社区观看上报、投票和提交操作。
- 更新信息后，当前播放会话继续使用已加载的数据，重新打开视频后应用更新。

## 验证情况

已构建 Android APK，并在真机上进行验证。

| 功能 | 结果 |
| --- | --- |
| 下载视频时保存对应分 P 的空降信息 | 正常 |
| 离线播放显示标记并执行自动、手动跳过 | 正常 |
| 离线播放跳过番剧片头片尾 | 正常 |
| 查看本地空降信息详情 | 正常 |
| 为已有缓存补齐空降信息 | 正常 |
| 单条、分组、多选及搜索结果更新 | 正常 |
| 重新获取信息，重新打开视频后生效 | 正常 |
| 切换分 P 后使用对应标记 | 正常 |
| 取消更新及更新失败时保留已有信息 | 正常 |
