### PR TITLE
feat: 支持扫码授权登录（用主账号为网页 / 电视端授权）

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -248,6 +248,7 @@
     </application>
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/lib/http/api.dart
+++ b/lib/http/api.dart
@@ -614,6 +614,20 @@ abstract final class Api {
   /// local_id
   static const getWebKey = '${HttpString.passBaseUrl}/x/passport-login/web/key';
 
+  // ===== Web 端扫码确认（用主账号凭证授权 Web 登录）=====
+
+  /// HD 端检查 Web 二维码
+  static const webQrcodeCheck =
+      '${HttpString.passBaseUrl}/x/passport-login/web/qrcode/check';
+
+  /// HD 端获取 Web 二维码场景
+  static const webQrcodeScene =
+      '${HttpString.passBaseUrl}/x/passport-login/web/qrcode/scene';
+
+  /// HD 端确认 Web 二维码
+  static const webQrcodeConfirm =
+      '${HttpString.passBaseUrl}/x/passport-login/web/qrcode/confirm';
+
   /// cookie转access_key
   static const qrcodeConfirm =
       '${HttpString.passBaseUrl}/x/passport-tv-login/h5/qrcode/confirm';

--- a/lib/http/scan_login.dart
+++ b/lib/http/scan_login.dart
@@ -1,0 +1,173 @@
+import 'package:PiliPlus/common/constants.dart';
+import 'package:PiliPlus/http/api.dart';
+import 'package:PiliPlus/http/init.dart';
+import 'package:PiliPlus/http/login.dart';
+import 'package:PiliPlus/utils/app_sign.dart';
+import 'package:dio/dio.dart';
+
+/// 扫码授权：用主账号（TV / HD 端登录得来）的凭证，替 Web 端或 TV 端完成登录确认。
+///
+/// 请求外观与 [LoginHttp] 完全一致 —— 走 HD（`android_hd`）通道：
+/// `app-key: android_hd`、HD UA、HD `statistics`、`build=2051100`，
+/// 签名用 HD appkey/appsec（[AppSign.appSign] 默认值）。
+///
+/// 两条硬性约束（实测）：
+///   1. 签名 appkey 必须与 access_key 签发端同源 —— 主账号是 TV 端登录得来，
+///      所以必须用 HD appkey 签名，用 App appkey 会返回 `-663 鉴权失败`；
+///   2. TV 端 confirm 的请求 UA 必须是 App 版 BiliDroid（见 [userAgentApp]），
+///      用 HD 版 UA 会返回 `86096 请使用最新版本扫码登录`（与签名 appkey 无关）。
+abstract final class ScanLoginHttp {
+  /// HD 通道请求头（与 [LoginHttp.headers] 同源）
+  static Map<String, String> get headers => LoginHttp.headers;
+
+  /// TV confirm 专用 UA：必须是 App 版 BiliDroid 且版本不能过低
+  static const String userAgentApp =
+      'Mozilla/5.0 BiliDroid/9.2.0 (bbcallen@gmail.com) 9.2.0 os/android '
+      'model/PJZ110 mobi_app/android build/9020300 '
+      'channel/oppo_tv.danmaku.bili_20200623 innerVer/9020310 osVer/16 network/2';
+
+  /// TV confirm 请求头：仅 UA 换成 App 版
+  static Map<String, String> get _tvHeaders => {
+    ...headers,
+    'user-agent': userAgentApp,
+    'Referer': 'https://account.bilibili.com/h5/account-h5/auth/scan-web',
+  };
+
+  /// Web 端确认的公共参数（HD 风格：不带 `mobi_app` / `platform`）
+  static Map<String, dynamic> _webParams({
+    required String accessKey,
+    required String csrf,
+    required String qrcodeKey,
+  }) => {
+    'access_key': accessKey,
+    'build': '2051100',
+    'csrf': csrf,
+    'disable_rcmd': '0',
+    'qrcode_key': qrcodeKey,
+    'statistics': Constants.statistics,
+  };
+
+  /// Web：检查二维码（鉴权核心 = access_key + csrf + sign）
+  static Future webQrcodeCheck({
+    required String accessKey,
+    required String csrf,
+    required String qrcodeKey,
+  }) async {
+    final params = _webParams(
+      accessKey: accessKey,
+      csrf: csrf,
+      qrcodeKey: qrcodeKey,
+    );
+    AppSign.appSign(params);
+    final res = await Request().get(
+      Api.webQrcodeCheck,
+      queryParameters: params,
+      options: Options(headers: headers),
+    );
+    return {
+      'code': res.data['code'],
+      'msg': res.data['message'],
+      'data': res.data['data'],
+    };
+  }
+
+  /// Web：取二维码场景（`data.transient` 表示是否需要二次确认）
+  static Future webQrcodeScene({
+    required String accessKey,
+    required String csrf,
+    required String qrcodeKey,
+  }) async {
+    final params = _webParams(
+      accessKey: accessKey,
+      csrf: csrf,
+      qrcodeKey: qrcodeKey,
+    );
+    AppSign.appSign(params);
+    final res = await Request().get(
+      Api.webQrcodeScene,
+      queryParameters: params,
+      options: Options(headers: headers),
+    );
+    return {
+      'code': res.data['code'],
+      'msg': res.data['message'],
+      'data': res.data['data'],
+    };
+  }
+
+  /// Web：确认二维码（Web 端随后自行 poll 领取登录态）
+  ///
+  /// `env_key` / `verify_code` / `verify_key` 为空串也必须参与签名
+  /// （编码成 `key=`），见 [AppSign]。
+  static Future webQrcodeConfirm({
+    required String accessKey,
+    required String csrf,
+    required String qrcodeKey,
+    required String transient,
+    String verifyType = 'verify_tel',
+  }) async {
+    final params = _webParams(
+      accessKey: accessKey,
+      csrf: csrf,
+      qrcodeKey: qrcodeKey,
+    )..addAll({
+      'env_key': '',
+      'transient': transient,
+      'verify_code': '',
+      'verify_key': '',
+      'verify_type': verifyType,
+    });
+    AppSign.appSign(params);
+    final res = await Request().post(
+      Api.webQrcodeConfirm,
+      data: params,
+      options: Options(
+        contentType: Headers.formUrlEncodedContentType,
+        headers: headers,
+      ),
+    );
+    return {
+      'code': res.data['code'],
+      'msg': res.data['message'],
+      'data': res.data['data'],
+    };
+  }
+
+  /// TV：确认二维码（TV 端随后自行 poll 领取登录态）
+  static Future tvConfirm({
+    required String accessKey,
+    required String authCode,
+    required String csrf,
+  }) async {
+    final params = {
+      'access_key': accessKey,
+      'auth_code': authCode,
+      'build': '2051100',
+      'csrf': csrf,
+      'disable_rcmd': '0',
+      'mobi_app': 'android',
+      'platform': 'android',
+      'statistics': Constants.statistics,
+    };
+    AppSign.appSign(params);
+    final res = await Request().post(
+      Api.qrcodeConfirm,
+      queryParameters: params,
+      options: Options(headers: _tvHeaders),
+    );
+    if (res.data['code'] == 0) {
+      return {
+        'status': true,
+        'data': res.data['data'],
+        'msg': res.data['message'],
+      };
+    } else {
+      return {
+        'status': false,
+        'code': res.data['code'],
+        'msg': res.data['message'],
+        'data': res.data['data'],
+      };
+    }
+  }
+}

--- a/lib/pages/mine/view.dart
+++ b/lib/pages/mine/view.dart
@@ -15,6 +15,7 @@ import 'package:PiliPlus/pages/login/controller.dart';
 import 'package:PiliPlus/pages/main/controller.dart';
 import 'package:PiliPlus/pages/mine/controller.dart';
 import 'package:PiliPlus/pages/mine/widgets/item.dart';
+import 'package:PiliPlus/pages/scan_login/controller.dart';
 import 'package:PiliPlus/utils/bili_utils.dart';
 import 'package:PiliPlus/utils/extension/get_ext.dart';
 import 'package:PiliPlus/utils/extension/num_ext.dart';
@@ -22,6 +23,7 @@ import 'package:PiliPlus/utils/extension/theme_ext.dart';
 import 'package:PiliPlus/utils/platform_utils.dart';
 import 'package:PiliPlus/utils/storage.dart';
 import 'package:PiliPlus/utils/utils.dart';
+import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:get/get.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
@@ -164,6 +166,20 @@ class _MediaPageState extends CommonPageState<MinePage>
               ),
               msgBadge(_mainController),
             ],
