### PR TITLE
 feat: 推荐流按视频tag屏蔽（推荐流/热门/排行榜/相关推荐）

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -28,7 +28,7 @@ android {
     }
 
     defaultConfig {
-        applicationId = "com.example.piliplus"
+        applicationId = "app.piliplus.tagfilter"
         minSdk = flutter.minSdkVersion
         targetSdk = 37
         versionCode = flutter.versionCode

--- a/lib/common/widgets/translate_text.dart
+++ b/lib/common/widgets/translate_text.dart
@@ -1,0 +1,39 @@
+import 'package:PiliPlus/utils/translate_service.dart';
+import 'package:flutter/material.dart';
+
+/// 标题翻译文本组件：
+/// 未启用翻译时直接显示原文；启用后先显示原文再异步替换为译文。
+class TranslateText extends StatelessWidget {
+  const TranslateText(
+    this.text, {
+    super.key,
+    this.maxLines,
+    this.overflow,
+    this.style,
+    this.textAlign,
+    this.enabled = true,
+  });
+
+  final String text;
+  final int? maxLines;
+  final TextOverflow? overflow;
+  final TextStyle? style;
+  final TextAlign? textAlign;
+
+  /// 是否启用翻译（用于按场景门控）
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<int>(
+      valueListenable: TranslateService.version,
+      builder: (context, _, _) => Text(
+        TranslateService.display(text, enabled: enabled),
+        maxLines: maxLines,
+        overflow: overflow,
+        style: style,
+        textAlign: textAlign,
+      ),
+    );
+  }
+}

--- a/lib/common/widgets/video_card/video_card_h.dart
+++ b/lib/common/widgets/video_card/video_card_h.dart
@@ -4,6 +4,7 @@ import 'package:PiliPlus/common/widgets/image/image_save.dart';
 import 'package:PiliPlus/common/widgets/image/network_img_layer.dart';
 import 'package:PiliPlus/common/widgets/progress_bar/video_progress_indicator.dart';
 import 'package:PiliPlus/common/widgets/stat/stat.dart';
+import 'package:PiliPlus/common/widgets/translate_text.dart';
 import 'package:PiliPlus/common/widgets/video_popup_menu.dart';
 import 'package:PiliPlus/http/search.dart';
 import 'package:PiliPlus/models/horizontal_video_model.dart';
@@ -12,6 +13,7 @@ import 'package:PiliPlus/utils/date_utils.dart';
 import 'package:PiliPlus/utils/duration_utils.dart';
 import 'package:PiliPlus/utils/page_utils.dart';
 import 'package:PiliPlus/utils/platform_utils.dart';
+import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:material_ui/material_ui.dart';
 
 // 视频卡片 - 水平布局
@@ -212,7 +214,7 @@ class VideoCardH extends StatelessWidget {
             )
           else
             Expanded(
-              child: Text(
+              child: TranslateText(
                 videoItem.title,
                 textAlign: .start,
                 style: TextStyle(
@@ -222,6 +224,7 @@ class VideoCardH extends StatelessWidget {
                 ),
                 maxLines: 2,
                 overflow: .ellipsis,
+                enabled: Pref.translateFeed,
               ),
             ),
           Text(

--- a/lib/common/widgets/video_card/video_card_v.dart
+++ b/lib/common/widgets/video_card/video_card_v.dart
@@ -3,6 +3,7 @@ import 'package:PiliPlus/common/widgets/badge.dart';
 import 'package:PiliPlus/common/widgets/image/image_save.dart';
 import 'package:PiliPlus/common/widgets/image/network_img_layer.dart';
 import 'package:PiliPlus/common/widgets/stat/stat.dart';
+import 'package:PiliPlus/common/widgets/translate_text.dart';
 import 'package:PiliPlus/common/widgets/video_popup_menu.dart';
 import 'package:PiliPlus/http/search.dart';
 import 'package:PiliPlus/models/home/rcmd/result.dart';
@@ -15,6 +16,7 @@ import 'package:PiliPlus/utils/extension/dimension_ext.dart';
 import 'package:PiliPlus/utils/id_utils.dart';
 import 'package:PiliPlus/utils/page_utils.dart';
 import 'package:PiliPlus/utils/platform_utils.dart';
+import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:intl/intl.dart';
 import 'package:material_ui/material_ui.dart';
@@ -158,11 +160,12 @@ class VideoCardV extends StatelessWidget {
           crossAxisAlignment: .start,
           children: [
             Expanded(
-              child: Text(
+              child: TranslateText(
                 videoItem.title,
                 maxLines: 2,
                 overflow: .ellipsis,
                 style: const TextStyle(height: 1.38),
+                enabled: Pref.translateFeed,
               ),
             ),
             videoStat(theme),

--- a/lib/http/video.dart
+++ b/lib/http/video.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math' show min;
 
 import 'package:PiliPlus/common/constants.dart';
 import 'package:PiliPlus/grpc/bilibili/main/community/reply/v1.pb.dart'
@@ -8,11 +9,13 @@ import 'package:PiliPlus/http/browser_ua.dart';
 import 'package:PiliPlus/http/init.dart';
 import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/http/login.dart';
+import 'package:PiliPlus/http/user.dart';
 import 'package:PiliPlus/models/common/account_type.dart';
 import 'package:PiliPlus/models/common/video/video_type.dart';
 import 'package:PiliPlus/models/home/rcmd/result.dart';
 import 'package:PiliPlus/models/model_hot_video_item.dart';
 import 'package:PiliPlus/models/model_rec_video_item.dart';
+import 'package:PiliPlus/models/model_video.dart';
 import 'package:PiliPlus/models/pgc_lcf.dart';
 import 'package:PiliPlus/models/video/play/url.dart';
 import 'package:PiliPlus/models_new/pgc/pgc_rank/pgc_rank_item_model.dart';
@@ -27,6 +30,7 @@ import 'package:PiliPlus/models_new/video/video_note_list/data.dart';
 import 'package:PiliPlus/models_new/video/video_play_info/data.dart';
 import 'package:PiliPlus/models_new/video/video_relation/data.dart';
 import 'package:PiliPlus/models_new/video/video_shot/data.dart';
+import 'package:PiliPlus/models_new/video/video_tag/data.dart';
 import 'package:PiliPlus/utils/accounts.dart';
 import 'package:PiliPlus/utils/app_sign.dart';
 import 'package:PiliPlus/utils/extension/string_ext.dart';
@@ -45,8 +49,53 @@ import 'package:protobuf/protobuf.dart';
 
 /// view层根据 status 判断渲染逻辑
 abstract final class VideoHttp {
-  static RegExp zoneRegExp = RegExp(Pref.banWordForZone, caseSensitive: false);
+  static RegExp zoneRegExp = RegExp(
+    Pref.banWordForZone.map(RegExp.escape).join('|'),
+    caseSensitive: false,
+  );
   static bool enableFilter = zoneRegExp.pattern.isNotEmpty;
+
+  /// 视频真实标签缓存（按 bvid）
+  static final Map<String, List<String>> _tagCache = {};
+
+  /// 查询视频真实标签
+  static Future<List<String>> getVideoTags(String bvid) async {
+    if (bvid.isEmpty) return const [];
+    final cached = _tagCache[bvid];
+    if (cached != null) return cached;
+    final res = await UserHttp.videoTags(bvid: bvid);
+    final tags = switch (res) {
+      Success(:final response) => (response ?? <VideoTagItem>[])
+          .map((e) => e.tagName ?? '')
+          .where((e) => e.isNotEmpty)
+          .toList(),
+      Error() => <String>[],
+      Loading() => <String>[],
+    };
+    _tagCache[bvid] = tags;
+    return tags;
+  }
+
+  /// 按视频真实标签过滤（开启标签过滤时，并发查询真实标签并移除命中项）
+  static Future<List<T>> filterByRealTags<T extends BaseVideoItemModel>(
+    List<T> list,
+  ) async {
+    if (!RecommendFilter.enableTagFilter || list.isEmpty) return list;
+    final result = <T>[];
+    const batch = 6;
+    for (var i = 0; i < list.length; i += batch) {
+      final chunk = list.sublist(i, min(i + batch, list.length));
+      final tags = await Future.wait(
+        chunk.map((e) => getVideoTags(e.bvid ?? '')),
+      );
+      for (var j = 0; j < chunk.length; j++) {
+        if (!RecommendFilter.filterTagList(tags[j])) {
+          result.add(chunk[j]);
+        }
+      }
+    }
+    return result;
+  }
 
   // 首页推荐视频
   static Future<LoadingState<List<RcmdVideoItemModel>>> rcmdVideoList({
@@ -78,7 +127,7 @@ abstract final class VideoHttp {
           }
         }
       }
-      return Success(list);
+      return Success(await filterByRealTags(list));
     } else {
       return Error(res.data['message']);
     }
@@ -157,7 +206,7 @@ abstract final class VideoHttp {
           }
         }
       }
-      return Success(list);
+      return Success(await filterByRealTags(list));
     } else {
       return Error(res.data['message']);
     }
@@ -328,6 +377,9 @@ abstract final class VideoHttp {
       final list = RecommendFilter.applyFilterToRelatedVideos
           ? items?.where((i) => !RecommendFilter.filterAll(i)).toList()
           : items?.toList();
+      if (list != null && RecommendFilter.applyFilterToRelatedVideos) {
+        return Success(await filterByRealTags(list));
+      }
       return Success(list);
     } else {
       return Error(res.data['message']);

--- a/lib/http/video.dart
+++ b/lib/http/video.dart
@@ -239,7 +239,7 @@ abstract final class VideoHttp {
           list.add(HotVideoItemModel.fromJson(i));
         }
       }
-      return Success(list);
+      return Success(await filterByRealTags(list));
     } else {
       return Error(res.data['message']);
     }
@@ -944,7 +944,7 @@ abstract final class VideoHttp {
           // }
         }
       }
-      return Success(list);
+      return Success(await filterByRealTags(list));
     } else {
       return Error(res.data['message']);
     }

