### PR TITLE
feat: 推荐流按视频tag屏蔽（推荐流/热门/排行榜/相关推荐）

### DIFF
--- a/lib/http/video.dart
+++ b/lib/http/video.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:math' show min;
 
 import 'package:PiliPlus/common/constants.dart';
 import 'package:PiliPlus/grpc/bilibili/main/community/reply/v1.pb.dart'
@@ -8,11 +9,13 @@ import 'package:PiliPlus/http/browser_ua.dart';
 import 'package:PiliPlus/http/init.dart';
 import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/http/login.dart';
+import 'package:PiliPlus/http/user.dart';
 import 'package:PiliPlus/models/common/account_type.dart';
 import 'package:PiliPlus/models/common/video/video_type.dart';
 import 'package:PiliPlus/models/home/rcmd/result.dart';
 import 'package:PiliPlus/models/model_hot_video_item.dart';
 import 'package:PiliPlus/models/model_rec_video_item.dart';
+import 'package:PiliPlus/models/model_video.dart';
 import 'package:PiliPlus/models/pgc_lcf.dart';
 import 'package:PiliPlus/models/video/play/url.dart';
 import 'package:PiliPlus/models_new/pgc/pgc_rank/pgc_rank_item_model.dart';
@@ -27,6 +30,7 @@ import 'package:PiliPlus/models_new/video/video_note_list/data.dart';
 import 'package:PiliPlus/models_new/video/video_play_info/data.dart';
 import 'package:PiliPlus/models_new/video/video_relation/data.dart';
 import 'package:PiliPlus/models_new/video/video_shot/data.dart';
+import 'package:PiliPlus/models_new/video/video_tag/data.dart';
 import 'package:PiliPlus/utils/accounts.dart';
 import 'package:PiliPlus/utils/app_sign.dart';
 import 'package:PiliPlus/utils/extension/string_ext.dart';
@@ -45,8 +49,53 @@ import 'package:protobuf/protobuf.dart';
 
 /// view层根据 status 判断渲染逻辑
 abstract final class VideoHttp {
-  static RegExp zoneRegExp = RegExp(Pref.banWordForZone, caseSensitive: false);
+  static RegExp zoneRegExp = RegExp(
+    Pref.banWordForZone.map(RegExp.escape).join('|'),
+    caseSensitive: false,
+  );
   static bool enableFilter = zoneRegExp.pattern.isNotEmpty;
+
+  /// 视频真实标签缓存（按 bvid）
+  static final Map<String, List<String>> _tagCache = {};
+
+  /// 查询视频真实标签
+  static Future<List<String>> getVideoTags(String bvid) async {
+    if (bvid.isEmpty) return const [];
+    final cached = _tagCache[bvid];
+    if (cached != null) return cached;
+    final res = await UserHttp.videoTags(bvid: bvid);
+    final tags = switch (res) {
+      Success(:final response) => (response ?? <VideoTagItem>[])
+          .map((e) => e.tagName ?? '')
+          .where((e) => e.isNotEmpty)
+          .toList(),
+      Error() => <String>[],
+      Loading() => <String>[],
+    };
+    _tagCache[bvid] = tags;
+    return tags;
+  }
+
+  /// 按视频真实标签过滤（开启标签过滤时，并发查询真实标签并移除命中项）
+  static Future<List<T>> filterByRealTags<T extends BaseVideoItemModel>(
+    List<T> list,
+  ) async {
+    if (!RecommendFilter.enableTagFilter || list.isEmpty) return list;
+    final result = <T>[];
+    const batch = 6;
+    for (var i = 0; i < list.length; i += batch) {
+      final chunk = list.sublist(i, min(i + batch, list.length));
+      final tags = await Future.wait(
+        chunk.map((e) => getVideoTags(e.bvid ?? '')),
+      );
+      for (var j = 0; j < chunk.length; j++) {
+        if (!RecommendFilter.filterTagList(tags[j])) {
+          result.add(chunk[j]);
+        }
+      }
+    }
+    return result;
+  }
 
   // 首页推荐视频
   static Future<LoadingState<List<RcmdVideoItemModel>>> rcmdVideoList({
@@ -78,7 +127,7 @@ abstract final class VideoHttp {
           }
         }
       }
-      return Success(list);
+      return Success(await filterByRealTags(list));
     } else {
       return Error(res.data['message']);
     }
@@ -157,7 +206,7 @@ abstract final class VideoHttp {
           }
         }
       }
-      return Success(list);
+      return Success(await filterByRealTags(list));
     } else {
       return Error(res.data['message']);
     }