+            IconButton(
+              iconSize: iconSize,
+              padding: padding,
+              style: style,
+              tooltip: '扫码授权',
+              onPressed: () {
+                if (ScanLoginController.canScan) {
+                  Get.toNamed('/scanLogin');
+                } else {
+                  SmartDialog.showToast('请先登录后再使用扫码授权');
+                }
+              },
+              icon: const Icon(Icons.qr_code_scanner),
+            ),
             if (GStorage.reply != null)
               IconButton(
                 iconSize: iconSize,

--- a/lib/pages/scan_login/controller.dart
+++ b/lib/pages/scan_login/controller.dart
@@ -1,0 +1,139 @@
+import 'package:PiliPlus/http/scan_login.dart';
+import 'package:PiliPlus/utils/accounts.dart';
+import 'package:PiliPlus/utils/accounts/account.dart';
+import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
+import 'package:get/get.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+/// 扫码授权登录：用当前主账号（TV / HD 端凭证）扫描 B 站 Web / TV 登录二维码完成授权。
+class ScanLoginController {
+  final MobileScannerController scannerController = MobileScannerController(
+    formats: const [BarcodeFormat.qrCode],
+    detectionSpeed: DetectionSpeed.noDuplicates,
+  );
+
+  bool _handling = false;
+
+  void dispose() {
+    scannerController.dispose();
+  }
+
+  /// 取当前主账号：必须已登录且持有 access_key 才能代为授权
+  /// （Cookie 方式登录没有 access_key，无法签名授权）
+  static LoginAccount? get account {
+    final main = Accounts.main;
+    if (main is LoginAccount && (main.accessKey?.isNotEmpty ?? false)) {
+      return main;
+    }
+    return null;
+  }
+
+  static bool get canScan => account != null;
+
+  void onDetect(BarcodeCapture capture) {
+    if (_handling) return;
+    final raw = capture.barcodes.isEmpty
+        ? null
+        : capture.barcodes.first.rawValue;
+    if (raw == null || raw.isEmpty) return;
+    _handling = true;
+    _handle(raw).whenComplete(() => _handling = false);
+  }
+
+  Future<void> _handle(String raw) async {
+    final authCode = _extract(raw, 'auth_code');
+    final qrcodeKey = _extract(raw, 'qrcode_key');
+    if (authCode == null && qrcodeKey == null) {
+      SmartDialog.showToast('未识别到 B 站登录二维码');
+      return;
+    }
+
+    final current = account;
+    if (current == null) {
+      SmartDialog.showToast('请先用 TV 端 / HD 端扫码登录主账号');
+      return;
+    }
+    final accessKey = current.accessKey!;
+    final csrf = current.csrf;
+
+    if (authCode != null) {
+      await _confirmTv(accessKey, authCode, csrf);
+    } else if (qrcodeKey != null) {
+      await _confirmWeb(accessKey, qrcodeKey, csrf);
+    }
+  }
+
+  static String? _extract(String raw, String name) {
+    final uri = Uri.tryParse(raw);
+    if (uri != null && uri.hasQuery) {
+      final value = uri.queryParameters[name];
+      if (value != null && value.isNotEmpty) return value;
+    }
+    final match = RegExp('$name=([0-9a-zA-Z]+)').firstMatch(raw);
+    return match?.group(1);
+  }
+
+  /// TV 端授权：确认后由 TV 端自行轮询领取登录态
+  Future<void> _confirmTv(
+    String accessKey,
+    String authCode,
+    String csrf,
+  ) async {
+    SmartDialog.showLoading(msg: '正在授权 TV 登录…');
+    final res = await ScanLoginHttp.tvConfirm(
+      accessKey: accessKey,
+      authCode: authCode,
+      csrf: csrf,
+    );
+    SmartDialog.dismiss();
+    if (res['status'] == true) {
+      SmartDialog.showToast('TV 扫码授权成功');
+      Get.back();
+    } else {
+      SmartDialog.showToast('授权失败：${res['msg']}（${res['code']}）');
+    }
+  }
+
+  /// Web 端授权：check → scene → confirm，Web 端自行轮询领取登录态
+  Future<void> _confirmWeb(
+    String accessKey,
+    String qrcodeKey,
+    String csrf,
+  ) async {
+    SmartDialog.showLoading(msg: '正在授权网页登录…');
+    final check = await ScanLoginHttp.webQrcodeCheck(
+      accessKey: accessKey,
+      csrf: csrf,
+      qrcodeKey: qrcodeKey,
+    );
+    if (check['code'] != 0) {
+      SmartDialog.dismiss();
+      SmartDialog.showToast('扫码确认失败：${check['msg']}（${check['code']}）');
+      return;
+    }
+    final scene = await ScanLoginHttp.webQrcodeScene(
+      accessKey: accessKey,
+      csrf: csrf,
+      qrcodeKey: qrcodeKey,
+    );
+    if (scene['code'] != 0) {
+      SmartDialog.dismiss();
+      SmartDialog.showToast('扫码确认失败：${scene['msg']}（${scene['code']}）');
+      return;
+    }
+    final data = scene['data'] as Map?;
+    final confirm = await ScanLoginHttp.webQrcodeConfirm(
+      accessKey: accessKey,
+      csrf: csrf,
+      qrcodeKey: qrcodeKey,
+      transient: data?['transient'] == true ? 'true' : 'false',
+    );
+    SmartDialog.dismiss();
+    if (confirm['code'] == 0) {
+      SmartDialog.showToast('网页扫码授权成功');
+      Get.back();
+    } else {
+      SmartDialog.showToast('确认失败：${confirm['msg']}（${confirm['code']}）');
+    }
+  }
+}

--- a/lib/pages/scan_login/view.dart
+++ b/lib/pages/scan_login/view.dart
@@ -1,0 +1,101 @@
+import 'package:PiliPlus/common/widgets/scaffold/simple_scaffold.dart';
+import 'package:PiliPlus/pages/scan_login/controller.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+class ScanLoginPage extends StatefulWidget {
+  const ScanLoginPage({super.key});
+
+  @override
+  State<ScanLoginPage> createState() => _ScanLoginPageState();
+}
+
+class _ScanLoginPageState extends State<ScanLoginPage> {
+  final ScanLoginController _controller = ScanLoginController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SimpleScaffold(
+      appBar: AppBar(title: const Text('扫码授权')),
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          MobileScanner(
+            controller: _controller.scannerController,
+            onDetect: _controller.onDetect,
+            errorBuilder: (context, error) => Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(
+                      Icons.no_photography_outlined,
+                      size: 56,
+                      color: Colors.grey,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      '无法使用相机，请在系统设置中授权后重试\n$error',
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(color: Colors.grey),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          const _ScanOverlay(),
+        ],
+      ),
+    );
+  }
+}
+
+class _ScanOverlay extends StatelessWidget {
+  const _ScanOverlay();
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: Column(
+        children: [
+          const Spacer(flex: 2),
+          Center(
+            child: Container(
+              width: 250,
+              height: 250,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(
+                  color: Theme.of(context).colorScheme.primary,
+                  width: 3,
+                ),
+              ),
+            ),
+          ),
+          const Spacer(),
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 24, vertical: 48),
+            child: Text(
+              '对准 B 站网页 / 电视端的登录二维码\n'
+              '将用当前主账号（TV 端凭证）授权登录',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 15,
+                shadows: [Shadow(color: Colors.black54, blurRadius: 6)],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/router/app_pages.dart
+++ b/lib/router/app_pages.dart
@@ -49,6 +49,7 @@ import 'package:PiliPlus/pages/music/view.dart';
 import 'package:PiliPlus/pages/my_reply/view.dart';
 import 'package:PiliPlus/pages/popular_precious/view.dart';
 import 'package:PiliPlus/pages/popular_series/view.dart';
+import 'package:PiliPlus/pages/scan_login/view.dart';
 import 'package:PiliPlus/pages/search/view.dart';
 import 'package:PiliPlus/pages/search_result/view.dart';
 import 'package:PiliPlus/pages/search_trending/view.dart';
@@ -138,6 +139,8 @@ class Routes {
     GetPage(name: '/sysMsg', page: () => const SysMsgPage()),
     // 登录页面
     GetPage(name: '/loginPage', page: () => const LoginPage()),
+    // 扫码授权登录
+    GetPage(name: '/scanLogin', page: () => const ScanLoginPage()),
     // 用户动态
     GetPage(name: '/memberDynamics', page: () => const MemberDynamicsPage()),
     // 日志

--- a/lib/utils/app_sign.dart
+++ b/lib/utils/app_sign.dart
@@ -36,7 +36,9 @@ abstract final class AppSign {
       result.write(separator);
       separator = '&';
       result.write(Uri.encodeComponent(key));
-      if (value != null && value.isNotEmpty) {
+      // 空字符串同样参与签名，必须编码为 key= （等号不能省略），
+      // 否则 web/qrcode/confirm 等接口会返回「签名错误」
+      if (value != null) {
         result
           ..write('=')
           ..write(Uri.encodeComponent(value));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -134,6 +134,7 @@ dependencies:
   media_kit_libs_video: 1.0.5
   media_kit_video: 1.2.5
   mime: ^2.0.0
+  mobile_scanner: ^7.4.1
   native_device_orientation:
     git:
       url: https://github.com/bggRGjQaUbCoE/flutter_native_device_orientation.git


### PR DESCRIPTION
新增「扫码授权」页：用当前已登录主账号的 access_key，为网页端 / 电视端的
登录二维码完成确认授权。本机登录态不变，凭证由对方端自行轮询领取。

- lib/http/scan_login.dart：ScanLoginHttp
  * Web：web/qrcode/{check,scene,confirm}
  * TV ：passport-tv-login/h5/qrcode/confirm 复用 HD 通道外观（appkey/UA/statistics/build）与 AppSign 默认签名。
- lib/pages/scan_login/{view,controller}.dart：基于 mobile_scanner 的扫码页
- lib/pages/mine/view.dart：「我的」页 header 新增常显入口（未登录时提示先登录）
- lib/router/app_pages.dart：注册 /scanLogin
- lib/http/api.dart：新增 webQrcodeCheck / webQrcodeScene / webQrcodeConfirm
- pubspec.yaml：mobile_scanner ^7.4.1；AndroidManifest.xml：CAMERA 权限

两条实测得出的硬性约束（已在代码注释中说明）：
1. 签名 appkey 必须与 access_key 的签发端同源，否则 web/qrcode/check 返回 -663 鉴权失败（HD 凭证必须配 HD appkey；scene 不校验 appkey，不能当判据）。
2. TV confirm 的请求 UA 必须是 App 版 BiliDroid，用 HD 版 UA 会返回 86096 请使用最新版本扫码登录（与签名 appkey 无关）。

fix: AppSign 空字符串参数必须编码为 key= 参与签名

web/qrcode/confirm 需要传 env_key/verify_code/verify_key 空串，原实现对 空字符串直接跳过 `=`，导致签名错误。改为 `if (value != null)`。
## 实测

- 环境：Android 15 真机（SM-F731N / arm64-v8a），release APK。
- 网页端、电视端各完整跑通一遍：`generate → check(0) → scene(0) → confirm(0)`，对端 poll 成功并拿到登录态。
- 未登录时点入口会提示「请先登录后再使用扫码授权」；登录后入口常显，不需要杀进程重启。

## 已知局限

- Cookie 方式登录的账号没有 `access_key`，无法代为签名授权，只能引导用户先用 HD/TV 扫码登录。
- 只做「确认授权」；网页端的多域 SSO（`legacy/login/sso`）无需处理，网页自己 poll 就会拿到登录态。

## 基线

基于 main `47e94b33b`。当前 main 相对该基线的 2 个 commit 未触及本 PR 涉及文件，`mergeable_state: clean`。

## 其他

若认为新增 `mobile_scanner` 依赖不合适，也可以只取 `lib/http/scan_login.dart` + `lib/utils/app_sign.dart` 两处，扫码输入改由调用方提供。