--- a/lib/http/video.dart
+++ b/lib/http/video.dart
@@ -180,7 +180,8 @@ abstract final class VideoHttp {
             !RecommendFilter.filterLikeRatio(
               i['stat']['like'],
               i['stat']['view'],
-            )) {
+            ) &&
+            !RecommendFilter.filterTag(i['tag'])) {
           if (enableFilter &&
               i['tname'] != null &&
               zoneRegExp.hasMatch(i['tname'])) {
@@ -856,7 +857,8 @@ abstract final class VideoHttp {
         !RecommendFilter.filterLikeRatio(
           i['stat']['like'],
           i['stat']['view'],
-        )) {
+        ) &&
+        !RecommendFilter.filterTag(i['tag'])) {
       if (enableFilter &&
           i['tname'] != null &&
           zoneRegExp.hasMatch(i['tname'])) {

--- a/lib/models/common/setting_type.dart
+++ b/lib/models/common/setting_type.dart
@@ -4,11 +4,13 @@ import 'package:PiliPlus/pages/setting/models/play_settings.dart';
 import 'package:PiliPlus/pages/setting/models/privacy_settings.dart';
 import 'package:PiliPlus/pages/setting/models/recommend_settings.dart';
 import 'package:PiliPlus/pages/setting/models/style_settings.dart';
+import 'package:PiliPlus/pages/setting/models/translate_settings.dart';
 import 'package:PiliPlus/pages/setting/models/video_settings.dart';
 
 enum SettingType {
   privacySetting('隐私设置'),
   recommendSetting('推荐流设置'),
+  translateSetting('翻译设置'),
   videoSetting('音视频设置'),
   playSetting('播放器设置'),
   styleSetting('外观设置'),
@@ -23,6 +25,7 @@ enum SettingType {
   List<SettingsModel> get settings => switch (this) {
     .privacySetting => privacySettings,
     .recommendSetting => recommendSettings,
+    .translateSetting => translateSettings,
     .videoSetting => videoSettings,
     .playSetting => playSettings,
     .styleSetting => styleSettings,

--- a/lib/models/home/rcmd/result.dart
+++ b/lib/models/home/rcmd/result.dart
@@ -49,6 +49,8 @@ class RcmdVideoItemAppModel extends BaseRcmdVideoItemModel {
         ? ThreePoint.fromJson(json['three_point_v2'])
         : null;
     desc = json['desc'];
+    // App推荐 args.tname 即视频标签/频道名（如"恐怖"、"家常菜"）
+    tag = json['args']?['tname'];
   }
 }
 

--- a/lib/models/model_hot_video_item.dart
+++ b/lib/models/model_hot_video_item.dart
@@ -37,6 +37,8 @@ class HotVideoItemModel extends HorizontalVideoModel with MultiSelectData {
         : Dimension.fromJson(json['dimension']);
     firstFrame = json["first_frame"];
     pubLocation = json["pub_location"];
+    // 相关视频等接口早期版本返回逗号分隔的标签字符串，做防御性解析
+    tag = json["tag"];
     redirectUrl = json['redirect_url'];
     progress = json['progress'];
     if (json['charging_pay']?['level'] != null) {

--- a/lib/models/model_rec_video_item.dart
+++ b/lib/models/model_rec_video_item.dart
@@ -25,6 +25,8 @@ class RcmdVideoItemModel extends BaseRcmdVideoItemModel {
     owner = Owner.fromJson(json["owner"]);
     stat = Stat.fromJson(json["stat"]);
     isFollowed = json["is_followed"] == 1;
+    // 网页推荐接口早期版本返回逗号分隔的标签字符串，做防御性解析
+    tag = json["tag"];
     // rcmdReason = json["rcmd_reason"] != null
     //     ? RcmdReason.fromJson(json["rcmd_reason"])
     //     : RcmdReason(content: '');

--- a/lib/models/model_video.dart
+++ b/lib/models/model_video.dart
@@ -13,6 +13,10 @@ abstract class BaseVideoItemModel extends BaseSimpleVideoItemModel {
   String? desc;
   int? pubdate;
   bool isFollowed = false;
+
+  /// 视频标签，不同来源含义略有差异：
+  /// App推荐为频道/标签名（args.tname），网页推荐/相关视频为逗号分隔的标签字符串
+  String? tag;
 }
 
 abstract class BaseOwner {

--- a/lib/pages/about/view.dart
+++ b/lib/pages/about/view.dart
@@ -23,6 +23,7 @@ import 'package:PiliPlus/utils/extension/num_ext.dart';
 import 'package:PiliPlus/utils/login_utils.dart';
 import 'package:PiliPlus/utils/page_utils.dart';
 import 'package:PiliPlus/utils/platform_utils.dart';
+import 'package:restart_app/restart_app.dart';
 import 'package:PiliPlus/utils/storage.dart';
 import 'package:PiliPlus/utils/update.dart';
 import 'package:PiliPlus/utils/utils.dart';
@@ -266,6 +267,34 @@ Commit Hash: ${BuildConfig.commitHash}''',
               localFileName: () => 'setting_${DeviceUtils.platformName}',
               onExport: GStorage.exportAllSettings,
               onImport: GStorage.importAllJsonSettings,
+            ),
+          ),
+          ListTile(
+            title: const Text('重启应用'),
+            dense: false,
+            subtitle: const Text('部分设置在导入备份后需重启应用才能生效'),
+            leading: const Icon(Icons.restart_alt_outlined),
+            onTap: () => showDialog(
+              context: context,
+              builder: (context) {
+                return AlertDialog(
+                  title: const Text('重启应用'),
+                  content: const Text('是否立即重启应用？重启后部分未生效的设置将会生效。'),
+                  actions: [
+                    TextButton(
+                      onPressed: Get.back,
+                      child: Text(
+                        '取消',
+                        style: TextStyle(color: ColorScheme.of(context).outline),
+                      ),
+                    ),
+                    const TextButton(
+                      onPressed: Restart.restartApp,
+                      child: Text('重启'),
+                    ),
+                  ],
+                );
+              },
             ),
           ),
           ListTile(

--- a/lib/pages/setting/models/model.dart
+++ b/lib/pages/setting/models/model.dart
@@ -266,6 +266,123 @@ SettingsModel getBanWordModel({
   );
 }
 
+SettingsModel getBanWordListModel({
+  required String title,
+  required String key,
+  required ValueChanged<List<String>> onChanged,
+  String? subtitle,
+}) {
+  List<String> banWords = _readBanWordList(key);
+  return NormalModel(
+    leading: const Icon(Icons.filter_alt_outlined),
+    title: title,
+    subtitle: subtitle,
+    getSubtitle: () => banWords.isEmpty
+        ? '点击添加'
+        : '已屏蔽 ${banWords.length} 个：${banWords.join('、')}',
+    onTap: (context, setState) {
+      final TextEditingController controller = TextEditingController();
+      void save() {
+        GStorage.setting.put(key, banWords);
+        onChanged(List<String>.from(banWords));
+      }
+
+      showDialog(
+        context: context,
+        builder: (context) => AlertDialog(
+          constraints: Style.dialogFixedConstraints,
+          title: Text(title),
+          content: StatefulBuilder(
+            builder: (context, setDialogState) {
+              void add() {
+                final word = controller.text.trim();
+                if (word.isEmpty) return;
+                if (!banWords.contains(word)) {
+                  banWords.add(word);
+                  save();
+                }
+                controller.clear();
+                setDialogState(() {});
+              }
+
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: TextFormField(
+                          controller: controller,
+                          autofocus: true,
+                          textInputAction: TextInputAction.done,
+                          onFieldSubmitted: (_) => add(),
+                          decoration: const InputDecoration(
+                            hintText: '输入单个关键词，点击添加',
+                          ),
+                        ),
+                      ),
+                      TextButton(
+                        onPressed: add,
+                        child: const Text('添加'),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  if (banWords.isNotEmpty)
+                    Flexible(
+                      child: SingleChildScrollView(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            for (final word in banWords)
+                              ListTile(
+                                dense: true,
+                                contentPadding: EdgeInsets.zero,
+                                title: Text(word),
+                                trailing: IconButton(
+                                  icon: const Icon(Icons.close),
+                                  tooltip: '移除',
+                                  onPressed: () {
+                                    banWords.remove(word);
+                                    save();
+                                    setDialogState(() {});
+                                  },
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
+                    )
+                  else
+                    const Text('暂无屏蔽词', style: TextStyle(fontSize: 13)),
+                ],
+              );
+            },
+          ),
+          actions: [
+            TextButton(
+              onPressed: Get.back,
+              child: Text(
+                '取消',
+                style: TextStyle(color: ColorScheme.of(context).outline),
+              ),
+            ),
+            TextButton(
+              child: const Text('完成'),
+              onPressed: () {
+                Get.back();
+                setState();
+                SmartDialog.showToast('已保存');
+              },
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}
+
 SettingsModel getVideoFilterSelectModel({
   required String title,
   String? subtitle,
@@ -348,4 +465,13 @@ SettingsModel getVideoFilterSelectModel({
       }
     },
   );
+}
+
+/// 读取屏蔽词列表，兼容旧版使用`|`分隔的字符串存储
+List<String> _readBanWordList(String key) {
+  final value = GStorage.setting.get(key, defaultValue: <String>[]);
+  if (value is String) {
+    return value.isEmpty ? <String>[] : value.split('|');
+  }
+  return List<String>.from(value);
 }

--- a/lib/pages/setting/models/model.dart
+++ b/lib/pages/setting/models/model.dart
@@ -210,11 +210,13 @@ SettingsModel getBanWordModel({
   required String title,
   required String key,
   required ValueChanged<RegExp> onChanged,
+  String? subtitle,
 }) {
   String banWord = GStorage.setting.get(key, defaultValue: '');
   return NormalModel(
     leading: const Icon(Icons.filter_alt_outlined),
     title: title,
+    subtitle: subtitle,
     getSubtitle: () => banWord.isEmpty ? "点击添加" : banWord,
     onTap: (context, setState) {
       String editValue = banWord;

--- a/lib/pages/setting/models/recommend_settings.dart
+++ b/lib/pages/setting/models/recommend_settings.dart
@@ -66,7 +66,6 @@ List<SettingsModel> get recommendSettings => [
   ),
   getBanWordListModel(
     title: '视频标签过滤',
-    subtitle: '按视频真实标签屏蔽，如：三角洲行动',
     key: SettingBoxKey.banTagForRecommend,
     onChanged: (List<String> words) {
       final pattern = words.map(RegExp.escape).join('|');

--- a/lib/pages/setting/models/recommend_settings.dart
+++ b/lib/pages/setting/models/recommend_settings.dart
@@ -64,6 +64,15 @@ List<SettingsModel> get recommendSettings => [
     },
   ),
   getBanWordModel(
+    title: '视频标签过滤',
+    subtitle: '按标签屏蔽视频，如：游戏|综艺（App推荐为频道/标签名）',
+    key: SettingBoxKey.banTagForRecommend,
+    onChanged: (value) {
+      RecommendFilter.tagRegExp = value;
+      RecommendFilter.enableTagFilter = value.pattern.isNotEmpty;
+    },
+  ),
+  getBanWordModel(
     title: 'App推荐/热门/排行榜: 视频分区关键词过滤',
     key: SettingBoxKey.banWordForZone,
     onChanged: (value) {

--- a/lib/pages/setting/models/recommend_settings.dart
+++ b/lib/pages/setting/models/recommend_settings.dart
@@ -55,29 +55,32 @@ List<SettingsModel> get recommendSettings => [
     values: [0, 1, 2, 3, 4],
     onChanged: (value) => RecommendFilter.minLikeRatioForRecommend = value,
   ),
-  getBanWordModel(
+  getBanWordListModel(
     title: '标题关键词过滤',
     key: SettingBoxKey.banWordForRecommend,
-    onChanged: (value) {
-      RecommendFilter.rcmdRegExp = value;
-      RecommendFilter.enableFilter = value.pattern.isNotEmpty;
+    onChanged: (List<String> words) {
+      final pattern = words.map(RegExp.escape).join('|');
+      RecommendFilter.rcmdRegExp = RegExp(pattern, caseSensitive: false);
+      RecommendFilter.enableFilter = words.isNotEmpty;
     },
   ),
-  getBanWordModel(
+  getBanWordListModel(
     title: '视频标签过滤',
-    subtitle: '按标签屏蔽视频，如：游戏|综艺（App推荐为频道/标签名）',
+    subtitle: '按视频真实标签屏蔽，如：三角洲行动',
     key: SettingBoxKey.banTagForRecommend,
-    onChanged: (value) {
-      RecommendFilter.tagRegExp = value;
-      RecommendFilter.enableTagFilter = value.pattern.isNotEmpty;
+    onChanged: (List<String> words) {
+      final pattern = words.map(RegExp.escape).join('|');
+      RecommendFilter.tagRegExp = RegExp(pattern, caseSensitive: false);
+      RecommendFilter.enableTagFilter = words.isNotEmpty;
     },
   ),
-  getBanWordModel(
+  getBanWordListModel(
     title: 'App推荐/热门/排行榜: 视频分区关键词过滤',
     key: SettingBoxKey.banWordForZone,
-    onChanged: (value) {
-      VideoHttp.zoneRegExp = value;
-      VideoHttp.enableFilter = value.pattern.isNotEmpty;
+    onChanged: (List<String> words) {
+      final pattern = words.map(RegExp.escape).join('|');
+      VideoHttp.zoneRegExp = RegExp(pattern, caseSensitive: false);
+      VideoHttp.enableFilter = words.isNotEmpty;
     },
   ),
   getVideoFilterSelectModel(

--- a/lib/pages/setting/models/translate_settings.dart
+++ b/lib/pages/setting/models/translate_settings.dart
@@ -1,0 +1,314 @@
+import 'package:PiliPlus/common/style.dart';
+import 'package:PiliPlus/common/widgets/dialog/simple_dialog_option.dart';
+import 'package:PiliPlus/pages/setting/models/model.dart';
+import 'package:PiliPlus/utils/storage.dart';
+import 'package:PiliPlus/utils/storage_key.dart';
+import 'package:PiliPlus/utils/translate_service.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
+import 'package:get/get.dart';
+
+List<SettingsModel> get translateSettings => [
+  const SwitchModel(
+    title: '启用翻译',
+    subtitle: '总开关，关闭后所有翻译都不生效',
+    leading: Icon(Icons.translate),
+    setKey: SettingBoxKey.translateEnable,
+    defaultVal: false,
+  ),
+  const SwitchModel(
+    title: '推荐流标题翻译',
+    subtitle: '推荐流/热门/排行榜/相关推荐的标题自动翻译',
+    leading: Icon(Icons.explore_outlined),
+    setKey: SettingBoxKey.translateFeed,
+    defaultVal: true,
+  ),
+  getDetailTitleModeModel(),
+  const SwitchModel(
+    title: '标签翻译',
+    subtitle: '详情页视频标签自动翻译',
+    leading: Icon(Icons.sell_outlined),
+    setKey: SettingBoxKey.translateTag,
+    defaultVal: true,
+  ),
+  getTranslateSkipLangsModel(),
+  getTranslateProviderModel(),
+  getTranslateTextInputModel(
+    title: 'API 地址',
+    key: SettingBoxKey.translateApiBase,
+    hint: 'OpenAI 兼容示例：https://api.deepseek.com/v1',
+  ),
+  getTranslateTextInputModel(
+    title: 'API Key',
+    key: SettingBoxKey.translateApiKey,
+    hint: '粘贴你的 API Key',
+    obscureText: true,
+  ),
+  getTranslateTextInputModel(
+    title: '模型名',
+    key: SettingBoxKey.translateModel,
+    hint: '仅 OpenAI 兼容接口，如 deepseek-chat',
+  ),
+  getTranslateTextInputModel(
+    title: '目标语言',
+    key: SettingBoxKey.translateTargetLang,
+    hint: '仅 DeepL，如 zh、zh-Hans、ja 等',
+  ),
+  getTranslateTextInputModel(
+    title: '自定义提示词',
+    key: SettingBoxKey.translateSystemPrompt,
+    hint: '仅 AI 翻译（OpenAI 兼容）可自定义，留空则使用默认提示词',
+    multiline: true,
+  ),
+  getTranslateTestModel(),
+];
+
+/// 详情页标题翻译方式：不翻译 / 自动 / 手动
+SettingsModel getDetailTitleModeModel() {
+  final mode = GStorage.setting
+      .get(SettingBoxKey.translateDetailTitleMode, defaultValue: 'auto');
+  const labels = {'none': '不翻译', 'auto': '自动翻译', 'manual': '手动翻译'};
+  return NormalModel(
+    leading: const Icon(Icons.title_outlined),
+    title: '详情页标题翻译方式',
+    getSubtitle: () => labels[mode] ?? '自动翻译',
+    onTap: (context, setState) {
+      showDialog(
+        context: context,
+        builder: (context) {
+          return SimpleDialog(
+            title: const Text('详情页标题翻译方式'),
+            children: [
+              for (final e in labels.entries)
+                DialogOption(
+                  onPressed: () {
+                    GStorage.setting.put(
+                      SettingBoxKey.translateDetailTitleMode,
+                      e.key,
+                    );
+                    SmartDialog.showToast('已设为：${e.value}');
+                    Get.back();
+                    setState();
+                  },
+                  child: Text(
+                    e.value,
+                    style: TextStyle(
+                      color:
+                          mode == e.key ? ColorScheme.of(context).primary : null,
+                    ),
+                  ),
+                ),
+            ],
+          );
+        },
+      );
+    },
+  );
+}
+
+/// 不用翻译的语言（跳过集，多选）
+SettingsModel getTranslateSkipLangsModel() {
+  final values = GStorage.setting.get(
+    SettingBoxKey.translateSkipLangs,
+    defaultValue: ['zh'],
+  ) as List;
+  final selected = values.cast<String>().toSet();
+  const options = {
+    'zh': '简体 / 繁体中文',
+    'ja': '日本語',
+    'ko': '한국어',
+  };
+  return NormalModel(
+    leading: const Icon(Icons.language_outlined),
+    title: '不用翻译的语言',
+    getSubtitle: () {
+      if (selected.isEmpty) return '全部翻译';
+      return selected.map((k) => options[k] ?? k).join('、');
+    },
+    onTap: (context, setState) {
+      showDialog(
+        context: context,
+        builder: (context) {
+          return StatefulBuilder(
+            builder: (context, setDialogState) => AlertDialog(
+              title: const Text('这些语言不翻译'),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  for (final e in options.entries)
+                    CheckboxListTile(
+                      dense: true,
+                      title: Text(e.value),
+                      value: selected.contains(e.key),
+                      onChanged: (checked) {
+                        setDialogState(() {
+                          if (checked == true) {
+                            selected.add(e.key);
+                          } else {
+                            selected.remove(e.key);
+                          }
+                        });
+                      },
+                    ),
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: Get.back,
+                  child: Text(
+                    '取消',
+                    style: TextStyle(color: ColorScheme.of(context).outline),
+                  ),
+                ),
+                TextButton(
+                  child: const Text('保存'),
+                  onPressed: () {
+                    Get.back();
+                    GStorage.setting.put(
+                      SettingBoxKey.translateSkipLangs,
+                      selected.toList(),
+                    );
+                    SmartDialog.showToast('已保存');
+                    setState();
+                  },
+                ),
+              ],
+            ),
+          );
+        },
+      );
+    },
+  );
+}
+
+/// 翻译服务选择
+SettingsModel getTranslateProviderModel() {
+  var current = GStorage.setting
+      .get(SettingBoxKey.translateProvider, defaultValue: 'openai');
+  return NormalModel(
+    leading: const Icon(Icons.cloud_outlined),
+    title: '翻译服务',
+    getSubtitle: () =>
+        current == 'deepl' ? 'DeepL' : 'OpenAI 兼容（DeepSeek 等）',
+    onTap: (context, setState) {
+      showDialog(
+        context: context,
+        builder: (context) {
+          return SimpleDialog(
+            title: const Text('选择翻译服务'),
+            children: [
+              DialogOption(
+                onPressed: () {
+                  current = 'openai';
+                  GStorage.setting.put(SettingBoxKey.translateProvider, current);
+                  SmartDialog.showToast('已选择 OpenAI 兼容接口');
+                  Get.back();
+                  setState();
+                },
+                child: const Text('OpenAI 兼容（DeepSeek / OpenAI / Moonshot 等）'),
+              ),
+              DialogOption(
+                onPressed: () {
+                  current = 'deepl';
+                  GStorage.setting.put(SettingBoxKey.translateProvider, current);
+                  SmartDialog.showToast('已选择 DeepL');
+                  Get.back();
+                  setState();
+                },
+                child: const Text('DeepL'),
+              ),
+            ],
+          );
+        },
+      );
+    },
+  );
+}
+
+/// 文本输入设置项（弹窗输入，保存到 key）
+SettingsModel getTranslateTextInputModel({
+  required String title,
+  required String key,
+  String? hint,
+  bool obscureText = false,
+  bool multiline = false,
+}) {
+  String value = GStorage.setting.get(key, defaultValue: '');
+  return NormalModel(
+    leading: const Icon(Icons.edit_outlined),
+    title: title,
+    getSubtitle: () => value.isEmpty ? '点击设置' : value,
+    onTap: (context, setState) {
+      String editValue = value;
+      showDialog(
+        context: context,
+        builder: (context) => AlertDialog(
+          constraints: Style.dialogFixedConstraints,
+          title: Text(title),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (hint case final h?) Text(h, style: const TextStyle(fontSize: 12)),
+              TextFormField(
+                autofocus: !obscureText,
+                obscureText: obscureText,
+                initialValue: editValue,
+                minLines: 1,
+                maxLines: multiline ? 4 : 2,
+                onChanged: (v) => editValue = v,
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: Get.back,
+              child: Text(
+                '取消',
+                style: TextStyle(color: ColorScheme.of(context).outline),
+              ),
+            ),
+            TextButton(
+              child: const Text('保存'),
+              onPressed: () {
+                Get.back();
+                value = editValue.trim();
+                setState();
+                GStorage.setting.put(key, value);
+                SmartDialog.showToast('已保存');
+              },
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}
+
+/// 测试翻译
+SettingsModel getTranslateTestModel() {
+  return NormalModel(
+    leading: const Icon(Icons.science_outlined),
+    title: '测试翻译',
+    subtitle: '用一段示例文本测试当前配置是否可用',
+    onTap: (context, setState) async {
+      if (!TranslateService.configured()) {
+        SmartDialog.showToast('请先填写并保存 API 地址与 Key');
+        return;
+      }
+      SmartDialog.showLoading(msg: '翻译中...');
+      try {
+        final result = await TranslateService.testConfigured();
+        SmartDialog.dismiss();
+        if (result.isEmpty) {
+          SmartDialog.showToast('翻译失败，请检查配置');
+        } else {
+          SmartDialog.showToast('测试成功：$result');
+        }
+      } catch (e) {
+        SmartDialog.dismiss();
+        SmartDialog.showToast('翻译失败：$e');
+      }
+    },
+  );
+}

--- a/lib/pages/setting/view.dart
+++ b/lib/pages/setting/view.dart
@@ -54,6 +54,11 @@ class _SettingPageState extends State<SettingPage> {
       icon: Icon(Icons.explore_outlined),
     ),
     _SettingsModel(
+      type: SettingType.translateSetting,
+      subtitle: '将国外视频的英文标题/标签翻译为中文',
+      icon: Icon(Icons.translate),
+    ),
+    _SettingsModel(
       type: SettingType.videoSetting,
       subtitle: '画质、音质、解码、缓冲、音频输出等',
       icon: Icon(Icons.video_settings_outlined),
@@ -123,6 +128,10 @@ class _SettingPageState extends State<SettingPage> {
                         settingType: _type,
                         showAppBar: false,
                       ),
+                      .translateSetting => CommonSetting(
+                        settingType: _type,
+                        showAppBar: false,
+                      ),
                       .webdavSetting => const WebDavSettingPage(
                         showAppBar: false,
                       ),
@@ -151,6 +160,7 @@ class _SettingPageState extends State<SettingPage> {
           .playSetting ||
           .styleSetting ||
           .extraSetting => CommonSetting(settingType: type),
+          .translateSetting => CommonSetting(settingType: type),
           .webdavSetting => const WebDavSettingPage(),
           .about => const AboutPage(),
         },

--- a/lib/pages/settings_search/view.dart
+++ b/lib/pages/settings_search/view.dart
@@ -9,6 +9,7 @@ import 'package:PiliPlus/pages/setting/models/play_settings.dart';
 import 'package:PiliPlus/pages/setting/models/privacy_settings.dart';
 import 'package:PiliPlus/pages/setting/models/recommend_settings.dart';
 import 'package:PiliPlus/pages/setting/models/style_settings.dart';
+import 'package:PiliPlus/pages/setting/models/translate_settings.dart';
 import 'package:PiliPlus/pages/setting/models/video_settings.dart';
 import 'package:PiliPlus/utils/grid.dart';
 import 'package:PiliPlus/utils/waterfall.dart';
@@ -32,6 +33,7 @@ class _SettingsSearchPageState
     ...extraSettings,
     ...privacySettings,
     ...recommendSettings,
+    ...translateSettings,
     ...videoSettings,
     ...playSettings,
     ...styleSettings,

--- a/lib/pages/video/introduction/ugc/view.dart
+++ b/lib/pages/video/introduction/ugc/view.dart
@@ -2,6 +2,7 @@ import 'package:PiliPlus/common/assets.dart';
 import 'package:PiliPlus/common/constants.dart';
 import 'package:PiliPlus/common/style.dart';
 import 'package:PiliPlus/common/widgets/animated_height.dart';
+import 'package:PiliPlus/common/widgets/dialog/simple_dialog_option.dart';
 import 'package:PiliPlus/common/widgets/dialog/dialog.dart';
 import 'package:PiliPlus/common/widgets/expandable.dart';
 import 'package:PiliPlus/common/widgets/gesture/tap_gesture_recognizer.dart';
@@ -40,6 +41,8 @@ import 'package:PiliPlus/utils/num_utils.dart';
 import 'package:PiliPlus/utils/page_utils.dart';
 import 'package:PiliPlus/utils/platform_utils.dart';
 import 'package:PiliPlus/utils/request_utils.dart';
+import 'package:PiliPlus/utils/storage_pref.dart';
+import 'package:PiliPlus/utils/translate_service.dart';
 import 'package:PiliPlus/utils/utils.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
@@ -268,10 +271,160 @@ class _UgcIntroPanelState extends State<UgcIntroPanel> {
     return GestureDetector(
       onLongPress: () {
         Feedback.forLongPress(context);
-        Utils.copyText(videoDetail.title ?? '');
+        _showTitleMenu(videoDetail.title ?? '');
       },
       child: _buildVideoTitle(videoDetail, isExpand: isExpand),
     );
+  }
+
+  /// 长按标题弹出的操作菜单
+  void _showTitleMenu(String title) {
+    // 只要翻译已配置即可手动翻译。
+    // 手动模式下固定出现；自动模式下命中了「不用翻译的语言」而被跳过的文本
+    // 也可通过长按手动翻译。
+    final manual = TranslateService.configured();
+    // 自动模式下若标题已被自动翻译，则额外提供「显示原文」。
+    final autoTranslated = Pref.translateDetailTitleMode == 'auto' &&
+        TranslateService.translatedIfAny(title) != null;
+    showDialog(
+      context: context,
+      builder: (context) => SimpleDialog(
+        title: const Text('标题操作'),
+        children: [
+          DialogOption(
+            onPressed: () {
+              Get.back();
+              Utils.copyText(title);
+              SmartDialog.showToast('已复制标题');
+            },
+            child: const Text('全部复制'),
+          ),
+          DialogOption(
+            onPressed: () {
+              Get.back();
+              _showSelectTitle(title);
+            },
+            child: const Text('自由复制'),
+          ),
+          if (autoTranslated)
+            DialogOption(
+              onPressed: () {
+                Get.back();
+                _showOriginalTitle(title);
+              },
+              child: const Text('显示原文'),
+            ),
+          if (manual)
+            DialogOption(
+              onPressed: () {
+                Get.back();
+                _manualTranslate(title);
+              },
+              child: const Text('翻译'),
+            ),
+        ],
+      ),
+    );
+  }
+
+  /// 显示原文（自动翻译模式下查看未翻译的原始标题，可框选复制）
+  void _showOriginalTitle(String title) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('标题原文'),
+        content: SingleChildScrollView(
+          child: SelectionArea(
+            child: Text(
+              title,
+              style: const TextStyle(fontSize: 16, height: 1.4),
+            ),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: Get.back,
+            child: Text(
+              '关闭',
+              style: TextStyle(color: ColorScheme.of(context).outline),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 自由复制：弹出标题，手动框选
+  void _showSelectTitle(String title) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('框选复制'),
+        content: SingleChildScrollView(
+          child: SelectionArea(
+            child: Text(
+              title,
+              style: const TextStyle(fontSize: 16, height: 1.4),
+            ),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: Get.back,
+            child: Text(
+              '关闭',
+              style: TextStyle(color: ColorScheme.of(context).outline),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 手动翻译：调用接口并把结果以可复制文本显示
+  Future<void> _manualTranslate(String title) async {
+    SmartDialog.showLoading(msg: '翻译中...');
+    try {
+      final translated = await TranslateService.translateOne(title);
+      SmartDialog.dismiss();
+      if (!mounted) return;
+      if (translated.isEmpty) {
+        SmartDialog.showToast('翻译失败，请检查配置');
+        return;
+      }
+      showDialog(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('翻译结果'),
+          content: SingleChildScrollView(
+            child: Text(
+              translated,
+              style: const TextStyle(fontSize: 16, height: 1.4),
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Utils.copyText(translated);
+                Get.back();
+                SmartDialog.showToast('已复制译文');
+              },
+              child: const Text('复制'),
+            ),
+            TextButton(
+              onPressed: Get.back,
+              child: Text(
+                '关闭',
+                style: TextStyle(color: ColorScheme.of(context).outline),
+              ),
+            ),
+          ],
+        ),
+      );
+    } catch (e) {
+      SmartDialog.dismiss();
+      SmartDialog.showToast('翻译失败：$e');
+    }
   }
 
   List<Widget> _infos(VideoDetailData videoDetail) => [
@@ -336,6 +489,10 @@ class _UgcIntroPanelState extends State<UgcIntroPanel> {
   }) {
     Widget child() {
       final videoLabel = videoDetailCtr.videoLabel.value;
+      final title = videoDetail.title ?? '';
+      final displayedTitle = Pref.translateDetailTitleMode == 'auto'
+          ? TranslateService.display(title)
+          : title;
       final textSpan = TextSpan(
         children: [
           if (videoLabel.isNotEmpty) ...[
@@ -405,7 +562,7 @@ class _UgcIntroPanelState extends State<UgcIntroPanel> {
             ),
             const TextSpan(text: ' '),
           ],
-          TextSpan(text: videoDetail.title),
+          TextSpan(text: displayedTitle),
         ],
       );
       if (isSelectable) {
@@ -422,10 +579,15 @@ class _UgcIntroPanelState extends State<UgcIntroPanel> {
       );
     }
 
+    final content = ValueListenableBuilder<int>(
+      valueListenable: TranslateService.version,
+      builder: (context, _, _) => child(),
+    );
+
     if (videoDetailCtr.plPlayerController.enableSponsorBlock) {
-      return Obx(child);
+      return Obx(() => content);
     }
-    return child();
+    return content;
   }
 
   Widget followButton(BuildContext context) {
@@ -1009,33 +1171,44 @@ class _UgcIntroPanelState extends State<UgcIntroPanel> {
       child: Wrap(
         spacing: 8,
         runSpacing: 8,
-        children: tags
-            .map(
-              (item) => SearchText(
+        children: [
+          for (final item in tags)
+            switch (item.tagType) {
+              'bgm' => SearchText(
                 fontSize: 13,
-                text: switch (item.tagType) {
-                  'bgm' => item.tagName!.replaceFirst('发现', '♫ BGM：'),
-                  'topic' => '#${item.tagName}',
-                  _ => item.tagName!,
-                },
-                onTap: switch (item.tagType) {
-                  'bgm' => (_) => Get.toNamed(
-                    '/musicDetail',
-                    parameters: {'musicId': item.musicId!},
+                text: item.tagName!.replaceFirst('发现', '♫ BGM：'),
+                onTap: (_) => Get.toNamed(
+                  '/musicDetail',
+                  parameters: {'musicId': item.musicId!},
+                ),
+                onLongPress: Utils.copyText,
+              ),
+              'topic' => SearchText(
+                fontSize: 13,
+                text: '#${item.tagName}',
+                onTap: (_) => Get.toNamed(
+                  '/dynTopic',
+                  parameters: {'id': item.tagId!.toString()},
+                ),
+                onLongPress: Utils.copyText,
+              ),
+              _ => ValueListenableBuilder<int>(
+                valueListenable: TranslateService.version,
+                builder: (context, _, _) => SearchText(
+                  fontSize: 13,
+                  text: TranslateService.display(
+                    item.tagName ?? '',
+                    enabled: Pref.translateTag,
                   ),
-                  'topic' => (_) => Get.toNamed(
-                    '/dynTopic',
-                    parameters: {'id': item.tagId!.toString()},
-                  ),
-                  _ => (tagName) => Get.toNamed(
+                  onTap: (tagName) => Get.toNamed(
                     '/searchResult',
                     parameters: {'keyword': tagName},
                   ),
-                },
-                onLongPress: Utils.copyText,
+                  onLongPress: Utils.copyText,
+                ),
               ),
-            )
-            .toList(),
+            },
+        ],
       ),
     );
   }

--- a/lib/utils/recommend_filter.dart
+++ b/lib/utils/recommend_filter.dart
@@ -7,16 +7,18 @@ abstract final class RecommendFilter {
   static int minLikeRatioForRecommend = Pref.minLikeRatioForRecommend;
   static bool exemptFilterForFollowed = Pref.exemptFilterForFollowed;
   static bool applyFilterToRelatedVideos = Pref.applyFilterToRelatedVideos;
+  static final List<String> rcmdBanWords = Pref.banWordForRecommend;
   static RegExp rcmdRegExp = RegExp(
-    Pref.banWordForRecommend,
+    rcmdBanWords.map(RegExp.escape).join('|'),
     caseSensitive: false,
   );
-  static bool enableFilter = rcmdRegExp.pattern.isNotEmpty;
+  static bool enableFilter = rcmdBanWords.isNotEmpty;
+  static final List<String> tagBanWords = Pref.banTagForRecommend;
   static RegExp tagRegExp = RegExp(
-    Pref.banTagForRecommend,
+    tagBanWords.map(RegExp.escape).join('|'),
     caseSensitive: false,
   );
-  static bool enableTagFilter = tagRegExp.pattern.isNotEmpty;
+  static bool enableTagFilter = tagBanWords.isNotEmpty;
 
   static bool filter(BaseVideoItemModel videoItem) {
     //由于相关视频中没有已关注标签，只能视为非关注视频
@@ -42,6 +44,11 @@ abstract final class RecommendFilter {
 
   static bool filterTag(String? tag) {
     return enableTagFilter && tag != null && tagRegExp.hasMatch(tag);
+  }
+
+  static bool filterTagList(List<String> tags) {
+    if (!enableTagFilter) return false;
+    return tags.any(tagRegExp.hasMatch);
   }
 
   static bool filterAll(BaseVideoItemModel videoItem) {

--- a/lib/utils/recommend_filter.dart
+++ b/lib/utils/recommend_filter.dart
@@ -12,6 +12,11 @@ abstract final class RecommendFilter {
     caseSensitive: false,
   );
   static bool enableFilter = rcmdRegExp.pattern.isNotEmpty;
+  static RegExp tagRegExp = RegExp(
+    Pref.banTagForRecommend,
+    caseSensitive: false,
+  );
+  static bool enableTagFilter = tagRegExp.pattern.isNotEmpty;
 
   static bool filter(BaseVideoItemModel videoItem) {
     //由于相关视频中没有已关注标签，只能视为非关注视频
@@ -35,10 +40,15 @@ abstract final class RecommendFilter {
     return (enableFilter && rcmdRegExp.hasMatch(title));
   }
 
+  static bool filterTag(String? tag) {
+    return enableTagFilter && tag != null && tagRegExp.hasMatch(tag);
+  }
+
   static bool filterAll(BaseVideoItemModel videoItem) {
     return (videoItem.duration > 0 &&
             videoItem.duration < minDurationForRcmd) ||
         filterLikeRatio(videoItem.stat.like, videoItem.stat.view) ||
-        filterTitle(videoItem.title);
+        filterTitle(videoItem.title) ||
+        filterTag(videoItem.tag);
   }
 }

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -54,6 +54,7 @@ abstract final class SettingBoxKey {
       minLikeRatioForRecommend = 'minLikeRatioForRecommend',
       exemptFilterForFollowed = 'exemptFilterForFollowed',
       banWordForRecommend = 'banWordForRecommend',
+      banTagForRecommend = 'banTagForRecommend',
       applyFilterToRelatedVideos = 'applyFilterToRelatedVideos',
       autoUpdate = 'autoUpdate',
       maxCacheSize = 'maxCacheSize',

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -153,11 +153,24 @@ abstract final class SettingBoxKey {
       showDynDispute = 'showDynDispute',
       touchSlopH = 'touchSlopH',
       floatingNavBar = 'floatingNavBar',
+      showDynamicHint = 'showDynamicHint',
       removeSafeArea = 'removeSafeArea',
       angleDegrees = 'angleDegrees',
       liveStream = 'liveStream',
       enableDocProvider = 'enableDocProvider',
       enableEmoteTooltip = 'enableEmoteTooltip';
+
+  static const String translateEnable = 'translateEnable',
+      translateProvider = 'translateProvider',
+      translateApiBase = 'translateApiBase',
+      translateApiKey = 'translateApiKey',
+      translateModel = 'translateModel',
+      translateSystemPrompt = 'translateSystemPrompt',
+      translateTargetLang = 'translateTargetLang',
+      translateFeed = 'translateFeed',
+      translateDetailTitleMode = 'translateDetailTitleMode',
+      translateTag = 'translateTag',
+      translateSkipLangs = 'translateSkipLangs';
 
   static const String minimizeOnExit = 'minimizeOnExit',
       windowSize = 'windowSize',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -674,6 +674,61 @@ abstract final class Pref {
     defaultValue: true,
   );
 
+  static bool get translateEnable =>
+      _setting.get(SettingBoxKey.translateEnable, defaultValue: false);
+
+  static String get translateProvider => _setting.get(
+    SettingBoxKey.translateProvider,
+    defaultValue: 'openai',
+  );
+
+  static String get translateApiBase => _setting.get(
+    SettingBoxKey.translateApiBase,
+    defaultValue: '',
+  );
+
+  static String get translateApiKey => _setting.get(
+    SettingBoxKey.translateApiKey,
+    defaultValue: '',
+  );
+
+  static String get translateModel => _setting.get(
+    SettingBoxKey.translateModel,
+    defaultValue: 'deepseek-chat',
+  );
+
+  static String get translateSystemPrompt => _setting.get(
+    SettingBoxKey.translateSystemPrompt,
+    defaultValue: '',
+  );
+
+  static String get translateTargetLang => _setting.get(
+    SettingBoxKey.translateTargetLang,
+    defaultValue: 'zh',
+  );
+
+  static bool get translateFeed => _setting.get(
+    SettingBoxKey.translateFeed,
+    defaultValue: true,
+  );
+
+  static String get translateDetailTitleMode => _setting.get(
+    SettingBoxKey.translateDetailTitleMode,
+    defaultValue: 'auto',
+  );
+
+  static bool get translateTag => _setting.get(
+    SettingBoxKey.translateTag,
+    defaultValue: true,
+  );
+
+  static List<String> get translateSkipLangs => List<String>.from(
+    _setting.get(
+      SettingBoxKey.translateSkipLangs,
+      defaultValue: ['zh'],
+    ),
+  );
+
   static bool get enableBackgroundPlay =>
       _setting.get(SettingBoxKey.enableBackgroundPlay, defaultValue: true);
 

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -283,17 +283,29 @@ abstract final class Pref {
     return CDNService.backupUrl;
   }
 
-  static String get banWordForRecommend =>
-      _setting.get(SettingBoxKey.banWordForRecommend, defaultValue: '');
+  static List<String> get banWordForRecommend => _banWordList(
+    SettingBoxKey.banWordForRecommend,
+  );
 
-  static String get banTagForRecommend =>
-      _setting.get(SettingBoxKey.banTagForRecommend, defaultValue: '');
+  static List<String> get banTagForRecommend => _banWordList(
+    SettingBoxKey.banTagForRecommend,
+  );
 
   static String get banWordForReply =>
       _setting.get(SettingBoxKey.banWordForReply, defaultValue: '');
 
-  static String get banWordForZone =>
-      _setting.get(SettingBoxKey.banWordForZone, defaultValue: '');
+  static List<String> get banWordForZone => _banWordList(
+    SettingBoxKey.banWordForZone,
+  );
+
+  /// 读取屏蔽词列表，兼容旧版使用`|`分隔的字符串存储
+  static List<String> _banWordList(String key) {
+    final value = _setting.get(key, defaultValue: <String>[]);
+    if (value is String) {
+      return value.isEmpty ? <String>[] : value.split('|');
+    }
+    return List<String>.from(value);
+  }
 
   static bool get appRcmd =>
       _setting.get(SettingBoxKey.appRcmd, defaultValue: true);

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -286,6 +286,9 @@ abstract final class Pref {
   static String get banWordForRecommend =>
       _setting.get(SettingBoxKey.banWordForRecommend, defaultValue: '');
 
+  static String get banTagForRecommend =>
+      _setting.get(SettingBoxKey.banTagForRecommend, defaultValue: '');
+
   static String get banWordForReply =>
       _setting.get(SettingBoxKey.banWordForReply, defaultValue: '');
 

--- a/lib/utils/translate_service.dart
+++ b/lib/utils/translate_service.dart
@@ -1,0 +1,238 @@
+import 'dart:async';
+
+import 'package:PiliPlus/utils/storage.dart';
+import 'package:PiliPlus/utils/storage_pref.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+/// 视频标题/标签翻译服务。
+/// 支持 OpenAI 兼容接口（DeepSeek、OpenAI、Moonshot 等）与 DeepL。
+/// 通过 [version] 通知 UI 刷新已翻译的文本。
+abstract final class TranslateService {
+  /// 翻译版本号，新增翻译完成时自增，UI 据此刷新
+  static final ValueNotifier<int> version = ValueNotifier(0);
+
+  /// 内存缓存：原文 -> 译文
+  static final Map<String, String> _cache = {};
+
+  /// 持久化缓存的 key（存储于 localCache）
+  static const String _cacheKey = 'translationCache';
+
+  /// 正在翻译 / 排队中的文本，用于去重
+  static final Set<String> _queue = {};
+
+  /// 并发限制
+  static int _running = 0;
+  static const int _maxConcurrent = 3;
+  static bool _loaded = false;
+
+  static final Dio _dio = Dio(
+    BaseOptions(
+      connectTimeout: const Duration(seconds: 15),
+      receiveTimeout: const Duration(seconds: 60),
+    ),
+  );
+
+  static bool get enabled => Pref.translateEnable;
+  static bool get isDeepL => Pref.translateProvider == 'deepl';
+
+  /// 是否已配置可用
+  static bool configured() {
+    if (!enabled) return false;
+    final base = Pref.translateApiBase.trim();
+    final key = Pref.translateApiKey.trim();
+    return base.isNotEmpty && key.isNotEmpty;
+  }
+
+  static void _ensureLoaded() {
+    if (_loaded) return;
+    _loaded = true;
+    final cached = GStorage.localCache.get(_cacheKey);
+    if (cached is Map) {
+      _cache.addAll(
+        cached.map((k, v) => MapEntry('$k', '$v')).cast<String, String>(),
+      );
+    }
+  }
+
+  static void _saveCache() {
+    // 限制缓存条数，避免无限增长
+    if (_cache.length > 3000) {
+      final it = _cache.keys.iterator;
+      var toRemove = _cache.length - 2000;
+      while (it.moveNext() && toRemove > 0) {
+        _cache.remove(it.current);
+        toRemove--;
+      }
+    }
+    GStorage.localCache.put(_cacheKey, _cache);
+  }
+
+  /// 判断是否需要翻译：包含拉丁字母，且不命中用户设定的「不用翻译的语言」
+  static bool needsTranslate(String text) {
+    if (text.isEmpty) return false;
+    var hasLatin = false;
+    var hasZh = false; // 简体/繁体中文
+    var hasJa = false; // 日文假名
+    var hasKo = false; // 韩文
+    for (final code in text.runes) {
+      if ((code >= 0x41 && code <= 0x5A) || (code >= 0x61 && code <= 0x7A)) {
+        hasLatin = true;
+      } else if ((code >= 0x3400 && code <= 0x4DBF) ||
+          (code >= 0x4E00 && code <= 0x9FFF)) {
+        hasZh = true;
+      } else if ((code >= 0x3040 && code <= 0x30FF) ||
+          (code >= 0x31F0 && code <= 0x31FF)) {
+        hasJa = true;
+      } else if ((code >= 0x1100 && code <= 0x11FF) ||
+          (code >= 0xAC00 && code <= 0xD7A3)) {
+        hasKo = true;
+      }
+    }
+    if (!hasLatin) return false;
+    final skip = Pref.translateSkipLangs;
+    // 命中某个「不用翻译」的语言时跳过：按推荐流/详情页/标签传入的跳过集判断
+    if (hasZh && skip.contains('zh')) return false;
+    if (hasJa && skip.contains('ja')) return false;
+    if (hasKo && skip.contains('ko')) return false;
+    return true;
+  }
+
+  /// 供 UI 调用的同步入口：有译文返回译文，否则立即返回原文并触发异步翻译。
+  /// [enabled] 用于按场景（推荐流/标签）开关门控。
+  static String display(String text, {bool enabled = true}) {
+    if (!enabled || !configured() || !needsTranslate(text)) return text;
+    _ensureLoaded();
+    final cached = _cache[text];
+    if (cached != null) return cached;
+    _enqueue(text);
+    return text;
+  }
+
+  /// 当前是否已有译文（仅已缓存、不含排队中的）。
+  /// 用于「显示原文」：若返回非空说明标题此刻确实被自动翻译了。
+  static String? translatedIfAny(String text) {
+    if (!configured() || !needsTranslate(text)) return null;
+    _ensureLoaded();
+    return _cache[text];
+  }
+
+  static void _enqueue(String text) {
+    if (_queue.contains(text)) return;
+    _queue.add(text);
+    _pump();
+  }
+
+  static void _pump() {
+    while (_running < _maxConcurrent && _queue.isNotEmpty) {
+      final text = _queue.first;
+      _queue.remove(text);
+      _running++;
+      unawaited(_runText(text));
+    }
+  }
+
+  static Future<void> _runText(String text) async {
+    try {
+      final result = await _translate(text);
+      if (result.isNotEmpty) {
+        _cache[text] = result;
+        _saveCache();
+        version.value++;
+      }
+    } catch (e) {
+      if (kDebugMode) debugPrint('翻译失败：$e');
+    } finally {
+      _running--;
+      _pump();
+    }
+  }
+
+  static Future<String> _translate(String text) {
+    if (isDeepL) {
+      return _translateDeepL(text);
+    }
+    return _translateOpenAI(text);
+  }
+
+  /// OpenAI 兼容接口：POST {base}/chat/completions
+  static Future<String> _translateOpenAI(String text) async {
+    final base = Pref.translateApiBase.trim();
+    final endpoint = base.endsWith('chat/completions')
+        ? base
+        : '${base.replaceAll(RegExp(r'/+$'), '')}/chat/completions';
+    final prompt = Pref.translateSystemPrompt.trim();
+    final response = await _dio.post(
+      endpoint,
+      options: Options(
+        headers: {
+          'Authorization': 'Bearer ${Pref.translateApiKey.trim()}',
+          'Content-Type': 'application/json',
+        },
+      ),
+      data: {
+        'model': Pref.translateModel.trim(),
+        'temperature': 0.3,
+        'messages': [
+          {
+            'role': 'system',
+            'content': prompt.isEmpty
+                ? '你是一个翻译助手。请把用户给出的视频标题或标签翻译成简体中文。'
+                    '只输出翻译结果，不要解释、不要加引号、不要添加任何额外内容。'
+                : prompt,
+          },
+          {'role': 'user', 'content': text},
+        ],
+      },
+    );
+    final data = response.data;
+    return data?['choices']?[0]?['message']?['content']
+            ?.toString()
+            .trim() ??
+        '';
+  }
+
+  /// DeepL：POST {base}/v2/translate
+  static Future<String> _translateDeepL(String text) async {
+    final base = Pref.translateApiBase.trim();
+    final endpoint = base.endsWith('translate')
+        ? base
+        : '${base.replaceAll(RegExp(r'/+$'), '')}/v2/translate';
+    final target = Pref.translateTargetLang.trim().isEmpty
+        ? 'zh'
+        : Pref.translateTargetLang.trim();
+    final response = await _dio.post(
+      endpoint,
+      options: Options(
+        headers: {
+          'Authorization': 'DeepL-Auth-Key ${Pref.translateApiKey.trim()}',
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+      ),
+      data: 'auth_key=${Uri.encodeQueryComponent(Pref.translateApiKey.trim())}'
+          '&text=${Uri.encodeQueryComponent(text)}'
+          '&target_lang=$target&source_lang=en',
+    );
+    return response.data?['translations']?[0]?['text']?.toString().trim() ?? '';
+  }
+
+  /// 手动翻译单个文本（详情页长按「翻译」入口用），不走缓存与队列
+  static Future<String> translateOne(String text) async {
+    if (!configured()) return '';
+    try {
+      return await _translate(text);
+    } catch (e) {
+      if (kDebugMode) debugPrint('翻译失败：$e');
+      return '';
+    }
+  }
+
+  /// 测试当前配置是否可用，返回测试句的译文
+  static Future<String> testConfigured() async {
+    const sample = 'Best action gameplay tips for beginners';
+    if (!configured()) {
+      return '';
+    }
+    return _translate(sample);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1517,6 +1517,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  restart_app:
+    dependency: "direct main"
+    description:
+      name: restart_app
+      sha256: "3ea6b790dd88d7d927ed4792f3c6dd68e2fdffcbb1bf4df6d19313702e2d6387"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.9.1"
   rxdart:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -147,6 +147,7 @@ dependencies:
   pretty_qr_code: ^3.3.0
   protobuf: ^6.0.0
   re_highlight: ^0.0.3
+  restart_app: ^1.3.2
   saver_gallery: ^5.0.2
   screen_brightness_platform_interface: ^2.1.0
   screen_retriever: ^0.2.0


### PR DESCRIPTION
为推荐流新增按视频真实标签屏蔽功能，覆盖 App 推荐、网页推荐、热门视频、排行榜、视频详情页相关推荐。
 
改动点：
 
​
tag过滤：查询每个视频的tag进行过滤，带内存缓存
​
设置界面改进：屏蔽词改为点击添加、列表式管理、逐条删除
​
覆盖范围：标签过滤对推荐流、热门、排行榜、相关推荐均生效（相关推荐受"过滤器也应用于详情页相关视频"开关控制）