@@ -328,6 +377,9 @@ abstract final class VideoHttp {
       final list = RecommendFilter.applyFilterToRelatedVideos
           ? items?.where((i) => !RecommendFilter.filterAll(i)).toList()
           : items?.toList();
+      if (list != null && RecommendFilter.applyFilterToRelatedVideos) {
+        return Success(await filterByRealTags(list));
+      }
       return Success(list);
     } else {
       return Error(res.data['message']);

--- a/lib/http/video.dart
+++ b/lib/http/video.dart
@@ -239,7 +239,7 @@ abstract final class VideoHttp {
           list.add(HotVideoItemModel.fromJson(i));
         }
       }
-      return Success(list);
+      return Success(await filterByRealTags(list));
     } else {
       return Error(res.data['message']);
     }
@@ -944,7 +944,7 @@ abstract final class VideoHttp {
           // }
         }
       }
-      return Success(list);
+      return Success(await filterByRealTags(list));
     } else {
       return Error(res.data['message']);
     }

--- a/lib/http/video.dart
+++ b/lib/http/video.dart
@@ -180,7 +180,8 @@ abstract final class VideoHttp {
             !RecommendFilter.filterLikeRatio(
               i['stat']['like'],
               i['stat']['view'],
-            )) {
+            ) &&
+            !RecommendFilter.filterTag(i['tag'])) {
           if (enableFilter &&
               i['tname'] != null &&
               zoneRegExp.hasMatch(i['tname'])) {
@@ -856,7 +857,8 @@ abstract final class VideoHttp {
         !RecommendFilter.filterLikeRatio(
           i['stat']['like'],
           i['stat']['view'],
-        )) {
+        ) &&
+        !RecommendFilter.filterTag(i['tag'])) {
       if (enableFilter &&
           i['tname'] != null &&
           zoneRegExp.hasMatch(i['tname'])) {

--- a/lib/models/home/rcmd/result.dart
+++ b/lib/models/home/rcmd/result.dart
@@ -49,6 +49,8 @@ class RcmdVideoItemAppModel extends BaseRcmdVideoItemModel {
         ? ThreePoint.fromJson(json['three_point_v2'])
         : null;
     desc = json['desc'];
+    // App推荐 args.tname 即视频标签/频道名（如"恐怖"、"家常菜"）
+    tag = json['args']?['tname'];
   }
 }
 

--- a/lib/models/model_hot_video_item.dart
+++ b/lib/models/model_hot_video_item.dart
@@ -37,6 +37,8 @@ class HotVideoItemModel extends HorizontalVideoModel with MultiSelectData {
         : Dimension.fromJson(json['dimension']);
     firstFrame = json["first_frame"];
     pubLocation = json["pub_location"];
+    // 相关视频等接口早期版本返回逗号分隔的标签字符串，做防御性解析
+    tag = json["tag"];
     redirectUrl = json['redirect_url'];
     progress = json['progress'];
     if (json['charging_pay']?['level'] != null) {

--- a/lib/models/model_rec_video_item.dart
+++ b/lib/models/model_rec_video_item.dart
@@ -25,6 +25,8 @@ class RcmdVideoItemModel extends BaseRcmdVideoItemModel {
     owner = Owner.fromJson(json["owner"]);
     stat = Stat.fromJson(json["stat"]);
     isFollowed = json["is_followed"] == 1;
+    // 网页推荐接口早期版本返回逗号分隔的标签字符串，做防御性解析
+    tag = json["tag"];
     // rcmdReason = json["rcmd_reason"] != null
     //     ? RcmdReason.fromJson(json["rcmd_reason"])
     //     : RcmdReason(content: '');

--- a/lib/models/model_video.dart
+++ b/lib/models/model_video.dart
@@ -13,6 +13,10 @@ abstract class BaseVideoItemModel extends BaseSimpleVideoItemModel {
   String? desc;
   int? pubdate;
   bool isFollowed = false;
+
+  /// 视频标签，不同来源含义略有差异：
+  /// App推荐为频道/标签名（args.tname），网页推荐/相关视频为逗号分隔的标签字符串
+  String? tag;
 }
 
 abstract class BaseOwner {

--- a/lib/pages/setting/models/model.dart
+++ b/lib/pages/setting/models/model.dart
@@ -266,6 +266,123 @@ SettingsModel getBanWordModel({
   );
 }
 
+SettingsModel getBanWordListModel({
+  required String title,
+  required String key,
+  required ValueChanged<List<String>> onChanged,
+  String? subtitle,
+}) {
+  List<String> banWords = _readBanWordList(key);
+  return NormalModel(
+    leading: const Icon(Icons.filter_alt_outlined),
+    title: title,
+    subtitle: subtitle,
+    getSubtitle: () => banWords.isEmpty
+        ? '点击添加'
+        : '已屏蔽 ${banWords.length} 个：${banWords.join('、')}',
+    onTap: (context, setState) {
+      final TextEditingController controller = TextEditingController();
+      void save() {
+        GStorage.setting.put(key, banWords);
+        onChanged(List<String>.from(banWords));
+      }
+
+      showDialog(
+        context: context,
+        builder: (context) => AlertDialog(
+          constraints: Style.dialogFixedConstraints,
+          title: Text(title),
+          content: StatefulBuilder(
+            builder: (context, setDialogState) {
+              void add() {
+                final word = controller.text.trim();
+                if (word.isEmpty) return;
+                if (!banWords.contains(word)) {
+                  banWords.add(word);
+                  save();
+                }
+                controller.clear();
+                setDialogState(() {});
+              }
+
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: TextFormField(
+                          controller: controller,
+                          autofocus: true,
+                          textInputAction: TextInputAction.done,
+                          onFieldSubmitted: (_) => add(),
+                          decoration: const InputDecoration(
+                            hintText: '输入单个关键词，点击添加',
+                          ),
+                        ),
+                      ),
+                      TextButton(
+                        onPressed: add,
+                        child: const Text('添加'),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  if (banWords.isNotEmpty)
+                    Flexible(
+                      child: SingleChildScrollView(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            for (final word in banWords)
+                              ListTile(
+                                dense: true,
+                                contentPadding: EdgeInsets.zero,
+                                title: Text(word),
+                                trailing: IconButton(
+                                  icon: const Icon(Icons.close),
+                                  tooltip: '移除',
+                                  onPressed: () {
+                                    banWords.remove(word);
+                                    save();
+                                    setDialogState(() {});
+                                  },
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
+                    )
+                  else
+                    const Text('暂无屏蔽词', style: TextStyle(fontSize: 13)),
+                ],
+              );
+            },
+          ),
+          actions: [
+            TextButton(
+              onPressed: Get.back,
+              child: Text(
+                '取消',
+                style: TextStyle(color: ColorScheme.of(context).outline),
+              ),
+            ),
+            TextButton(
+              child: const Text('完成'),
+              onPressed: () {
+                Get.back();
+                setState();
+                SmartDialog.showToast('已保存');
+              },
+            ),
+          ],
+        ),
+      );
+    },
+  );
+}
+
 SettingsModel getVideoFilterSelectModel({
   required String title,
   String? subtitle,
@@ -348,4 +465,13 @@ SettingsModel getVideoFilterSelectModel({
       }
     },
   );
+}
+
+/// 读取屏蔽词列表，兼容旧版使用`|`分隔的字符串存储
+List<String> _readBanWordList(String key) {
+  final value = GStorage.setting.get(key, defaultValue: <String>[]);
+  if (value is String) {
+    return value.isEmpty ? <String>[] : value.split('|');
+  }
+  return List<String>.from(value);
 }

--- a/lib/pages/setting/models/model.dart
+++ b/lib/pages/setting/models/model.dart
@@ -210,11 +210,13 @@ SettingsModel getBanWordModel({
   required String title,
   required String key,
   required ValueChanged<RegExp> onChanged,
+  String? subtitle,
 }) {
   String banWord = GStorage.setting.get(key, defaultValue: '');
   return NormalModel(
     leading: const Icon(Icons.filter_alt_outlined),
     title: title,
+    subtitle: subtitle,
     getSubtitle: () => banWord.isEmpty ? "点击添加" : banWord,
     onTap: (context, setState) {
       String editValue = banWord;

--- a/lib/pages/setting/models/recommend_settings.dart
+++ b/lib/pages/setting/models/recommend_settings.dart
@@ -66,7 +66,6 @@ List<SettingsModel> get recommendSettings => [
   ),
   getBanWordListModel(
     title: '视频标签过滤',
-    subtitle: '按视频真实标签屏蔽，如：三角洲行动',
     key: SettingBoxKey.banTagForRecommend,
     onChanged: (List<String> words) {
       final pattern = words.map(RegExp.escape).join('|');

--- a/lib/pages/setting/models/recommend_settings.dart
+++ b/lib/pages/setting/models/recommend_settings.dart
@@ -64,6 +64,15 @@ List<SettingsModel> get recommendSettings => [
     },
   ),
   getBanWordModel(
+    title: '视频标签过滤',
+    subtitle: '按标签屏蔽视频，如：游戏|综艺（App推荐为频道/标签名）',
+    key: SettingBoxKey.banTagForRecommend,
+    onChanged: (value) {
+      RecommendFilter.tagRegExp = value;
+      RecommendFilter.enableTagFilter = value.pattern.isNotEmpty;
+    },
+  ),
+  getBanWordModel(
     title: 'App推荐/热门/排行榜: 视频分区关键词过滤',
     key: SettingBoxKey.banWordForZone,
     onChanged: (value) {

--- a/lib/pages/setting/models/recommend_settings.dart
+++ b/lib/pages/setting/models/recommend_settings.dart
@@ -55,29 +55,32 @@ List<SettingsModel> get recommendSettings => [
     values: [0, 1, 2, 3, 4],
     onChanged: (value) => RecommendFilter.minLikeRatioForRecommend = value,
   ),
-  getBanWordModel(
+  getBanWordListModel(
     title: '标题关键词过滤',
     key: SettingBoxKey.banWordForRecommend,
-    onChanged: (value) {
-      RecommendFilter.rcmdRegExp = value;
-      RecommendFilter.enableFilter = value.pattern.isNotEmpty;
+    onChanged: (List<String> words) {
+      final pattern = words.map(RegExp.escape).join('|');
+      RecommendFilter.rcmdRegExp = RegExp(pattern, caseSensitive: false);
+      RecommendFilter.enableFilter = words.isNotEmpty;
     },
   ),
-  getBanWordModel(
+  getBanWordListModel(
     title: '视频标签过滤',
-    subtitle: '按标签屏蔽视频，如：游戏|综艺（App推荐为频道/标签名）',
+    subtitle: '按视频真实标签屏蔽，如：三角洲行动',
     key: SettingBoxKey.banTagForRecommend,
-    onChanged: (value) {
-      RecommendFilter.tagRegExp = value;
-      RecommendFilter.enableTagFilter = value.pattern.isNotEmpty;
+    onChanged: (List<String> words) {
+      final pattern = words.map(RegExp.escape).join('|');
+      RecommendFilter.tagRegExp = RegExp(pattern, caseSensitive: false);
+      RecommendFilter.enableTagFilter = words.isNotEmpty;
     },
   ),
-  getBanWordModel(
+  getBanWordListModel(
     title: 'App推荐/热门/排行榜: 视频分区关键词过滤',
     key: SettingBoxKey.banWordForZone,
-    onChanged: (value) {
-      VideoHttp.zoneRegExp = value;
-      VideoHttp.enableFilter = value.pattern.isNotEmpty;
+    onChanged: (List<String> words) {
+      final pattern = words.map(RegExp.escape).join('|');
+      VideoHttp.zoneRegExp = RegExp(pattern, caseSensitive: false);
+      VideoHttp.enableFilter = words.isNotEmpty;
     },
   ),
   getVideoFilterSelectModel(

--- a/lib/utils/recommend_filter.dart
+++ b/lib/utils/recommend_filter.dart
@@ -7,16 +7,18 @@ abstract final class RecommendFilter {
   static int minLikeRatioForRecommend = Pref.minLikeRatioForRecommend;
   static bool exemptFilterForFollowed = Pref.exemptFilterForFollowed;
   static bool applyFilterToRelatedVideos = Pref.applyFilterToRelatedVideos;
+  static final List<String> rcmdBanWords = Pref.banWordForRecommend;
   static RegExp rcmdRegExp = RegExp(
-    Pref.banWordForRecommend,
+    rcmdBanWords.map(RegExp.escape).join('|'),
     caseSensitive: false,
   );
-  static bool enableFilter = rcmdRegExp.pattern.isNotEmpty;
+  static bool enableFilter = rcmdBanWords.isNotEmpty;
+  static final List<String> tagBanWords = Pref.banTagForRecommend;
   static RegExp tagRegExp = RegExp(
-    Pref.banTagForRecommend,
+    tagBanWords.map(RegExp.escape).join('|'),
     caseSensitive: false,
   );
-  static bool enableTagFilter = tagRegExp.pattern.isNotEmpty;
+  static bool enableTagFilter = tagBanWords.isNotEmpty;
 
   static bool filter(BaseVideoItemModel videoItem) {
     //由于相关视频中没有已关注标签，只能视为非关注视频
@@ -42,6 +44,11 @@ abstract final class RecommendFilter {
 
   static bool filterTag(String? tag) {
     return enableTagFilter && tag != null && tagRegExp.hasMatch(tag);
+  }
+
+  static bool filterTagList(List<String> tags) {
+    if (!enableTagFilter) return false;
+    return tags.any(tagRegExp.hasMatch);
   }
 
   static bool filterAll(BaseVideoItemModel videoItem) {

--- a/lib/utils/recommend_filter.dart
+++ b/lib/utils/recommend_filter.dart
@@ -12,6 +12,11 @@ abstract final class RecommendFilter {
     caseSensitive: false,
   );
   static bool enableFilter = rcmdRegExp.pattern.isNotEmpty;
+  static RegExp tagRegExp = RegExp(
+    Pref.banTagForRecommend,
+    caseSensitive: false,
+  );
+  static bool enableTagFilter = tagRegExp.pattern.isNotEmpty;
 
   static bool filter(BaseVideoItemModel videoItem) {
     //由于相关视频中没有已关注标签，只能视为非关注视频
@@ -35,10 +40,15 @@ abstract final class RecommendFilter {
     return (enableFilter && rcmdRegExp.hasMatch(title));
   }
 
+  static bool filterTag(String? tag) {
+    return enableTagFilter && tag != null && tagRegExp.hasMatch(tag);
+  }
+
   static bool filterAll(BaseVideoItemModel videoItem) {
     return (videoItem.duration > 0 &&
             videoItem.duration < minDurationForRcmd) ||
         filterLikeRatio(videoItem.stat.like, videoItem.stat.view) ||
-        filterTitle(videoItem.title);
+        filterTitle(videoItem.title) ||
+        filterTag(videoItem.tag);
   }
 }

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -54,6 +54,7 @@ abstract final class SettingBoxKey {
       minLikeRatioForRecommend = 'minLikeRatioForRecommend',
       exemptFilterForFollowed = 'exemptFilterForFollowed',
       banWordForRecommend = 'banWordForRecommend',
+      banTagForRecommend = 'banTagForRecommend',
       applyFilterToRelatedVideos = 'applyFilterToRelatedVideos',
       autoUpdate = 'autoUpdate',
       maxCacheSize = 'maxCacheSize',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -283,17 +283,29 @@ abstract final class Pref {
     return CDNService.backupUrl;
   }
 
-  static String get banWordForRecommend =>
-      _setting.get(SettingBoxKey.banWordForRecommend, defaultValue: '');
+  static List<String> get banWordForRecommend => _banWordList(
+    SettingBoxKey.banWordForRecommend,
+  );
 
-  static String get banTagForRecommend =>
-      _setting.get(SettingBoxKey.banTagForRecommend, defaultValue: '');
+  static List<String> get banTagForRecommend => _banWordList(
+    SettingBoxKey.banTagForRecommend,
+  );
 
   static String get banWordForReply =>
       _setting.get(SettingBoxKey.banWordForReply, defaultValue: '');
 
-  static String get banWordForZone =>
-      _setting.get(SettingBoxKey.banWordForZone, defaultValue: '');
+  static List<String> get banWordForZone => _banWordList(
+    SettingBoxKey.banWordForZone,
+  );
+
+  /// 读取屏蔽词列表，兼容旧版使用`|`分隔的字符串存储
+  static List<String> _banWordList(String key) {
+    final value = _setting.get(key, defaultValue: <String>[]);
+    if (value is String) {
+      return value.isEmpty ? <String>[] : value.split('|');
+    }
+    return List<String>.from(value);
+  }
 
   static bool get appRcmd =>
       _setting.get(SettingBoxKey.appRcmd, defaultValue: true);

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -286,6 +286,9 @@ abstract final class Pref {
   static String get banWordForRecommend =>
       _setting.get(SettingBoxKey.banWordForRecommend, defaultValue: '');
 
+  static String get banTagForRecommend =>
+      _setting.get(SettingBoxKey.banTagForRecommend, defaultValue: '');
+
   static String get banWordForReply =>
       _setting.get(SettingBoxKey.banWordForReply, defaultValue: '');
 


### PR DESCRIPTION
为推荐流新增按视频tag屏蔽功能，覆盖 App 推荐、网页推荐、热门视频、排行榜、视频详情页相关推荐。
 
改动点：
 
tag过滤：查询每个视频的标签进行过滤，带内存缓存
​
设置界面改进：屏蔽词改为点击添加、列表式管理、逐条删除（标题关键词、视频tag、分区屏蔽三个入口统一）
​
覆盖：tag过滤对推荐流、热门、排行榜、相关推荐均生效（相关推荐受"过滤器也应用于详情页相关视频"开关控制）

已在安卓端测试通过
https://github.com/silverwolf-lv9999/PiliPlus/releases/download/v2.1.3-tagfilter/PiliPlus_android_2.1.3-b1e9d77ce%2B5337_arm64-v8a.apk