### PR TITLE
feat(danmaku): 支持基于视频蒙版的人像防挡

### DIFF
--- a/lib/models_new/video/video_play_info/data.dart
+++ b/lib/models_new/video/video_play_info/data.dart
@@ -1,3 +1,4 @@
+import 'package:PiliPlus/models_new/video/video_play_info/dm_mask.dart';
 import 'package:PiliPlus/models_new/video/video_play_info/interaction.dart';
 import 'package:PiliPlus/models_new/video/video_play_info/subtitle_info.dart';
 import 'package:PiliPlus/models_new/video/video_play_info/view_point.dart';
@@ -7,12 +8,14 @@ class PlayInfoData {
   SubtitleInfo? subtitle;
   List<ViewPoint>? viewPoints;
   Interaction? interaction;
+  DmMask? dmMask;
 
   PlayInfoData({
     this.lastPlayCid,
     this.subtitle,
     this.viewPoints,
     this.interaction,
+    this.dmMask,
   });
 
   factory PlayInfoData.fromJson(Map<String, dynamic> json) => PlayInfoData(
@@ -26,5 +29,6 @@ class PlayInfoData {
     interaction: json["interaction"] == null
         ? null
         : Interaction.fromJson(json["interaction"]),
+    dmMask: DmMask.fromJsonOrNull(json['dm_mask']),
   );
 }

--- a/lib/models_new/video/video_play_info/dm_mask.dart
+++ b/lib/models_new/video/video_play_info/dm_mask.dart
@@ -1,0 +1,36 @@
+import 'package:PiliPlus/utils/extension/string_ext.dart';
+
+final class DmMask {
+  const DmMask({
+    required this.cid,
+    required this.plat,
+    required this.fps,
+    required this.time,
+    required this.maskUrl,
+  });
+
+  final int cid;
+  final int plat;
+  final int fps;
+  final int time;
+  final String maskUrl;
+
+  static DmMask? fromJsonOrNull(Object? json) {
+    if (json is! Map<String, dynamic>) return null;
+    try {
+      final cid = json['cid'] as int;
+      final fps = json['fps'] as int;
+      final maskUrl = (json['mask_url'] as String).http2https;
+      if (cid <= 0 || fps <= 0 || maskUrl.isEmpty) return null;
+      return DmMask(
+        cid: cid,
+        plat: json['plat'] as int,
+        fps: fps,
+        time: json['time'] as int,
+        maskUrl: maskUrl,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/lib/pages/danmaku/mask/controller.dart
+++ b/lib/pages/danmaku/mask/controller.dart
@@ -1,0 +1,504 @@
+import 'dart:async' show Future, unawaited;
+import 'dart:ui' as ui;
+
+import 'package:PiliPlus/http/init.dart';
+import 'package:PiliPlus/models_new/video/video_play_info/dm_mask.dart';
+import 'package:PiliPlus/pages/danmaku/mask/parser.dart';
+import 'package:PiliPlus/utils/accounts/account.dart';
+import 'package:PiliPlus/utils/storage.dart';
+import 'package:PiliPlus/utils/storage_key.dart';
+import 'package:PiliPlus/utils/storage_pref.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:path_parsing/path_parsing.dart';
+
+final class DanmakuMaskRange {
+  const DanmakuMaskRange({required this.bytes, required this.totalLength});
+
+  final Uint8List bytes;
+  final int totalLength;
+}
+
+typedef DanmakuMaskRangeLoader = Future<DanmakuMaskRange> Function(
+  String url,
+  int start,
+  int end,
+  CancelToken cancelToken,
+);
+
+typedef DanmakuMaskEnabledReader = bool Function();
+
+final class DanmakuMaskTransientException implements Exception {
+  const DanmakuMaskTransientException(this.statusCode);
+
+  final int? statusCode;
+
+  @override
+  String toString() => 'Transient webmask request failure: $statusCode';
+}
+
+final class DanmakuMaskFrame {
+  const DanmakuMaskFrame({required this.viewBox, required this.allowedPath});
+
+  final ui.Rect viewBox;
+  final ui.Path allowedPath;
+}
+
+final class DanmakuMaskController {
+  DanmakuMaskController({
+    DanmakuMaskRangeLoader? rangeLoader,
+    DanmakuMaskEnabledReader? enabledReader,
+    @visibleForTesting bool? enabled,
+    @visibleForTesting this.retryDelay = const Duration(seconds: 2),
+  }) : _rangeLoader = rangeLoader ?? _loadRange,
+       _enabledReader = enabledReader ?? _readEnabled,
+       _enabled = enabled ?? (enabledReader ?? _readEnabled)();
+
+  final DanmakuMaskRangeLoader _rangeLoader;
+  final DanmakuMaskEnabledReader _enabledReader;
+  @visibleForTesting
+  final Duration retryDelay;
+  final ValueNotifier<DanmakuMaskFrame?> frame = ValueNotifier(null);
+
+  final Map<int, WebMaskSegmentData> _segments = {};
+  final Map<int, Future<void>> _segmentLoads = {};
+  final Map<int, CancelToken> _segmentTokens = {};
+  final Set<int> _failedSegments = {};
+
+  DmMask? _source;
+  WebMaskIndex? _index;
+  Future<void>? _indexLoad;
+  CancelToken? _indexToken;
+  bool _indexFailed = false;
+  bool _enabled;
+  bool _disposed = false;
+  int _generation = 0;
+  int _positionMs = 0;
+  int? _selectedSegment;
+  int? _selectedFrame;
+
+  bool get enabled => _enabled;
+  bool get available => _source != null;
+
+  void setSource(DmMask? source) {
+    if (_source?.cid == source?.cid && _source?.maskUrl == source?.maskUrl) {
+      return;
+    }
+    _reset(keepSource: false);
+    _source = source;
+    if (_enabled && source != null) {
+      unawaited(_ensurePosition());
+    }
+  }
+
+  void setEnabled(bool value, int positionMs) {
+    _applyEnabled(value, positionMs, persist: true);
+  }
+
+  void syncEnabledFromPreference(int positionMs) {
+    _applyEnabled(_enabledReader(), positionMs, persist: false);
+  }
+
+  void _applyEnabled(
+    bool value,
+    int positionMs, {
+    required bool persist,
+  }) {
+    _positionMs = positionMs;
+    if (_enabled == value) return;
+    _enabled = value;
+    if (persist) {
+      unawaited(
+        GStorage.setting.put(SettingBoxKey.enableDanmakuMask, value),
+      );
+    }
+    if (value) {
+      unawaited(_ensurePosition());
+    } else {
+      _reset(keepSource: true);
+    }
+  }
+
+  void updatePosition(Duration position) {
+    _positionMs = position.inMilliseconds;
+    if (!_enabled || _source == null || _disposed) return;
+    final index = _index;
+    if (index == null) {
+      if (!_indexFailed) unawaited(_ensurePosition());
+      return;
+    }
+
+    final segmentIndex = index.segmentFor(_positionMs);
+    _cancelUnneededLoads(segmentIndex);
+    final segment = _segments[segmentIndex];
+    if (segment == null) {
+      _clearFrame();
+      if (!_failedSegments.contains(segmentIndex)) {
+        unawaited(_loadSegment(segmentIndex, _generation));
+      }
+      return;
+    }
+
+    _selectFrame(segmentIndex, segment);
+    _prefetchNextIfNeeded(segmentIndex, _generation);
+  }
+
+  Future<void> _ensurePosition() async {
+    if (!_enabled || _source == null || _disposed || _indexFailed) return;
+    final generation = _generation;
+    await _ensureIndex(generation);
+    if (!_isCurrent(generation) || _index == null) return;
+    final segmentIndex = _index!.segmentFor(_positionMs);
+    await _loadSegment(segmentIndex, generation);
+  }
+
+  Future<void> _ensureIndex(int generation) async {
+    if (_index != null || _indexFailed) return;
+    final existing = _indexLoad;
+    if (existing != null) return existing;
+
+    final future = _readIndex(generation);
+    _indexLoad = future;
+    try {
+      await future;
+    } finally {
+      if (identical(_indexLoad, future)) _indexLoad = null;
+    }
+  }
+
+  Future<void> _readIndex(int generation) async {
+    final source = _source;
+    if (source == null) return;
+    final token = _indexToken = CancelToken();
+    try {
+      final headerRange = await _loadRangeWithRetry(
+        source.maskUrl,
+        0,
+        15,
+        token,
+        generation,
+      );
+      if (!_isCurrent(generation)) return;
+      final header = parseWebMaskHeader(headerRange.bytes);
+      final indexEnd = 16 + header.segmentCount * 16 - 1;
+      if (indexEnd >= headerRange.totalLength) {
+        throw const FormatException('Invalid webmask index range');
+      }
+      final indexRange = await _loadRangeWithRetry(
+        source.maskUrl,
+        16,
+        indexEnd,
+        token,
+        generation,
+      );
+      if (!_isCurrent(generation)) return;
+      if (indexRange.totalLength != headerRange.totalLength) {
+        throw const FormatException('Inconsistent webmask total length');
+      }
+      _index = parseWebMaskIndex(
+        Uint8List.fromList([...headerRange.bytes, ...indexRange.bytes]),
+        indexRange.totalLength,
+      );
+    } catch (error) {
+      if (_isCurrent(generation) && !token.isCancelled) {
+        _indexFailed = true;
+        _debugError('load index', error);
+      }
+    } finally {
+      if (identical(_indexToken, token)) _indexToken = null;
+    }
+  }
+
+  Future<void> _loadSegment(int segmentIndex, int generation) {
+    if (!_isCurrent(generation) ||
+        _segments.containsKey(segmentIndex) ||
+        _failedSegments.contains(segmentIndex)) {
+      return Future.value();
+    }
+    final existing = _segmentLoads[segmentIndex];
+    if (existing != null) return existing;
+
+    final future = _readSegment(segmentIndex, generation);
+    _segmentLoads[segmentIndex] = future;
+    future.whenComplete(() {
+      if (identical(_segmentLoads[segmentIndex], future)) {
+        _segmentLoads.remove(segmentIndex);
+        _segmentTokens.remove(segmentIndex);
+      }
+    });
+    return future;
+  }
+
+  Future<void> _readSegment(int segmentIndex, int generation) async {
+    final source = _source;
+    final index = _index;
+    if (source == null || index == null) return;
+    final segmentIndexData = index.segments[segmentIndex];
+    final token = CancelToken();
+    _segmentTokens[segmentIndex] = token;
+    try {
+      final range = await _loadRangeWithRetry(
+        source.maskUrl,
+        segmentIndexData.start,
+        segmentIndexData.end - 1,
+        token,
+        generation,
+      );
+      if (!_isCurrent(generation) || token.isCancelled) return;
+      if (range.totalLength != index.totalLength) {
+        throw const FormatException('Inconsistent webmask total length');
+      }
+      final segment = await compute(parseWebMaskSegment, range.bytes);
+      if (!_isCurrent(generation) || token.isCancelled) return;
+      _segments[segmentIndex] = segment;
+      _trimCache(segmentIndex);
+      if (_index?.segmentFor(_positionMs) == segmentIndex) {
+        _selectFrame(segmentIndex, segment);
+        _prefetchNextIfNeeded(segmentIndex, generation);
+      }
+    } catch (error) {
+      if (_isCurrent(generation) && !token.isCancelled) {
+        _failedSegments.add(segmentIndex);
+        if (_index?.segmentFor(_positionMs) == segmentIndex) {
+          _clearFrame();
+        }
+        _debugError('load segment', error);
+      }
+    }
+  }
+
+  void _selectFrame(int segmentIndex, WebMaskSegmentData segment) {
+    final frameIndex = segment.frameFor(_positionMs);
+    if (_selectedSegment == segmentIndex && _selectedFrame == frameIndex) {
+      return;
+    }
+    _selectedSegment = segmentIndex;
+    _selectedFrame = frameIndex;
+    if (frameIndex < 0) {
+      frame.value = null;
+      return;
+    }
+    frame.value = _buildFrame(segment.frames[frameIndex]);
+  }
+
+  DanmakuMaskFrame? _buildFrame(WebMaskFrameData data) {
+    try {
+      return buildDanmakuMaskFrame(data);
+    } catch (error) {
+      _debugError('parse path', error);
+      return null;
+    }
+  }
+
+  void _prefetchNextIfNeeded(int segmentIndex, int generation) {
+    final index = _index;
+    if (index != null &&
+        segmentIndex + 1 < index.segments.length &&
+        _positionMs >= index.segments[segmentIndex + 1].timeMs - 1000) {
+      unawaited(_loadSegment(segmentIndex + 1, generation));
+    }
+  }
+
+  void _cancelUnneededLoads(int current) {
+    for (final entry in _segmentTokens.entries.toList()) {
+      if (entry.key != current && entry.key != current + 1) {
+        entry.value.cancel();
+        _segmentTokens.remove(entry.key);
+        _segmentLoads.remove(entry.key);
+      }
+    }
+  }
+
+  void _trimCache(int current) {
+    if (_segments.length <= 3) return;
+    final keys = _segments.keys.toList()
+      ..sort((a, b) => (a - current).abs().compareTo((b - current).abs()));
+    for (final key in keys.skip(3)) {
+      _segments.remove(key);
+    }
+  }
+
+  bool _isCurrent(int generation) {
+    return !_disposed && _enabled && generation == _generation;
+  }
+
+  void _clearFrame() {
+    _selectedSegment = null;
+    _selectedFrame = null;
+    frame.value = null;
+  }
+
+  void _reset({required bool keepSource}) {
+    _generation++;
+    _indexToken?.cancel();
+    _indexToken = null;
+    for (final token in _segmentTokens.values) {
+      token.cancel();
+    }
+    _segmentTokens.clear();
+    _segmentLoads.clear();
+    _segments.clear();
+    _failedSegments.clear();
+    _index = null;
+    _indexLoad = null;
+    _indexFailed = false;
+    if (!keepSource) _source = null;
+    _clearFrame();
+  }
+
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _reset(keepSource: false);
+    frame.dispose();
+  }
+
+  Future<DanmakuMaskRange> _loadRangeWithRetry(
+    String url,
+    int start,
+    int end,
+    CancelToken cancelToken,
+    int generation,
+  ) async {
+    try {
+      return await _rangeLoader(url, start, end, cancelToken);
+    } on DanmakuMaskTransientException {
+      await Future.any<void>([
+        Future<void>.delayed(retryDelay),
+        cancelToken.whenCancel.then<void>((_) {}),
+      ]);
+      if (!_isCurrent(generation) || cancelToken.isCancelled) {
+        throw const _DanmakuMaskCancelledException();
+      }
+      return _rangeLoader(url, start, end, cancelToken);
+    }
+  }
+
+  static Future<DanmakuMaskRange> _loadRange(
+    String url,
+    int start,
+    int end,
+    CancelToken cancelToken,
+  ) async {
+    final response = await Request().get<List<int>>(
+      url,
+      options: Options(
+        responseType: ResponseType.bytes,
+        headers: {
+          'range': 'bytes=$start-$end',
+          'accept-encoding': 'identity',
+        },
+        extra: {'account': const NoAccount()},
+      ),
+      cancelToken: cancelToken,
+    );
+    final statusCode = response.statusCode;
+    if (statusCode == -1 ||
+        statusCode == 408 ||
+        statusCode == 429 ||
+        (statusCode != null && statusCode >= 500 && statusCode < 600)) {
+      throw DanmakuMaskTransientException(statusCode);
+    }
+    if (statusCode != 206 || response.data is! List<int>) {
+      throw const FormatException('Webmask server did not return a byte range');
+    }
+
+    final value = response.headers.value('content-range');
+    final match = value == null
+        ? null
+        : RegExp(r'^bytes (\d+)-(\d+)/(\d+)$').firstMatch(value);
+    if (match == null ||
+        int.parse(match.group(1)!) != start ||
+        int.parse(match.group(2)!) != end) {
+      throw const FormatException('Invalid webmask Content-Range');
+    }
+    final bytes = Uint8List.fromList(response.data!);
+    if (bytes.length != end - start + 1) {
+      throw const FormatException('Invalid webmask range length');
+    }
+    return DanmakuMaskRange(
+      bytes: bytes,
+      totalLength: int.parse(match.group(3)!),
+    );
+  }
+
+  static void _debugError(String action, Object error) {
+    if (kDebugMode) debugPrint('danmaku mask $action: $error');
+  }
+
+  static bool _readEnabled() => Pref.enableDanmakuMask;
+}
+
+final class _DanmakuMaskCancelledException implements Exception {
+  const _DanmakuMaskCancelledException();
+}
+
+@visibleForTesting
+DanmakuMaskFrame? buildDanmakuMaskFrame(WebMaskFrameData data) {
+  final viewBox = data.viewBox;
+  final paths = data.paths;
+  if (viewBox == null || paths == null) return null;
+
+  final result = ui.Path();
+  for (final pathData in paths) {
+    final proxy = _UiPathProxy();
+    writeSvgPathDataToPath(pathData.data, proxy);
+    result.addPath(
+      proxy.path.transform(_toMatrix4(pathData.transform)),
+      ui.Offset.zero,
+    );
+  }
+  return DanmakuMaskFrame(
+    viewBox: ui.Rect.fromLTWH(
+      viewBox[0],
+      viewBox[1],
+      viewBox[2],
+      viewBox[3],
+    ),
+    allowedPath: result,
+  );
+}
+
+final class _UiPathProxy implements PathProxy {
+  final ui.Path path = ui.Path();
+
+  @override
+  void close() => path.close();
+
+  @override
+  void cubicTo(
+    double x1,
+    double y1,
+    double x2,
+    double y2,
+    double x3,
+    double y3,
+  ) => path.cubicTo(x1, y1, x2, y2, x3, y3);
+
+  @override
+  void lineTo(double x, double y) => path.lineTo(x, y);
+
+  @override
+  void moveTo(double x, double y) => path.moveTo(x, y);
+}
+
+Float64List _toMatrix4(List<double> value) {
+  return Float64List.fromList([
+    value[0],
+    value[1],
+    0,
+    0,
+    value[2],
+    value[3],
+    0,
+    0,
+    0,
+    0,
+    1,
+    0,
+    value[4],
+    value[5],
+    0,
+    1,
+  ]);
+}

--- a/lib/pages/danmaku/mask/parser.dart
+++ b/lib/pages/danmaku/mask/parser.dart
@@ -1,0 +1,334 @@
+import 'dart:convert' show base64, utf8;
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart' show GZipDecoder;
+import 'package:html/dom.dart' show Element;
+import 'package:html/parser.dart' show parseFragment;
+
+const _dataUriPrefix = 'data:image/svg+xml;base64,';
+final _whitespace = RegExp(r'\s');
+final _numberSeparator = RegExp(r'[\s,]+');
+final _transformExpression = RegExp(r'([A-Za-z]+)\s*\(([^)]*)\)');
+
+final class WebMaskHeader {
+  const WebMaskHeader({required this.segmentCount});
+
+  final int segmentCount;
+}
+
+final class WebMaskSegmentIndex {
+  const WebMaskSegmentIndex({
+    required this.timeMs,
+    required this.start,
+    required this.end,
+  });
+
+  final int timeMs;
+  final int start;
+  final int end;
+}
+
+final class WebMaskIndex {
+  const WebMaskIndex({required this.segments, required this.totalLength});
+
+  final List<WebMaskSegmentIndex> segments;
+  final int totalLength;
+
+  int segmentFor(int positionMs) {
+    var low = 0;
+    var high = segments.length;
+    while (low < high) {
+      final mid = (low + high) >> 1;
+      if (segments[mid].timeMs <= positionMs) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+    return (low - 1).clamp(0, segments.length - 1);
+  }
+}
+
+final class WebMaskPathData {
+  const WebMaskPathData({required this.data, required this.transform});
+
+  final String data;
+  final List<double> transform;
+}
+
+final class WebMaskFrameData {
+  const WebMaskFrameData({
+    required this.timeMs,
+    required this.viewBox,
+    required this.paths,
+  });
+
+  const WebMaskFrameData.invalid(this.timeMs) : viewBox = null, paths = null;
+
+  final int timeMs;
+  final List<double>? viewBox;
+  final List<WebMaskPathData>? paths;
+
+  bool get isValid => viewBox != null && paths != null;
+}
+
+final class WebMaskSegmentData {
+  const WebMaskSegmentData(this.frames);
+
+  final List<WebMaskFrameData> frames;
+
+  int frameFor(int positionMs) {
+    var low = 0;
+    var high = frames.length;
+    while (low < high) {
+      final mid = (low + high) >> 1;
+      if (frames[mid].timeMs <= positionMs) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+    return low - 1;
+  }
+}
+
+WebMaskHeader parseWebMaskHeader(Uint8List bytes) {
+  if (bytes.length < 16 || utf8.decode(bytes.sublist(0, 4)) != 'MASK') {
+    throw const FormatException('Invalid webmask header');
+  }
+  final data = ByteData.sublistView(bytes);
+  if (data.getInt32(4, Endian.big) != 1) {
+    throw const FormatException('Unsupported webmask version');
+  }
+  final segmentCount = data.getInt32(12, Endian.big);
+  if (segmentCount <= 0) {
+    throw const FormatException('Invalid webmask segment count');
+  }
+  return WebMaskHeader(segmentCount: segmentCount);
+}
+
+WebMaskIndex parseWebMaskIndex(Uint8List bytes, int totalLength) {
+  final header = parseWebMaskHeader(bytes);
+  final indexEnd = 16 + header.segmentCount * 16;
+  if (bytes.length < indexEnd || indexEnd >= totalLength) {
+    throw const FormatException('Invalid webmask index length');
+  }
+
+  final data = ByteData.sublistView(bytes);
+  final times = List<int>.filled(header.segmentCount, 0);
+  final offsets = List<int>.filled(header.segmentCount, 0);
+  for (var i = 0; i < header.segmentCount; i++) {
+    final offset = 16 + i * 16;
+    final timeMs = data.getInt64(offset, Endian.big);
+    final dataOffset = data.getInt64(offset + 8, Endian.big);
+    if (timeMs < 0 ||
+        (i != 0 && timeMs < times[i - 1]) ||
+        dataOffset < indexEnd ||
+        dataOffset >= totalLength ||
+        (i != 0 && dataOffset <= offsets[i - 1])) {
+      throw const FormatException('Invalid webmask segment index');
+    }
+    times[i] = timeMs;
+    offsets[i] = dataOffset;
+  }
+
+  return WebMaskIndex(
+    totalLength: totalLength,
+    segments: List.generate(header.segmentCount, (index) {
+      return WebMaskSegmentIndex(
+        timeMs: times[index],
+        start: offsets[index],
+        end: index + 1 == header.segmentCount
+            ? totalLength
+            : offsets[index + 1],
+      );
+    }, growable: false),
+  );
+}
+
+WebMaskSegmentData parseWebMaskSegment(Uint8List compressed) {
+  final decoded = Uint8List.fromList(
+    const GZipDecoder().decodeBytes(compressed),
+  );
+  final data = ByteData.sublistView(decoded);
+  final frames = <WebMaskFrameData>[];
+  var offset = 0;
+  var lastTimeMs = -1;
+
+  while (offset < decoded.length) {
+    if (decoded.length - offset < 12) {
+      throw const FormatException('Truncated webmask frame header');
+    }
+    final length = data.getInt32(offset, Endian.big);
+    final timeMs = data.getInt32(offset + 8, Endian.big);
+    final end = offset + 12 + length;
+    if (length < _dataUriPrefix.length ||
+        timeMs < lastTimeMs ||
+        end > decoded.length) {
+      throw const FormatException('Invalid webmask frame');
+    }
+
+    try {
+      final uri = utf8.decode(decoded.sublist(offset + 12, end));
+      if (!uri.startsWith(_dataUriPrefix)) {
+        throw const FormatException('Invalid webmask SVG data URI');
+      }
+      final svg = utf8.decode(
+        base64.decode(
+          uri.substring(_dataUriPrefix.length).replaceAll(_whitespace, ''),
+        ),
+      );
+      frames.add(_parseSvgFrame(timeMs, svg));
+    } catch (_) {
+      frames.add(WebMaskFrameData.invalid(timeMs));
+    }
+
+    lastTimeMs = timeMs;
+    offset = end;
+  }
+
+  if (frames.isEmpty) {
+    throw const FormatException('Empty webmask segment');
+  }
+  return WebMaskSegmentData(List.unmodifiable(frames));
+}
+
+WebMaskFrameData _parseSvgFrame(int timeMs, String source) {
+  final document = parseFragment(source);
+  final svg = document.querySelector('svg');
+  if (svg == null) throw const FormatException('Missing SVG root');
+
+  final viewBox = _numbers(svg.attributes['viewBox'] ?? '');
+  if (viewBox.length != 4 || viewBox[2] <= 0 || viewBox[3] <= 0) {
+    throw const FormatException('Invalid SVG viewBox');
+  }
+
+  final descendants = svg.querySelectorAll('*');
+  if (descendants.any((element) {
+    return element.localName != 'g' && element.localName != 'path';
+  })) {
+    throw const FormatException('Unsupported SVG element');
+  }
+
+  final paths = <WebMaskPathData>[];
+  for (final path in svg.querySelectorAll('path')) {
+    final pathData = path.attributes['d'];
+    if (pathData == null || pathData.isEmpty) continue;
+    paths.add(
+      WebMaskPathData(
+        data: pathData,
+        transform: List.unmodifiable(_elementTransform(path, svg)),
+      ),
+    );
+  }
+  if (paths.isEmpty) throw const FormatException('Empty SVG mask');
+
+  return WebMaskFrameData(
+    timeMs: timeMs,
+    viewBox: List.unmodifiable(viewBox),
+    paths: List.unmodifiable(paths),
+  );
+}
+
+List<double> _elementTransform(Element element, Element svg) {
+  final ancestors = <Element>[];
+  Element? current = element;
+  while (current != null) {
+    ancestors.add(current);
+    if (identical(current, svg)) break;
+    current = current.parent;
+  }
+  if (ancestors.lastOrNull != svg) {
+    throw const FormatException('Invalid SVG hierarchy');
+  }
+
+  var result = _identity;
+  for (final item in ancestors.reversed) {
+    final transform = item.attributes['transform'];
+    if (transform != null && transform.isNotEmpty) {
+      result = _multiply(result, _parseTransform(transform));
+    }
+  }
+  return result;
+}
+
+List<double> _parseTransform(String source) {
+  var result = _identity;
+  var end = 0;
+  for (final match in _transformExpression.allMatches(source)) {
+    if (source
+        .substring(end, match.start)
+        .trim()
+        .replaceAll(',', '')
+        .isNotEmpty) {
+      throw const FormatException('Invalid SVG transform');
+    }
+    final name = match.group(1)!;
+    final values = _numbers(match.group(2)!);
+    final List<double> matrix = switch (name) {
+      'matrix' when values.length == 6 => values,
+      'translate' when values.length == 1 => [1, 0, 0, 1, values[0], 0],
+      'translate' when values.length == 2 => [1, 0, 0, 1, ...values],
+      'scale' when values.length == 1 => [values[0], 0, 0, values[0], 0, 0],
+      'scale' when values.length == 2 => [values[0], 0, 0, values[1], 0, 0],
+      'rotate' when values.length == 1 => _rotation(values[0]),
+      'rotate' when values.length == 3 => _multiply(
+        _multiply([1, 0, 0, 1, values[1], values[2]], _rotation(values[0])),
+        [1, 0, 0, 1, -values[1], -values[2]],
+      ),
+      'skewX' when values.length == 1 => [
+        1,
+        0,
+        math.tan(values[0] * math.pi / 180),
+        1,
+        0,
+        0,
+      ],
+      'skewY' when values.length == 1 => [
+        1,
+        math.tan(values[0] * math.pi / 180),
+        0,
+        1,
+        0,
+        0,
+      ],
+      _ => throw const FormatException('Unsupported SVG transform'),
+    };
+    result = _multiply(result, matrix);
+    end = match.end;
+  }
+  if (end == 0 || source.substring(end).trim().replaceAll(',', '').isNotEmpty) {
+    throw const FormatException('Invalid SVG transform');
+  }
+  return result;
+}
+
+List<double> _rotation(double degrees) {
+  final radians = degrees * math.pi / 180;
+  final cosine = math.cos(radians);
+  final sine = math.sin(radians);
+  return [cosine, sine, -sine, cosine, 0, 0];
+}
+
+List<double> _multiply(List<double> left, List<double> right) {
+  return [
+    left[0] * right[0] + left[2] * right[1],
+    left[1] * right[0] + left[3] * right[1],
+    left[0] * right[2] + left[2] * right[3],
+    left[1] * right[2] + left[3] * right[3],
+    left[0] * right[4] + left[2] * right[5] + left[4],
+    left[1] * right[4] + left[3] * right[5] + left[5],
+  ];
+}
+
+List<double> _numbers(String source) {
+  return source
+      .trim()
+      .split(_numberSeparator)
+      .where((value) => value.isNotEmpty)
+      .map(double.parse)
+      .toList(growable: false);
+}
+
+const _identity = <double>[1, 0, 0, 1, 0, 0];

--- a/lib/pages/danmaku/mask/view.dart
+++ b/lib/pages/danmaku/mask/view.dart
@@ -1,0 +1,300 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:PiliPlus/pages/danmaku/mask/controller.dart';
+import 'package:flutter/foundation.dart' show ValueListenable;
+import 'package:material_ui/material_ui.dart';
+
+class DanmakuMaskView extends StatelessWidget {
+  const DanmakuMaskView({
+    required this.controller,
+    required this.videoRect,
+    required this.transformationController,
+    required this.devicePixelRatio,
+    required this.viewportSize,
+    required this.overlayOffset,
+    required this.fit,
+    required this.alignment,
+    required this.flipX,
+    required this.flipY,
+    required this.child,
+    this.forcedAspectRatio,
+    super.key,
+  });
+
+  final DanmakuMaskController controller;
+  final ValueListenable<ui.Rect?> videoRect;
+  final TransformationController transformationController;
+  final double devicePixelRatio;
+  final ui.Size viewportSize;
+  final ui.Offset overlayOffset;
+  final BoxFit fit;
+  final Alignment alignment;
+  final bool flipX;
+  final bool flipY;
+  final double? forcedAspectRatio;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListenableBuilder(
+      listenable: Listenable.merge([
+        controller.frame,
+        videoRect,
+        transformationController,
+      ]),
+      child: child,
+      builder: (context, child) {
+        final frame = controller.frame.value;
+        final rect = videoRect.value;
+        final DanmakuMaskClipper? clipper;
+        if (frame == null || rect == null || rect.isEmpty) {
+          clipper = null;
+        } else {
+          final logicalVideoSize = ui.Size(
+            rect.width / devicePixelRatio,
+            rect.height / devicePixelRatio,
+          );
+          clipper = DanmakuMaskClipper(
+            frame: frame,
+            videoSize: logicalVideoSize,
+            viewportSize: viewportSize,
+            overlayOffset: overlayOffset,
+            fit: fit,
+            alignment: alignment,
+            flipX: flipX,
+            flipY: flipY,
+            forcedAspectRatio: forcedAspectRatio,
+            interactiveTransform: Float64List.fromList(
+              transformationController.value.storage,
+            ),
+          );
+        }
+        return ClipPath(
+          clipBehavior: clipper == null ? Clip.none : Clip.antiAlias,
+          clipper: clipper,
+          child: child,
+        );
+      },
+    );
+  }
+}
+
+final class DanmakuMaskClipper extends CustomClipper<ui.Path> {
+  const DanmakuMaskClipper({
+    required this.frame,
+    required this.videoSize,
+    required this.viewportSize,
+    required this.overlayOffset,
+    required this.fit,
+    required this.alignment,
+    required this.flipX,
+    required this.flipY,
+    required this.interactiveTransform,
+    this.forcedAspectRatio,
+  });
+
+  final DanmakuMaskFrame frame;
+  final ui.Size videoSize;
+  final ui.Size viewportSize;
+  final ui.Offset overlayOffset;
+  final BoxFit fit;
+  final Alignment alignment;
+  final bool flipX;
+  final bool flipY;
+  final double? forcedAspectRatio;
+  final Float64List interactiveTransform;
+
+  @override
+  ui.Path getClip(ui.Size size) {
+    return DanmakuMaskGeometry.allowedPath(
+      frame: frame,
+      videoSize: videoSize,
+      viewportSize: viewportSize,
+      overlaySize: size,
+      overlayOffset: overlayOffset,
+      fit: fit,
+      alignment: alignment,
+      flipX: flipX,
+      flipY: flipY,
+      forcedAspectRatio: forcedAspectRatio,
+      interactiveTransform: interactiveTransform,
+    );
+  }
+
+  @override
+  bool shouldReclip(DanmakuMaskClipper oldClipper) =>
+      oldClipper.frame != frame ||
+      oldClipper.videoSize != videoSize ||
+      oldClipper.viewportSize != viewportSize ||
+      oldClipper.overlayOffset != overlayOffset ||
+      oldClipper.fit != fit ||
+      oldClipper.alignment != alignment ||
+      oldClipper.flipX != flipX ||
+      oldClipper.flipY != flipY ||
+      oldClipper.forcedAspectRatio != forcedAspectRatio ||
+      oldClipper.interactiveTransform != interactiveTransform;
+}
+
+abstract final class DanmakuMaskGeometry {
+  static ui.Path allowedPath({
+    required DanmakuMaskFrame frame,
+    required ui.Size videoSize,
+    required ui.Size viewportSize,
+    required ui.Size overlaySize,
+    required ui.Offset overlayOffset,
+    required BoxFit fit,
+    required Alignment alignment,
+    required bool flipX,
+    required bool flipY,
+    required Float64List interactiveTransform,
+    double? forcedAspectRatio,
+  }) {
+    final overlayRect = ui.Offset.zero & overlaySize;
+    if (videoSize.isEmpty || viewportSize.isEmpty || frame.viewBox.isEmpty) {
+      return ui.Path()..addRect(overlayRect);
+    }
+
+    try {
+      final effectiveVideoSize = forcedAspectRatio == null
+          ? videoSize
+          : ui.Size(videoSize.height * forcedAspectRatio, videoSize.height);
+      final fitted = applyBoxFit(fit, effectiveVideoSize, viewportSize);
+      final sourceRect = alignment.inscribe(
+        fitted.source,
+        ui.Offset.zero & effectiveVideoSize,
+      );
+      final destinationRect = alignment.inscribe(
+        fitted.destination,
+        ui.Offset.zero & viewportSize,
+      );
+      if (sourceRect.isEmpty || destinationRect.isEmpty) {
+        return ui.Path()..addRect(overlayRect);
+      }
+
+      final scaleX =
+          effectiveVideoSize.width /
+          frame.viewBox.width *
+          destinationRect.width /
+          sourceRect.width;
+      final scaleY =
+          effectiveVideoSize.height /
+          frame.viewBox.height *
+          destinationRect.height /
+          sourceRect.height;
+      final translateX =
+          destinationRect.left -
+          sourceRect.left * destinationRect.width / sourceRect.width -
+          frame.viewBox.left * scaleX;
+      final translateY =
+          destinationRect.top -
+          sourceRect.top * destinationRect.height / sourceRect.height -
+          frame.viewBox.top * scaleY;
+
+      var allowed = frame.allowedPath.transform(
+        _affine(scaleX, 0, 0, scaleY, translateX, translateY),
+      );
+      var video = ui.Path()..addRect(destinationRect);
+
+      if (flipX || flipY) {
+        final flip = _affine(
+          flipX ? -1 : 1,
+          0,
+          0,
+          flipY ? -1 : 1,
+          flipX ? viewportSize.width : 0,
+          flipY ? viewportSize.height : 0,
+        );
+        allowed = allowed.transform(flip);
+        video = video.transform(flip);
+      }
+      allowed = allowed.transform(interactiveTransform);
+      video = video.transform(interactiveTransform);
+
+      final viewport = ui.Path()..addRect(ui.Offset.zero & viewportSize);
+      final allowedInVideo = ui.Path.combine(
+        ui.PathOperation.intersect,
+        allowed,
+        video,
+      );
+      final outsideVideo = ui.Path.combine(
+        ui.PathOperation.difference,
+        viewport,
+        video,
+      );
+      var result = ui.Path.combine(
+        ui.PathOperation.union,
+        outsideVideo,
+        allowedInVideo,
+      );
+      if (overlayOffset != ui.Offset.zero) {
+        result = result.transform(
+          _affine(1, 0, 0, 1, -overlayOffset.dx, -overlayOffset.dy),
+        );
+      }
+      return ui.Path.combine(
+        ui.PathOperation.intersect,
+        result,
+        ui.Path()..addRect(overlayRect),
+      );
+    } catch (_) {
+      return ui.Path()..addRect(overlayRect);
+    }
+  }
+
+  static bool contains({
+    required ui.Offset position,
+    required DanmakuMaskFrame? frame,
+    required ui.Size videoSize,
+    required ui.Size viewportSize,
+    required BoxFit fit,
+    required Alignment alignment,
+    required bool flipX,
+    required bool flipY,
+    required Float64List interactiveTransform,
+    double? forcedAspectRatio,
+  }) {
+    if (frame == null) return true;
+    return allowedPath(
+      frame: frame,
+      videoSize: videoSize,
+      viewportSize: viewportSize,
+      overlaySize: viewportSize,
+      overlayOffset: ui.Offset.zero,
+      fit: fit,
+      alignment: alignment,
+      flipX: flipX,
+      flipY: flipY,
+      forcedAspectRatio: forcedAspectRatio,
+      interactiveTransform: interactiveTransform,
+    ).contains(position);
+  }
+}
+
+Float64List _affine(
+  double a,
+  double b,
+  double c,
+  double d,
+  double e,
+  double f,
+) {
+  return Float64List.fromList([
+    a,
+    b,
+    0,
+    0,
+    c,
+    d,
+    0,
+    0,
+    0,
+    0,
+    1,
+    0,
+    e,
+    f,
+    0,
+    1,
+  ]);
+}

--- a/lib/pages/setting/models/play_settings.dart
+++ b/lib/pages/setting/models/play_settings.dart
@@ -30,6 +30,13 @@ List<SettingsModel> get playSettings => [
     setKey: SettingBoxKey.enableShowDanmaku,
     defaultVal: true,
   ),
+  const SwitchModel(
+    title: '智能防挡',
+    subtitle: '让弹幕避开画面中的人物（部分视频支持）',
+    leading: Icon(Icons.person_off_outlined),
+    setKey: SettingBoxKey.enableDanmakuMask,
+    defaultVal: false,
+  ),
   if (PlatformUtils.isMobile)
     const SwitchModel(
       title: '启用点击弹幕',

--- a/lib/pages/video/controller.dart
+++ b/lib/pages/video/controller.dart
@@ -37,6 +37,7 @@ import 'package:PiliPlus/models_new/video/video_play_info/subtitle.dart';
 import 'package:PiliPlus/models_new/video/video_stein_edgeinfo/data.dart';
 import 'package:PiliPlus/pages/audio/view.dart';
 import 'package:PiliPlus/pages/common/publish/publish_route.dart';
+import 'package:PiliPlus/pages/danmaku/mask/controller.dart';
 import 'package:PiliPlus/pages/search/widgets/search_text.dart';
 import 'package:PiliPlus/pages/sponsor_block/block_mixin.dart';
 import 'package:PiliPlus/pages/video/download_panel/view.dart';
@@ -1030,6 +1031,7 @@ class VideoDetailController extends GetxController
   }
 
   RxList<Subtitle> subtitles = RxList<Subtitle>();
+  final danmakuMaskController = DanmakuMaskController();
   final Map<int, ({bool isData, String id})> vttSubtitles = {};
   late final vttSubtitlesIndex = (-1).obs;
   late final showVP = true.obs;
@@ -1102,6 +1104,7 @@ class VideoDetailController extends GetxController
   late bool continuePlayingPart = Pref.continuePlayingPart;
 
   Future<void> _queryPlayInfo() async {
+    final requestedCid = cid.value;
     vttSubtitles.clear();
     vttSubtitlesIndex.value = 0;
     if (plPlayerController.showViewPoints) {
@@ -1114,6 +1117,12 @@ class VideoDetailController extends GetxController
       epId: epId,
     );
     if (res case Success(:final response)) {
+      if (requestedCid == cid.value) {
+        final dmMask = response.dmMask;
+        danmakuMaskController.setSource(
+          dmMask?.cid == requestedCid ? dmMask : null,
+        );
+      }
       // interactive video
       late final introCtr = Get.find<UgcIntroController>(tag: heroTag);
       if (isUgc && graphVersion == null) {
@@ -1256,6 +1265,7 @@ class VideoDetailController extends GetxController
       ..dispose();
     subtitles.clear();
     vttSubtitles.clear();
+    danmakuMaskController.dispose();
     super.onClose();
   }
 
@@ -1271,6 +1281,7 @@ class VideoDetailController extends GetxController
 
     // danmaku
     savedDanmaku = null;
+    danmakuMaskController.setSource(null);
 
     // subtitle
     subtitles.clear();

--- a/lib/pages/video/view.dart
+++ b/lib/pages/video/view.dart
@@ -183,6 +183,7 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
 
   void positionListener(Duration position) {
     videoDetailController.playedTime = position;
+    videoDetailController.danmakuMaskController.updatePosition(position);
   }
 
   @override
@@ -413,6 +414,10 @@ class _VideoDetailPageVState extends State<VideoDetailPageV>
     PlPlayerController.setPlayCallBack(playCallBack);
 
     introController.startTimer();
+
+    videoDetailController.danmakuMaskController.syncEnabledFromPreference(
+      videoDetailController.plPlayerController.positionInMilliseconds,
+    );
 
     if (mounted &&
         Platform.isAndroid &&

--- a/lib/pages/video/widgets/header_control.dart
+++ b/lib/pages/video/widgets/header_control.dart
@@ -24,6 +24,7 @@ import 'package:PiliPlus/models/video/play/url.dart';
 import 'package:PiliPlus/models_new/video/video_play_info/subtitle.dart';
 import 'package:PiliPlus/pages/common/common_intro_controller.dart';
 import 'package:PiliPlus/pages/danmaku/danmaku_model.dart';
+import 'package:PiliPlus/pages/danmaku/mask/controller.dart';
 import 'package:PiliPlus/pages/setting/models/play_settings.dart'
     show showPlayerVolumeDialog;
 import 'package:PiliPlus/pages/setting/widgets/popup_item.dart';
@@ -329,6 +330,9 @@ class HeaderControlState extends State<HeaderControl>
   @override
   late final PlPlayerController plPlayerController = widget.controller;
   late final VideoDetailController videoDetailCtr = widget.videoDetailCtr;
+  @override
+  DanmakuMaskController? get danmakuMaskController =>
+      videoDetailCtr.isFileSource ? null : videoDetailCtr.danmakuMaskController;
   late final PlayUrlModel videoInfo = videoDetailCtr.data;
   static const TextStyle subTitleStyle = TextStyle(fontSize: 12);
   static const TextStyle titleStyle = TextStyle(fontSize: 14);

--- a/lib/pages/video/widgets/header_mixin.dart
+++ b/lib/pages/video/widgets/header_mixin.dart
@@ -1,5 +1,6 @@
 import 'package:PiliPlus/common/widgets/button/icon_button.dart';
 import 'package:PiliPlus/pages/video/introduction/ugc/widgets/menu_row.dart';
+import 'package:PiliPlus/pages/danmaku/mask/controller.dart';
 import 'package:PiliPlus/plugin/pl_player/controller.dart';
 import 'package:PiliPlus/plugin/pl_player/utils/danmaku_options.dart';
 import 'package:PiliPlus/utils/extension/num_ext.dart';
@@ -10,6 +11,8 @@ import 'package:material_ui/material_ui.dart';
 
 mixin HeaderMixin<T extends StatefulWidget> on State<T> {
   PlPlayerController get plPlayerController;
+
+  DanmakuMaskController? get danmakuMaskController => null;
 
   bool get isFullScreen => plPlayerController.isFullScreen.value;
 
@@ -61,6 +64,7 @@ mixin HeaderMixin<T extends StatefulWidget> on State<T> {
     ];
 
     final danmakuController = plPlayerController.danmakuController;
+    final maskController = danmakuMaskController;
 
     final isFullScreen = this.isFullScreen;
 
@@ -242,6 +246,20 @@ mixin HeaderMixin<T extends StatefulWidget> on State<T> {
                       child: Row(
                         spacing: 10,
                         children: [
+                          if (!isLive &&
+                              maskController != null &&
+                              maskController.available)
+                            ActionRowLineItem(
+                              selectStatus: maskController.enabled,
+                              onTap: () {
+                                maskController.setEnabled(
+                                  !maskController.enabled,
+                                  plPlayerController.positionInMilliseconds,
+                                );
+                                setState(() {});
+                              },
+                              text: '智能防挡',
+                            ),
                           ActionRowLineItem(
                             selectStatus: DanmakuOptions.danmakuMassiveMode,
                             onTap: () {

--- a/lib/plugin/pl_player/view/view.dart
+++ b/lib/plugin/pl_player/view/view.dart
@@ -28,6 +28,7 @@ import 'package:PiliPlus/models_new/video/video_detail/episode.dart' as ugc;
 import 'package:PiliPlus/models_new/video/video_detail/ugc_season.dart';
 import 'package:PiliPlus/pages/common/common_intro_controller.dart';
 import 'package:PiliPlus/pages/danmaku/danmaku_model.dart';
+import 'package:PiliPlus/pages/danmaku/mask/view.dart';
 import 'package:PiliPlus/pages/live_room/widgets/bottom_control.dart'
     as live_bottom;
 import 'package:PiliPlus/pages/video/controller.dart';
@@ -1162,6 +1163,11 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
     final ctr = plPlayerController.danmakuController;
     if (ctr != null) {
       final pos = details.localPosition;
+      if (!_isDanmakuPointVisible(pos)) {
+        _suspendedDm?.suspend = false;
+        _dmOffset.value = null;
+        return;
+      }
       final res = ctr.findSingleDanmaku(pos);
       if (res != null) {
         final (dy, item) = res;
@@ -1322,6 +1328,51 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
     }
   }
 
+  Widget _withDanmakuMask(Widget child) {
+    final controller = widget.videoDetailController?.danmakuMaskController;
+    if (controller == null) return child;
+    return Obx(() {
+      final videoFit = plPlayerController.videoFit.value;
+      return DanmakuMaskView(
+        controller: controller,
+        videoRect: videoController.rect,
+        transformationController: _transformationController,
+        devicePixelRatio: MediaQuery.devicePixelRatioOf(context),
+        viewportSize: Size(maxWidth, maxHeight),
+        overlayOffset: const Offset(0, 4),
+        fit: videoFit.boxFit,
+        alignment: widget.alignment,
+        flipX: plPlayerController.flipX.value,
+        flipY: plPlayerController.flipY.value,
+        forcedAspectRatio: videoFit.aspectRatio,
+        child: child,
+      );
+    });
+  }
+
+  bool _isDanmakuPointVisible(Offset position) {
+    final controller = widget.videoDetailController?.danmakuMaskController;
+    final rect = videoController.rect.value;
+    if (controller == null || rect == null || rect.isEmpty) return true;
+    final videoFit = plPlayerController.videoFit.value;
+    final devicePixelRatio = MediaQuery.devicePixelRatioOf(context);
+    return DanmakuMaskGeometry.contains(
+      position: position,
+      frame: controller.frame.value,
+      videoSize: Size(
+        rect.width / devicePixelRatio,
+        rect.height / devicePixelRatio,
+      ),
+      viewportSize: Size(maxWidth, maxHeight),
+      fit: videoFit.boxFit,
+      alignment: widget.alignment,
+      flipX: plPlayerController.flipX.value,
+      flipY: plPlayerController.flipY.value,
+      forcedAspectRatio: videoFit.aspectRatio,
+      interactiveTransform: _transformationController.value.storage,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     maxWidth = widget.maxWidth;
@@ -1345,7 +1396,7 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
         _videoWidget,
 
         if (widget.danmuWidget case final danmaku?)
-          Positioned.fill(top: 4, child: danmaku),
+          Positioned.fill(top: 4, child: _withDanmakuMask(danmaku)),
 
         if (!isLive)
           Positioned.fill(

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -193,6 +193,7 @@ abstract final class SettingBoxKey {
 
   static const String enableShowDanmaku = 'enableShowDanmaku',
       enableShowLiveDanmaku = 'enableShowLiveDanmaku',
+      enableDanmakuMask = 'enableDanmakuMask',
       pipNoDanmaku = 'pipNoDanmaku',
       showVipDanmaku = 'showVipDanmaku',
       mergeDanmaku = 'mergeDanmaku',

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -724,6 +724,9 @@ abstract final class Pref {
   static bool get enableShowLiveDanmaku =>
       _setting.get(SettingBoxKey.enableShowLiveDanmaku, defaultValue: true);
 
+  static bool get enableDanmakuMask =>
+      _setting.get(SettingBoxKey.enableDanmakuMask, defaultValue: false);
+
   static bool get enableQuickFav =>
       _setting.get(SettingBoxKey.enableQuickFav, defaultValue: false);
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1334,7 +1334,7 @@ packages:
     source: hosted
     version: "1.9.1"
   path_parsing:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_parsing
       sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -140,6 +140,7 @@ dependencies:
       ref: master
   package_info_plus: ^10.1.0
   path: ^1.9.1
+  path_parsing: ^1.1.0
   path_provider: ^2.1.5
   permission_handler_android: ^14.0.0
   permission_handler_apple: ^9.4.7


### PR DESCRIPTION
## 功能说明

为解决 #2749，新增基于视频弹幕蒙版的人像防挡功能。

功能开启后，存在蒙版的视频会自动获取并解析蒙版数据，并按照蒙版进行人像防挡；不存在有效蒙版的视频保持原有弹幕显示行为。

## 主要改动

- 解析视频播放信息中的 `dm_mask` 数据
- 按播放位置请求并解析 WebMask 索引和分段数据
- 根据播放器画面比例、对齐、翻转及交互变换映射蒙版
- 按照蒙版裁剪弹幕显示区域
- 在播放设置和播放器弹幕面板增加“智能防挡”开关
- 切换视频或拖动进度时取消过期请求并管理分段缓存
- 对瞬时请求失败进行一次重试

## 效果展示

### 开启智能防挡

<img width="1894" height="860" alt="开启后" src="https://github.com/user-attachments/assets/d7f4fea6-6a3d-478a-b821-b70b36441b7f" />

### 未开启智能防挡

<img width="2019" height="809" alt="开启前" src="https://github.com/user-attachments/assets/98d5dadb-a3d6-42b7-9519-904cc1134f95" />

### 播放设置入口

<img width="2550" height="1339" alt="设置页" src="https://github.com/user-attachments/assets/d65857d6-fe95-48b2-a37e-b953a8e195cd" />

## 验证

- 使用视频 `BV1Fg411D7Jy` 验证蒙版获取、解析及人像防挡效果
- 验证设置页和播放器内开关
- 验证关闭功能后恢复普通弹幕显示
- 本地相关自动化测试通过
- 本次修改涉及的文件无新增静态分析诊断

## CI 验证

[完整构建工作流](https://github.com/StarsWhere/PiliPlus/actions/runs/35294686530) 已在合并上游最新代码后的本 PR head 提交 `95cc1676f` 上执行完成，以下平台构建均通过：

- Android
- iOS
- macOS
- Windows x64
- Linux x64

<img width="1115" height="1169" alt="CI 全平台构建通过" src="https://github.com/user-attachments/assets/d4f73837-cd89-42c0-8efe-421500f6cbac" />

Closes #2749