### PR TITLE
feat: 动态页支持全部关注 UP 的更新红点

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,5 @@ pili_release.json
 dist
 
 test*
+!test/
+!test/**/*.dart

--- a/lib/http/dynamics.dart
+++ b/lib/http/dynamics.dart
@@ -27,6 +27,7 @@ import 'package:PiliPlus/models_new/dynamic/dyn_topic_top/top_details.dart';
 import 'package:PiliPlus/models_new/dynamic/dyn_topic_top/topic_item.dart';
 import 'package:PiliPlus/models_new/followee_votes/vote.dart';
 import 'package:PiliPlus/utils/accounts.dart';
+import 'package:PiliPlus/utils/parse_int.dart';
 import 'package:PiliPlus/utils/utils.dart';
 import 'package:PiliPlus/utils/wbi_sign.dart';
 import 'package:dio/dio.dart';
@@ -101,76 +102,54 @@ abstract final class DynamicsHttp {
     }
   }
 
-  /// 按 B 站动态流的更新基线收集新增动态作者。
+  /// 按本地动态 id 基线收集新增动态的作者。
   ///
-  /// 首次调用没有基线时只返回服务端当前基线，避免把历史动态全部标为未读；
-  /// 后续调用会按 `update_num` 翻页，确保低频访问 UP 的更新也能进入红点列表。
+  /// 动态流接口虽然接受 `update_baseline` 参数并返回 `update_num`，但实测该字段在
+  /// 传入基线后恒为字符串 `'0'`、与基线深浅无关，因此「哪些动态算新」改由客户端判定：
+  /// 把服务端返回的 `update_baseline`（代表「此刻」的截止线）存下来，下次只取回动态 id
+  /// 严格大于该截止线的记录即可，无需再向接口传参。
+  ///
+  /// 这里固定读综合动态流（`type=all`）而不是按模式切换流：实测同一时间窗内，综合流中
+  /// `DYNAMIC_TYPE_AV` 的集合与视频流（`type=video`）返回的集合完全一致，所以一次请求
+  /// 就能同时支撑「所有动态」与「仅视频」两种展示，且后者天然是前者的子集。
+  ///
+  /// 翻页与截断规则本身位于 [DynamicUpUpdateResult.scan]，此处只负责取页，
+  /// 使同一套规则可以用真实抓包数据离线回归。
+  ///
+  /// [backfillPages] 只在首次启用（本地还没有基线）时生效：先取若干页作为回补，
+  /// 避免刚开启功能后红点长时间为空；基线仍推进到「此刻」，回补内容不会被重复计入。
+  /// [maxPages] 是已有基线时的翻页上限，防止长时间未检查导致请求无限翻页。
   static Future<LoadingState<DynamicUpUpdateResult>> followDynamicUpdates({
     required String? updateBaseline,
-    required DynamicsTabType type,
+    int backfillPages = 0,
+    int maxPages = 8,
   }) async {
-    String? offset;
-    String? nextBaseline;
-    int remaining = 0;
-    bool firstPage = true;
-    final updatedUps = <int, UpItem>{};
-
-    while (true) {
-      final res = await Request().get(
-        Api.followDynamic,
-        queryParameters: {
-          if (updateBaseline?.isNotEmpty == true)
-            'update_baseline': updateBaseline,
-          if (offset?.isNotEmpty == true) 'offset': offset,
-          'type': type.name,
-          'features': Constants.dynFeatures,
-        },
-      );
-      if (res.data['code'] != 0) {
-        return Error(res.data['message']);
-      }
-
-      final page = DynamicUpUpdatePage.fromJson(res.data['data']);
-      if (firstPage) {
-        nextBaseline = page.updateBaseline;
-        // 首次启用只建立基线，不展示此前积累的历史更新。
-        if (updateBaseline?.isNotEmpty != true) {
-          return Success(
-            DynamicUpUpdateResult(
-              updateBaseline: nextBaseline,
-              updatedUps: const [],
-            ),
-          );
+    // 取页失败时暂存服务端返回的错误信息，供上层提示用户。
+    dynamic errorMessage;
+    final result = await DynamicUpUpdateResult.scan(
+      baselineId: safeToInt(updateBaseline) ?? 0,
+      backfillPages: backfillPages,
+      maxPages: maxPages,
+      loadPage: (offset) async {
+        final res = await Request().get(
+          Api.followDynamic,
+          queryParameters: {
+            if (offset?.isNotEmpty == true) 'offset': offset,
+            'type': DynamicsTabType.all.name,
+            'features': Constants.dynFeatures,
+          },
+        );
+        if (res.data['code'] != 0) {
+          errorMessage = res.data['message'];
+          return null;
         }
-        // 服务端正常值为非负数；异常负值按无更新处理，避免分页截取越界。
-        remaining = page.updateNum > 0 ? page.updateNum : 0;
-        firstPage = false;
-      }
-
-      remaining = DynamicUpUpdateResult.collectPage(
-        updatedUps,
-        page,
-        remaining,
-      );
-
-      final nextOffset = page.offset;
-      if (remaining <= 0 ||
-          !page.hasMore ||
-          page.itemCount == 0 ||
-          nextOffset == null ||
-          nextOffset.isEmpty ||
-          nextOffset == offset) {
-        break;
-      }
-      offset = nextOffset;
-    }
-
-    return Success(
-      DynamicUpUpdateResult(
-        updateBaseline: nextBaseline,
-        updatedUps: updatedUps.values.toList(),
-      ),
+        return DynamicUpUpdatePage.fromJson(res.data['data']);
+      },
     );
+    if (result == null) {
+      return Error(errorMessage ?? '获取更新动态失败');
+    }
+    return Success(result);
   }
 
   static Future<LoadingState<FollowUpModel>> followings({

--- a/lib/http/dynamics.dart
+++ b/lib/http/dynamics.dart
@@ -101,6 +101,78 @@ abstract final class DynamicsHttp {
     }
   }
 
+  /// 按 B 站动态流的更新基线收集新增动态作者。
+  ///
+  /// 首次调用没有基线时只返回服务端当前基线，避免把历史动态全部标为未读；
+  /// 后续调用会按 `update_num` 翻页，确保低频访问 UP 的更新也能进入红点列表。
+  static Future<LoadingState<DynamicUpUpdateResult>> followDynamicUpdates({
+    required String? updateBaseline,
+    required DynamicsTabType type,
+  }) async {
+    String? offset;
+    String? nextBaseline;
+    int remaining = 0;
+    bool firstPage = true;
+    final updatedUps = <int, UpItem>{};
+
+    while (true) {
+      final res = await Request().get(
+        Api.followDynamic,
+        queryParameters: {
+          if (updateBaseline?.isNotEmpty == true)
+            'update_baseline': updateBaseline,
+          if (offset?.isNotEmpty == true) 'offset': offset,
+          'type': type.name,
+          'features': Constants.dynFeatures,
+        },
+      );
+      if (res.data['code'] != 0) {
+        return Error(res.data['message']);
+      }
+
+      final page = DynamicUpUpdatePage.fromJson(res.data['data']);
+      if (firstPage) {
+        nextBaseline = page.updateBaseline;
+        // 首次启用只建立基线，不展示此前积累的历史更新。
+        if (updateBaseline?.isNotEmpty != true) {
+          return Success(
+            DynamicUpUpdateResult(
+              updateBaseline: nextBaseline,
+              updatedUps: const [],
+            ),
+          );
+        }
+        // 服务端正常值为非负数；异常负值按无更新处理，避免分页截取越界。
+        remaining = page.updateNum > 0 ? page.updateNum : 0;
+        firstPage = false;
+      }
+
+      remaining = DynamicUpUpdateResult.collectPage(
+        updatedUps,
+        page,
+        remaining,
+      );
+
+      final nextOffset = page.offset;
+      if (remaining <= 0 ||
+          !page.hasMore ||
+          page.itemCount == 0 ||
+          nextOffset == null ||
+          nextOffset.isEmpty ||
+          nextOffset == offset) {
+        break;
+      }
+      offset = nextOffset;
+    }
+
+    return Success(
+      DynamicUpUpdateResult(
+        updateBaseline: nextBaseline,
+        updatedUps: updatedUps.values.toList(),
+      ),
+    );
+  }
+
   static Future<LoadingState<FollowUpModel>> followings({
     int? vmid,
     int? pn,

--- a/lib/models/common/dynamic/dynamic_up_list_mode.dart
+++ b/lib/models/common/dynamic/dynamic_up_list_mode.dart
@@ -13,3 +13,12 @@ enum DynamicUpListMode implements EnumWithLabel {
   final String label;
   const DynamicUpListMode(this.label);
 }
+
+extension DynamicUpListModeBadge on DynamicUpListMode {
+  /// 该模式是否展示某个红点。
+  ///
+  /// 「仅视频」只展示确知最新动态是视频投稿的红点；由官方常看列表带入的红点没有动态
+  /// 类型信息（[isVideo] 为 null），因此不会被该模式展示，避免把只发图文的 UP 标红。
+  bool showsBadge(bool? isVideo) =>
+      this != DynamicUpListMode.video || isVideo == true;
+}

--- a/lib/models/common/dynamic/dynamic_up_list_mode.dart
+++ b/lib/models/common/dynamic/dynamic_up_list_mode.dart
@@ -1,0 +1,15 @@
+import 'package:PiliPlus/models/common/enum_with_label.dart';
+
+/// 控制动态页 UP 主列表范围，以及全部关注模式下红点所代表的动态类型。
+enum DynamicUpListMode implements EnumWithLabel {
+  frequent('常看（官方红点）'),
+  all('全部关注（所有动态）'),
+  video('全部关注（仅视频，含动态小视频）');
+
+  /// 只有扩展模式才需要拉取完整关注列表并维护本地更新基线。
+  bool get showAllFollowed => this != frequent;
+
+  @override
+  final String label;
+  const DynamicUpListMode(this.label);
+}

--- a/lib/models/dynamics/up.dart
+++ b/lib/models/dynamics/up.dart
@@ -1,4 +1,3 @@
-import 'package:PiliPlus/models_new/follow/list.dart';
 import 'package:PiliPlus/utils/parse_int.dart';
 
 class FollowUpModel {
@@ -36,7 +35,7 @@ class FollowUpModel {
 
   FollowUpModel.fromFollowList(Map<String, dynamic> json) {
     upList = (json['list'] as List?)
-        ?.map((e) => FollowItemModel.fromJson(e))
+        ?.map((e) => UpItem.fromJson(e))
         .toList();
   }
 }
@@ -78,12 +77,14 @@ class LiveUserItem extends UpItem {
 class UpItem {
   String? face;
   bool? hasUpdate;
+  int? latestUpdateAt;
   late int mid;
   String? uname;
 
   UpItem({
     this.face,
     this.hasUpdate,
+    this.latestUpdateAt,
     required this.mid,
     this.uname,
   });
@@ -91,8 +92,18 @@ class UpItem {
   UpItem.fromJson(Map<String, dynamic> json) {
     face = json['face'];
     hasUpdate = json['has_update'];
+    latestUpdateAt = safeToInt(json['latest_update_at']);
     mid = safeToInt(json['mid']) ?? 0;
     uname = json['uname'];
+  }
+
+  /// 从动态流的作者模块构建 UP，用于补齐官方“常看”列表之外的更新作者。
+  UpItem.fromDynamicAuthor(Map<String, dynamic> json) {
+    face = json['face'];
+    hasUpdate = true;
+    latestUpdateAt = safeToInt(json['pub_ts']);
+    mid = safeToInt(json['mid']) ?? 0;
+    uname = json['name'];
   }
 
   @override
@@ -101,4 +112,86 @@ class UpItem {
 
   @override
   int get hashCode => mid.hashCode;
+}
+
+/// 动态流单页携带的更新基线及作者摘要。
+class DynamicUpUpdatePage {
+  DynamicUpUpdatePage.fromJson(Map<String, dynamic> json) {
+    updateBaseline = json['update_baseline']?.toString();
+    updateNum = safeToInt(json['update_num']) ?? 0;
+    offset = json['offset']?.toString();
+    hasMore = json['has_more'] == true;
+
+    final rawItems = json['items'] as List?;
+    if (rawItems == null) return;
+    // 个别响应缺少显式基线时，以首条动态 ID 作为下一次检查基线。
+    if (updateBaseline?.isNotEmpty != true && rawItems.isNotEmpty) {
+      final firstItem = rawItems.first;
+      if (firstItem is Map) updateBaseline = firstItem['id_str']?.toString();
+    }
+    for (final rawItem in rawItems) {
+      final modules = rawItem is Map ? rawItem['modules'] : null;
+      final author = modules is Map ? modules['module_author'] : null;
+      // 动态流还可能包含番剧等非关注作者，只为明确处于关注状态的 UP 标红。
+      if (author is Map && author['following'] == true) {
+        final up = UpItem.fromDynamicAuthor(
+          Map<String, dynamic>.from(author),
+        );
+        items.add(up.mid > 0 ? up : null);
+      } else {
+        // 保留空位，确保按 `update_num` 截取时与服务端动态条数严格对齐。
+        items.add(null);
+      }
+    }
+  }
+
+  String? updateBaseline;
+  int updateNum = 0;
+  String? offset;
+  bool hasMore = false;
+  int get itemCount => items.length;
+  final List<UpItem?> items = <UpItem?>[];
+}
+
+/// 一次更新检查的完整结果；同一 UP 发布多条动态时只保留一份作者信息。
+class DynamicUpUpdateResult {
+  const DynamicUpUpdateResult({
+    required this.updateBaseline,
+    required this.updatedUps,
+  });
+
+  final String? updateBaseline;
+  final List<UpItem> updatedUps;
+
+  /// 收集当前页仍处于更新范围内的作者，并返回尚待读取的动态条数。
+  static int collectPage(
+    Map<int, UpItem> updatedUps,
+    DynamicUpUpdatePage page,
+    int remaining,
+  ) {
+    for (final up in page.items.take(remaining)) {
+      // 动态流按时间倒序，首次出现的记录就是该 UP 最新的一条更新。
+      if (up != null) updatedUps.putIfAbsent(up.mid, () => up);
+    }
+    // `update_num` 统计的是动态条数，不是去重后的作者数。
+    return remaining - page.itemCount;
+  }
+
+  /// 将有更新的 UP 按最新发布时间倒序置顶，未更新 UP 保持接口原顺序。
+  static void sortUnreadFirst(List<UpItem> upList) {
+    final updated = upList.indexed
+        .where((entry) => entry.$2.hasUpdate == true)
+        .toList();
+    final unchanged = upList.where((up) => up.hasUpdate != true).toList();
+    updated.sort((a, b) {
+      final timeOrder = (b.$2.latestUpdateAt ?? 0).compareTo(
+        a.$2.latestUpdateAt ?? 0,
+      );
+      return timeOrder != 0 ? timeOrder : a.$1.compareTo(b.$1);
+    });
+    upList
+      ..clear()
+      ..addAll(updated.map((entry) => entry.$2))
+      ..addAll(unchanged);
+  }
 }

--- a/lib/models/dynamics/up.dart
+++ b/lib/models/dynamics/up.dart
@@ -81,12 +81,20 @@ class UpItem {
   late int mid;
   String? uname;
 
+  /// 该 UP 最新一条动态是否为视频投稿。
+  ///
+  /// 接口不返回该字段，它由动态流的动态类型推导而来，只服务于本地红点的
+  /// 「仅视频」筛选；持久化时落在 `is_video` 上，null 表示尚不可知
+  /// （例如来自官方常看列表、没有类型信息的红点）。
+  bool? isVideo;
+
   UpItem({
     this.face,
     this.hasUpdate,
     this.latestUpdateAt,
     required this.mid,
     this.uname,
+    this.isVideo,
   });
 
   UpItem.fromJson(Map<String, dynamic> json) {
@@ -95,16 +103,33 @@ class UpItem {
     latestUpdateAt = safeToInt(json['latest_update_at']);
     mid = safeToInt(json['mid']) ?? 0;
     uname = json['uname'];
+    // 仅用于读取本地红点缓存，接口本身不会下发该键。
+    isVideo = json['is_video'] == true ? true : null;
   }
 
   /// 从动态流的作者模块构建 UP，用于补齐官方“常看”列表之外的更新作者。
-  UpItem.fromDynamicAuthor(Map<String, dynamic> json) {
+  UpItem.fromDynamicAuthor(Map<String, dynamic> json, {this.isVideo}) {
     face = json['face'];
     hasUpdate = true;
     latestUpdateAt = safeToInt(json['pub_ts']);
     mid = safeToInt(json['mid']) ?? 0;
     uname = json['name'];
   }
+
+  /// 判断作者是否处于关注状态。
+  ///
+  /// 服务端对 `module_author.following` 的下发形态并不统一：既可能是布尔 `true`，
+  /// 也可能是整数 `1`（实测动态流返回的就是整数 1）。早期实现写作
+  /// `following == true`，在整数 1 上恒为 false，使每条动态都被当成番剧等
+  /// 非关注作者过滤掉，红点增量于是永久为空。这里同时接受两种形态。
+  static bool isFollowingAuthor(dynamic following) =>
+      following == true || following == 1;
+
+  /// 判断动态类型是否为视频投稿（含以动态形式发布的小视频）。
+  ///
+  /// 实测在同一时间窗内，综合动态流里 `DYNAMIC_TYPE_AV` 的集合与视频流
+  /// （`type=video`）返回的集合完全一致，因此这里可以替代再发一次视频流请求。
+  static bool isVideoDynamicType(dynamic type) => type == 'DYNAMIC_TYPE_AV';
 
   @override
   bool operator ==(Object other) =>
@@ -114,44 +139,80 @@ class UpItem {
   int get hashCode => mid.hashCode;
 }
 
-/// 动态流单页携带的更新基线及作者摘要。
+/// 动态流中的单条记录：保留动态 id 与已关注作者摘要。
+///
+/// 动态 id 是随时间单调递增的雪花号，因此「动态 id 严格大于本地基线」可以
+/// 自证「是否为新动态」。之所以不沿用接口的 `update_num`：实测该字段在有基线
+/// 时恒为字符串 `'0'`，与基线深浅无关，按它截取条数只会得到空集。
+class DynamicUpdateEntry {
+  const DynamicUpdateEntry({required this.dynamicId, this.up});
+
+  /// 动态 id；缺失或解析失败按 0 处理，视为早于任何基线。
+  final int dynamicId;
+
+  /// 仅当作者处于关注状态且 mid 有效时非空，番剧、直播推荐等记录为 null。
+  final UpItem? up;
+}
+
+/// 动态流单页：一次更新检查所需的分页信息与作者摘要。
 class DynamicUpUpdatePage {
   DynamicUpUpdatePage.fromJson(Map<String, dynamic> json) {
     updateBaseline = json['update_baseline']?.toString();
-    updateNum = safeToInt(json['update_num']) ?? 0;
     offset = json['offset']?.toString();
     hasMore = json['has_more'] == true;
 
     final rawItems = json['items'] as List?;
     if (rawItems == null) return;
-    // 个别响应缺少显式基线时，以首条动态 ID 作为下一次检查基线。
-    if (updateBaseline?.isNotEmpty != true && rawItems.isNotEmpty) {
-      final firstItem = rawItems.first;
-      if (firstItem is Map) updateBaseline = firstItem['id_str']?.toString();
-    }
     for (final rawItem in rawItems) {
-      final modules = rawItem is Map ? rawItem['modules'] : null;
-      final author = modules is Map ? modules['module_author'] : null;
-      // 动态流还可能包含番剧等非关注作者，只为明确处于关注状态的 UP 标红。
-      if (author is Map && author['following'] == true) {
-        final up = UpItem.fromDynamicAuthor(
-          Map<String, dynamic>.from(author),
-        );
-        items.add(up.mid > 0 ? up : null);
-      } else {
-        // 保留空位，确保按 `update_num` 截取时与服务端动态条数严格对齐。
-        items.add(null);
+      if (rawItem is! Map) {
+        entries.add(const DynamicUpdateEntry(dynamicId: 0));
+        continue;
       }
+      final modules = rawItem['modules'];
+      final author = modules is Map ? modules['module_author'] : null;
+      UpItem? up;
+      // 动态流可能混入番剧、直播推荐等非关注作者，只为关注中的 UP 标红。
+      if (author is Map && UpItem.isFollowingAuthor(author['following'])) {
+        final parsed = UpItem.fromDynamicAuthor(
+          Map<String, dynamic>.from(author),
+          isVideo: UpItem.isVideoDynamicType(rawItem['type']),
+        );
+        if (parsed.mid > 0) up = parsed;
+      }
+      entries.add(
+        DynamicUpdateEntry(
+          dynamicId: safeToInt(rawItem['id_str']) ?? 0,
+          up: up,
+        ),
+      );
     }
   }
 
+  /// 服务端给出的当前基线，代表「此刻」对应的动态 id，用作下一次检查的截止线。
   String? updateBaseline;
-  int updateNum = 0;
   String? offset;
   bool hasMore = false;
-  int get itemCount => items.length;
-  final List<UpItem?> items = <UpItem?>[];
+  final List<DynamicUpdateEntry> entries = <DynamicUpdateEntry>[];
+
+  int get itemCount => entries.length;
+
+  /// 本页最后一条动态的 id；用于判断本页是否已经越过基线。
+  int? get lastId => entries.isEmpty ? null : entries.last.dynamicId;
+
+  /// 本页最大的动态 id；服务端未下发基线时用它兜底。
+  ///
+  /// 不能直接取首条 id：置顶动态（is_top）会以较早的 id 排在最前面。
+  int get maxId {
+    var max = 0;
+    for (final entry in entries) {
+      if (entry.dynamicId > max) max = entry.dynamicId;
+    }
+    return max;
+  }
 }
+
+/// 动态流取页回调；[offset] 为空表示取第一页，返回 null 表示取页失败。
+typedef DynamicPageLoader = Future<DynamicUpUpdatePage?> Function(String? offset);
 
 /// 一次更新检查的完整结果；同一 UP 发布多条动态时只保留一份作者信息。
 class DynamicUpUpdateResult {
@@ -163,18 +224,100 @@ class DynamicUpUpdateResult {
   final String? updateBaseline;
   final List<UpItem> updatedUps;
 
-  /// 收集当前页仍处于更新范围内的作者，并返回尚待读取的动态条数。
-  static int collectPage(
+  /// 收集本页中动态 id 严格大于 [baselineId] 的已关注作者。
+  ///
+  /// [baselineId] 为 0 表示首次启用后的回补，此时本页所有已关注作者都计入。
+  /// 同一 UP 出现多条新动态时只保留发布时间最新的一条。
+  static void collectPage(
     Map<int, UpItem> updatedUps,
     DynamicUpUpdatePage page,
-    int remaining,
+    int baselineId,
   ) {
-    for (final up in page.items.take(remaining)) {
-      // 动态流按时间倒序，首次出现的记录就是该 UP 最新的一条更新。
-      if (up != null) updatedUps.putIfAbsent(up.mid, () => up);
+    for (final entry in page.entries) {
+      if (baselineId > 0 && entry.dynamicId <= baselineId) continue;
+      final up = entry.up;
+      if (up == null) continue;
+      final old = updatedUps[up.mid];
+      if (old == null || (up.latestUpdateAt ?? 0) > (old.latestUpdateAt ?? 0)) {
+        updatedUps[up.mid] = up;
+      }
     }
-    // `update_num` 统计的是动态条数，不是去重后的作者数。
-    return remaining - page.itemCount;
+  }
+
+  /// 本页是否已越过基线（末条动态不晚于基线即说明增量已收完）。
+  static bool passedBaseline(DynamicUpUpdatePage page, int baselineId) {
+    final last = page.lastId;
+    return last == null || last <= baselineId;
+  }
+
+  /// 按动态 id 基线扫描新增作者的纯逻辑，与网络实现解耦。
+  ///
+  /// 解耦的目的是让这套翻页/截断规则可以被真实抓包数据直接驱动，而不必依赖设备联网，
+  /// 从而避免「单测全绿但线上拿不到红点」的情况再次发生。
+  ///
+  /// [baselineId] 为 0 表示首次启用（本地还没有基线）：此时按 [backfillPages] 回补最近
+  /// 若干页，并把基线锁定到「此刻」对应的动态 id；否则只收集晚于基线的动态，最多翻
+  /// [maxPages] 页，遇到末条不晚于基线的页即停止。
+  ///
+  /// 任意一页取页失败都返回 null，调用方必须保留原基线重试，避免这期间的新动态被跳过。
+  /// [maxPages] 是已有基线时的翻页上限，防止长时间未检查导致请求无限翻页。
+  /// 按当前关注规模，一页约覆盖 1.5 小时的综合动态流，8 页可覆盖半天左右的离开时长；
+  /// 超出部分不会被标为未读（基线仍推进到「此刻」），代价是放弃「很久没看」的陈旧更新，
+  /// 换取动态页首屏不会被几十次串行请求拖慢。
+  static Future<DynamicUpUpdateResult?> scan({
+    required DynamicPageLoader loadPage,
+    required int baselineId,
+    int backfillPages = 0,
+    int maxPages = 8,
+  }) async {
+    final isInitial = baselineId <= 0;
+    // 首次启用且要求回补时，本页全部已关注作者都计入未读；否则只收晚于基线的。
+    final collectAll = isInitial && backfillPages > 0;
+    // 首次启用即使不回补也至少要取一页，用于把基线推进到此刻。
+    final pageLimit = isInitial
+        ? (backfillPages < 1 ? 1 : backfillPages)
+        : maxPages;
+
+    final updatedUps = <int, UpItem>{};
+    String? offset;
+    String? nextBaseline;
+
+    for (var page = 0; page < pageLimit; page++) {
+      final data = await loadPage(offset);
+      if (data == null) return null;
+      if (data.itemCount == 0) break;
+
+      // 首次取页时锁定本次基线；服务端没有下发时用本页最大动态 id 兜底。
+      if (nextBaseline == null) {
+        final serverBaseline = data.updateBaseline;
+        if (serverBaseline?.isNotEmpty == true) {
+          nextBaseline = serverBaseline;
+        } else if (data.maxId > 0) {
+          nextBaseline = data.maxId.toString();
+        }
+      }
+
+      collectPage(
+        updatedUps,
+        data,
+        collectAll ? 0 : baselineId,
+      );
+
+      final nextOffset = data.offset;
+      if (!data.hasMore || nextOffset == null || nextOffset.isEmpty) {
+        break;
+      }
+      // 已有基线时，本页末条不晚于基线即说明增量已经收完。
+      if (!isInitial && passedBaseline(data, baselineId)) {
+        break;
+      }
+      offset = nextOffset;
+    }
+
+    return DynamicUpUpdateResult(
+      updateBaseline: nextBaseline,
+      updatedUps: updatedUps.values.toList(),
+    );
   }
 
   /// 将有更新的 UP 按最新发布时间倒序置顶，未更新 UP 保持接口原顺序。

--- a/lib/pages/dynamics/controller.dart
+++ b/lib/pages/dynamics/controller.dart
@@ -40,8 +40,18 @@ class DynamicsController
   /// 标记当前已载入缓存的账号，避免账号切换后串用未读状态。
   int? _badgeAccountMid;
 
-  /// 仅在首次建立“所有动态”基线时接收一次官方已有红点。
+  /// 仅在首次建立更新基线时接收一次官方已有红点，避免切换到全量模式后红点先变少。
   bool _preserveOfficialBadges = false;
+
+  /// 首次启用某模式时回补的页数：基线刚建立时增量必然为空，回补可避免「红点全没了」的观感。
+  static const _initialBackfillPages = 2;
+
+  /// 本地红点缓存键版本。
+  ///
+  /// v1 按模式分桶，且基线是配合服务端 `update_num` 推进的，而该字段实测恒为 `'0'`，
+  /// 那份基线已不能代表「已读到哪一条」；v3 起红点集合不再按模式分桶（两种模式共用
+  /// 一份增量，只按视频与否筛选），因此升级键名强制丢弃旧状态、重新建立基线。
+  static const _badgeCacheVersion = 'v3';
 
   final upPanelPosition = Pref.upPanelPosition;
 
@@ -159,9 +169,9 @@ class DynamicsController
   }
 
   String _badgeCacheKey(String prefix) =>
-      '$prefix:${Accounts.main.mid}:${_upListMode.name}';
+      '$prefix.$_badgeCacheVersion:${Accounts.main.mid}';
 
-  /// 从账号与模式隔离的缓存恢复尚未点开的 UP 更新。
+  /// 从账号隔离的缓存恢复尚未点开的 UP 更新。
   void _loadUnreadUps() {
     final accountMid = Accounts.main.mid;
     if (_badgeAccountMid == accountMid) return;
@@ -195,6 +205,7 @@ class DynamicsController
             'uname': up.uname,
             'has_update': true,
             'latest_update_at': up.latestUpdateAt,
+            'is_video': up.isVideo,
           },
         )
         .toList(),
@@ -205,15 +216,12 @@ class DynamicsController
     try {
       _loadUnreadUps();
       final accountMid = Accounts.main.mid;
-      final baselineKey =
-          '${LocalCacheKey.dynamicUpBaseline}:$accountMid:${_upListMode.name}';
+      final baselineKey = _badgeCacheKey(LocalCacheKey.dynamicUpBaseline);
       final baseline = GStorage.localCache.get(baselineKey);
       final isInitialBaseline = baseline is! String || baseline.isEmpty;
       final res = await DynamicsHttp.followDynamicUpdates(
         updateBaseline: baseline is String ? baseline : null,
-        type: _upListMode == DynamicUpListMode.video
-            ? DynamicsTabType.video
-            : DynamicsTabType.all,
+        backfillPages: isInitialBaseline ? _initialBackfillPages : 0,
       );
       // 账号在请求期间发生切换时丢弃旧结果，避免污染新账号缓存。
       if (Accounts.main.mid != accountMid) return;
@@ -221,6 +229,8 @@ class DynamicsController
         _preserveOfficialBadges = isInitialBaseline;
         for (final up in response.updatedUps) {
           final old = _unreadUps[up.mid];
+          // 动态流条目带发布时间（pub_ts），官方常看带入的红点没有时间戳，
+          // 于是任何一次真实更新都能覆盖掉「类型未知」的旧条目，补上视频标记。
           if (old == null ||
               (up.latestUpdateAt ?? 0) > (old.latestUpdateAt ?? 0)) {
             _unreadUps[up.mid] = up;
@@ -237,6 +247,12 @@ class DynamicsController
     }
   }
 
+  /// 「仅视频」模式下只有确知最新动态是视频投稿的 UP 才展示红点。
+  ///
+  /// 由官方常看列表带入的红点没有动态类型信息（[UpItem.isVideo] 为 null），
+  /// 因此不会被该模式展示，避免把只发了图文的 UP 也标红。
+  bool _matchesBadgeMode(UpItem up) => _upListMode.showsBadge(up.isVideo);
+
   /// 将本地未读状态覆盖到列表，并把新更新但不常看的 UP 提到列表前方。
   void _applyUnreadUps(FollowUpModel data, {required bool includeMissing}) {
     if (!_showAllUp) return;
@@ -244,8 +260,9 @@ class DynamicsController
 
     final upList = data.upList ??= <UpItem>[];
     bool shouldSave = false;
-    if (_upListMode == DynamicUpListMode.all && _preserveOfficialBadges) {
-      // 首次切换到“所有动态”时保留官方已经判定的常看 UP 红点。
+    if (_preserveOfficialBadges) {
+      // 首次建立更新基线时先继承官方已经判定的常看 UP 红点，避免切换模式后红点先变少；
+      // 这些条目没有动态类型，只会出现在「所有动态」模式里。
       for (final up in upList.where((up) => up.hasUpdate == true)) {
         if (!_unreadUps.containsKey(up.mid)) {
           _unreadUps[up.mid] = up;
@@ -257,12 +274,14 @@ class DynamicsController
     final currentUps = <int, UpItem>{for (final up in upList) up.mid: up};
     for (final up in upList) {
       final unread = _unreadUps[up.mid];
-      up.hasUpdate = unread != null;
-      if (unread != null) up.latestUpdateAt = unread.latestUpdateAt;
+      final visible = unread != null && _matchesBadgeMode(unread);
+      up.hasUpdate = visible;
+      if (visible) up.latestUpdateAt = unread.latestUpdateAt;
     }
     if (includeMissing) {
       final missing = _unreadUps.values
           .where((up) => !currentUps.containsKey(up.mid))
+          .where(_matchesBadgeMode)
           .toList();
       upList.insertAll(0, missing);
       DynamicUpUpdateResult.sortUnreadFirst(upList);

--- a/lib/pages/dynamics/controller.dart
+++ b/lib/pages/dynamics/controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:PiliPlus/http/dynamics.dart';
 import 'package:PiliPlus/http/loading_state.dart';
+import 'package:PiliPlus/models/common/dynamic/dynamic_up_list_mode.dart';
 import 'package:PiliPlus/models/common/dynamic/dynamics_type.dart';
 import 'package:PiliPlus/models/dynamics/up.dart';
 import 'package:PiliPlus/pages/common/common_data_controller.dart';
@@ -10,6 +11,8 @@ import 'package:PiliPlus/services/account_service.dart';
 import 'package:PiliPlus/utils/accounts.dart';
 import 'package:PiliPlus/utils/extension/scroll_controller_ext.dart';
 import 'package:PiliPlus/utils/extension/string_ext.dart';
+import 'package:PiliPlus/utils/storage.dart';
+import 'package:PiliPlus/utils/storage_key.dart';
 import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:easy_debounce/easy_throttle.dart';
 import 'package:get/get.dart';
@@ -28,7 +31,17 @@ class DynamicsController
   Set<UpItem>? _cacheUpList;
   late int hostMid = -1, currentMid = -1;
   late bool showLiveUp = Pref.expandDynLivePanel;
-  late final _showAllUp = Pref.dynamicsShowAllFollowedUp;
+  late final DynamicUpListMode _upListMode = Pref.dynamicUpListMode;
+  late final bool _showAllUp = _upListMode.showAllFollowed;
+
+  /// 本地维护的未读作者同时保存头像与昵称，使“不常看”UP 无需等关注列表翻页即可展示。
+  final Map<int, UpItem> _unreadUps = <int, UpItem>{};
+
+  /// 标记当前已载入缓存的账号，避免账号切换后串用未读状态。
+  int? _badgeAccountMid;
+
+  /// 仅在首次建立“所有动态”基线时接收一次官方已有红点。
+  bool _preserveOfficialBadges = false;
 
   final upPanelPosition = Pref.upPanelPosition;
 
@@ -138,12 +151,146 @@ class DynamicsController
   }
 
   @override
-  void onChangeAccount(bool isLogin) => onReload();
+  void onChangeAccount(bool isLogin) {
+    _badgeAccountMid = null;
+    _unreadUps.clear();
+    _preserveOfficialBadges = false;
+    onReload();
+  }
+
+  String _badgeCacheKey(String prefix) =>
+      '$prefix:${Accounts.main.mid}:${_upListMode.name}';
+
+  /// 从账号与模式隔离的缓存恢复尚未点开的 UP 更新。
+  void _loadUnreadUps() {
+    final accountMid = Accounts.main.mid;
+    if (_badgeAccountMid == accountMid) return;
+
+    _badgeAccountMid = accountMid;
+    _unreadUps.clear();
+    final cached = GStorage.localCache.get(
+      _badgeCacheKey(LocalCacheKey.dynamicUpUnread),
+    );
+    if (cached is! List) return;
+    for (final item in cached) {
+      if (item is Map) {
+        try {
+          final up = UpItem.fromJson(Map<String, dynamic>.from(item));
+          if (up.mid > 0) _unreadUps[up.mid] = up;
+        } catch (_) {
+          // 单条旧缓存损坏时跳过，不能阻断整个动态页加载。
+        }
+      }
+    }
+  }
+
+  /// 持久化未读作者，保证应用重启后红点仍保留到用户点开该 UP。
+  Future<void> _saveUnreadUps() => GStorage.localCache.put(
+    _badgeCacheKey(LocalCacheKey.dynamicUpUnread),
+    _unreadUps.values
+        .map(
+          (up) => <String, dynamic>{
+            'mid': up.mid,
+            'face': up.face,
+            'uname': up.uname,
+            'has_update': true,
+            'latest_update_at': up.latestUpdateAt,
+          },
+        )
+        .toList(),
+  );
+
+  /// 使用动态流更新基线补齐官方常看列表之外的红点。
+  Future<void> _refreshUnreadUps() async {
+    try {
+      _loadUnreadUps();
+      final accountMid = Accounts.main.mid;
+      final baselineKey =
+          '${LocalCacheKey.dynamicUpBaseline}:$accountMid:${_upListMode.name}';
+      final baseline = GStorage.localCache.get(baselineKey);
+      final isInitialBaseline = baseline is! String || baseline.isEmpty;
+      final res = await DynamicsHttp.followDynamicUpdates(
+        updateBaseline: baseline is String ? baseline : null,
+        type: _upListMode == DynamicUpListMode.video
+            ? DynamicsTabType.video
+            : DynamicsTabType.all,
+      );
+      // 账号在请求期间发生切换时丢弃旧结果，避免污染新账号缓存。
+      if (Accounts.main.mid != accountMid) return;
+      if (res case Success(:final response)) {
+        _preserveOfficialBadges = isInitialBaseline;
+        for (final up in response.updatedUps) {
+          final old = _unreadUps[up.mid];
+          if (old == null ||
+              (up.latestUpdateAt ?? 0) > (old.latestUpdateAt ?? 0)) {
+            _unreadUps[up.mid] = up;
+          }
+        }
+        await Future.wait([
+          if (response.updateBaseline?.isNotEmpty == true)
+            GStorage.localCache.put(baselineKey, response.updateBaseline),
+          _saveUnreadUps(),
+        ]);
+      }
+    } catch (_) {
+      // 补充红点失败时沿用缓存，主动态列表和官方常看列表仍应正常加载。
+    }
+  }
+
+  /// 将本地未读状态覆盖到列表，并把新更新但不常看的 UP 提到列表前方。
+  void _applyUnreadUps(FollowUpModel data, {required bool includeMissing}) {
+    if (!_showAllUp) return;
+    _loadUnreadUps();
+
+    final upList = data.upList ??= <UpItem>[];
+    bool shouldSave = false;
+    if (_upListMode == DynamicUpListMode.all && _preserveOfficialBadges) {
+      // 首次切换到“所有动态”时保留官方已经判定的常看 UP 红点。
+      for (final up in upList.where((up) => up.hasUpdate == true)) {
+        if (!_unreadUps.containsKey(up.mid)) {
+          _unreadUps[up.mid] = up;
+          shouldSave = true;
+        }
+      }
+      _preserveOfficialBadges = false;
+    }
+    final currentUps = <int, UpItem>{for (final up in upList) up.mid: up};
+    for (final up in upList) {
+      final unread = _unreadUps[up.mid];
+      up.hasUpdate = unread != null;
+      if (unread != null) up.latestUpdateAt = unread.latestUpdateAt;
+    }
+    if (includeMissing) {
+      final missing = _unreadUps.values
+          .where((up) => !currentUps.containsKey(up.mid))
+          .toList();
+      upList.insertAll(0, missing);
+      DynamicUpUpdateResult.sortUnreadFirst(upList);
+    }
+    if (shouldSave) unawaited(_saveUnreadUps());
+  }
+
+  /// 点开 UP 后仅清除此人的本地红点，其他未读更新保持不变。
+  void markUpRead(UpItem item) {
+    item.hasUpdate = false;
+    if (_showAllUp && _unreadUps.remove(item.mid) != null) {
+      unawaited(_saveUnreadUps());
+      if (loadingState.value case Success(:final response)) {
+        final upList = response.upList;
+        if (upList != null) {
+          DynamicUpUpdateResult.sortUnreadFirst(upList);
+          loadingState.refresh();
+        }
+      }
+    }
+  }
 
   @override
-  Future<LoadingState<FollowUpModel>> customGetData() {
+  Future<LoadingState<FollowUpModel>> customGetData() async {
     if (_offset == null) {
-      return DynamicsHttp.followUp();
+      final portal = DynamicsHttp.followUp();
+      if (_showAllUp) await _refreshUnreadUps();
+      return portal;
     }
     if (_showAllUp) {
       return DynamicsHttp.followings(
@@ -166,6 +313,8 @@ class DynamicsController
   @override
   bool customHandleResponse(bool isRefresh, Success<FollowUpModel> response) {
     final res = response.response;
+
+    _applyUnreadUps(res, includeMissing: isRefresh);
 
     if (_showAllUp) {
       if (res.upList?.isNotEmpty != true) {

--- a/lib/pages/dynamics/controller.dart
+++ b/lib/pages/dynamics/controller.dart
@@ -290,17 +290,14 @@ class DynamicsController
   }
 
   /// 点开 UP 后仅清除此人的本地红点，其他未读更新保持不变。
+  ///
+  /// 这里刻意不立刻重排列表：点了哪个 UP 就让哪个 UP 原地消掉红点，位置统一留到下一次
+  /// 刷新时由 [applyUnreadUps] 调整。否则刚点过的 UP 会从指下跳到「有更新」与
+  /// 「无更新」的分界线上，和「常看」模式的表现也不一致。
   void markUpRead(UpItem item) {
     item.hasUpdate = false;
     if (_showAllUp && _unreadUps.remove(item.mid) != null) {
       unawaited(_saveUnreadUps());
-      if (loadingState.value case Success(:final response)) {
-        final upList = response.upList;
-        if (upList != null) {
-          DynamicUpUpdateResult.sortUnreadFirst(upList);
-          loadingState.refresh();
-        }
-      }
     }
   }
 

--- a/lib/pages/dynamics/widgets/up_panel.dart
+++ b/lib/pages/dynamics/widgets/up_panel.dart
@@ -129,8 +129,9 @@ class _UpPanelState extends State<UpPanel> {
   }
 
   void _onSelect(UpItem item) {
-    item.hasUpdate = false;
-    controller.onSelectUp(item.mid);
+    controller
+      ..markUpRead(item)
+      ..onSelectUp(item.mid);
     setState(() {});
   }
 

--- a/lib/pages/setting/models/style_settings.dart
+++ b/lib/pages/setting/models/style_settings.dart
@@ -11,6 +11,7 @@ import 'package:PiliPlus/common/widgets/scroll_physics.dart'
 import 'package:PiliPlus/common/widgets/stateful_builder.dart';
 import 'package:PiliPlus/models/common/bar_hide_type.dart';
 import 'package:PiliPlus/models/common/dynamic/dynamic_badge_mode.dart';
+import 'package:PiliPlus/models/common/dynamic/dynamic_up_list_mode.dart';
 import 'package:PiliPlus/models/common/dynamic/up_panel_position.dart';
 import 'package:PiliPlus/models/common/home_tab_type.dart';
 import 'package:PiliPlus/models/common/msg/msg_unread_type.dart';
@@ -163,12 +164,12 @@ List<SettingsModel> get styleSettings => [
       SmartDialog.showToast('重启生效');
     },
   ),
-  const SwitchModel(
-    title: '动态页显示所有已关注UP主',
-    leading: Icon(Icons.people_alt_outlined),
-    setKey: SettingBoxKey.dynamicsShowAllFollowedUp,
-    defaultVal: false,
-    needReboot: true,
+  PopupModel(
+    title: '动态页UP主与更新红点',
+    leading: const Icon(Icons.people_alt_outlined),
+    value: () => Pref.dynamicUpListMode,
+    items: DynamicUpListMode.values,
+    onSelected: _setDynamicUpListMode,
   ),
   const SwitchModel(
     title: '动态页展开正在直播UP列表',
@@ -691,6 +692,19 @@ void _setDynBadge(DynamicBadgeMode value, VoidCallback setState) {
   GStorage.setting
       .put(SettingBoxKey.dynamicBadgeMode, value.index)
       .whenComplete(setState);
+}
+
+/// 保存动态页 UP 主范围；页面控制器在重启后会按新模式建立独立更新基线。
+void _setDynamicUpListMode(
+  DynamicUpListMode value,
+  VoidCallback setState,
+) {
+  GStorage.setting
+      .put(SettingBoxKey.dynamicUpListMode, value.index)
+      .whenComplete(() {
+        setState();
+        SmartDialog.showToast('重启生效');
+      });
 }
 
 Future<void> _setMsgBadge(DynamicBadgeMode value, VoidCallback setState) async {

--- a/lib/utils/settings_sync.dart
+++ b/lib/utils/settings_sync.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+
+import 'package:hive_ce/hive.dart';
+
+/// 负责设置 Box 的序列化与恢复，不依赖任何平台或 UI 实现。
+abstract final class SettingsSync {
+  static const _jsonEncoder = JsonEncoder.withIndent('    ');
+
+  /// 导出设置与视频配置，字段结构保持现有 WebDAV 载荷不变。
+  static String export(Box<dynamic> setting, Box<dynamic> video) {
+    return _jsonEncoder.convert({
+      setting.name: setting.toMap(),
+      video.name: video.toMap(),
+    });
+  }
+
+  /// 从 JSON 字符串恢复设置；解析成功后沿用原有的整 Box 替换规则。
+  static Future<List<void>> import(
+    String data,
+    Box<dynamic> setting,
+    Box<dynamic> video,
+  ) {
+    return importMap(jsonDecode(data), setting, video);
+  }
+
+  /// 用同一份快照分别替换设置与视频 Box，避免新旧配置混合。
+  static Future<List<void>> importMap(
+    Map<String, dynamic> map,
+    Box<dynamic> setting,
+    Box<dynamic> video,
+  ) {
+    return Future.wait([
+      setting.clear().then((_) => setting.putAll(map[setting.name])),
+      video.clear().then((_) => video.putAll(map[video.name])),
+    ]);
+  }
+}

--- a/lib/utils/storage.dart
+++ b/lib/utils/storage.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:PiliPlus/models/model_owner.dart';
@@ -10,8 +9,8 @@ import 'package:PiliPlus/utils/accounts/account_type_adapter.dart';
 import 'package:PiliPlus/utils/accounts/cookie_jar_adapter.dart';
 import 'package:PiliPlus/utils/path_utils.dart';
 import 'package:PiliPlus/utils/set_int_adapter.dart';
+import 'package:PiliPlus/utils/settings_sync.dart';
 import 'package:PiliPlus/utils/storage_pref.dart';
-import 'package:PiliPlus/utils/utils.dart';
 import 'package:hive_ce/hive.dart';
 import 'package:path/path.dart' as path;
 
@@ -77,24 +76,14 @@ abstract final class GStorage {
     }
   }
 
-  static String exportAllSettings() {
-    return Utils.jsonEncoder.convert({
-      setting.name: setting.toMap(),
-      video.name: video.toMap(),
-    });
-  }
+  static String exportAllSettings() => SettingsSync.export(setting, video);
 
   static Future<void> importAllSettings(String data) =>
-      importAllJsonSettings(jsonDecode(data));
+      SettingsSync.import(data, setting, video);
 
   static Future<List<void>> importAllJsonSettings(
     Map<String, dynamic> map,
-  ) {
-    return Future.wait([
-      setting.clear().then((_) => setting.putAll(map[setting.name])),
-      video.clear().then((_) => video.putAll(map[video.name])),
-    ]);
-  }
+  ) => SettingsSync.importMap(map, setting, video);
 
   static void regAdapter() {
     Hive

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -225,6 +225,7 @@ abstract final class SettingBoxKey {
       dynamicsWaterfallFlow = 'dynamicsWaterfallFlow',
       upPanelPosition = 'upPanelPosition',
       dynamicsShowAllFollowedUp = 'dynamicsShowAllFollowedUp',
+      dynamicUpListMode = 'dynamicUpListMode',
       useSideBar = 'useSideBar',
       enableMYBar = 'enableMYBar',
       hideTopBar = 'hideSearchBar',
@@ -246,6 +247,8 @@ abstract final class LocalCacheKey {
   static const String historyPause = 'historyPause',
       blackMids = 'blackMids',
       danmakuFilterRules = 'danmakuFilterRules',
+      dynamicUpBaseline = 'dynamicUpBaseline',
+      dynamicUpUnread = 'dynamicUpUnread',
       mixinKey = 'mixinKey',
       timeStamp = 'timeStamp',
       buvid = 'buvid';

--- a/lib/utils/storage_pref.dart
+++ b/lib/utils/storage_pref.dart
@@ -6,6 +6,7 @@ import 'package:PiliPlus/common/widgets/pair.dart';
 import 'package:PiliPlus/http/constants.dart';
 import 'package:PiliPlus/models/common/bar_hide_type.dart';
 import 'package:PiliPlus/models/common/dynamic/dynamic_badge_mode.dart';
+import 'package:PiliPlus/models/common/dynamic/dynamic_up_list_mode.dart';
 import 'package:PiliPlus/models/common/dynamic/dynamics_type.dart';
 import 'package:PiliPlus/models/common/dynamic/up_panel_position.dart';
 import 'package:PiliPlus/models/common/follow_order_type.dart';
@@ -717,6 +718,19 @@ abstract final class Pref {
     SettingBoxKey.dynamicsShowAllFollowedUp,
     defaultValue: false,
   );
+
+  /// 兼容旧版“显示所有已关注 UP 主”布尔设置，并迁移到可选择红点范围的模式。
+  static DynamicUpListMode get dynamicUpListMode {
+    final index = _setting.get(SettingBoxKey.dynamicUpListMode);
+    if (index is int &&
+        index >= 0 &&
+        index < DynamicUpListMode.values.length) {
+      return DynamicUpListMode.values[index];
+    }
+    return dynamicsShowAllFollowedUp
+        ? DynamicUpListMode.all
+        : DynamicUpListMode.frequent;
+  }
 
   static bool get enableShowDanmaku =>
       _setting.get(SettingBoxKey.enableShowDanmaku, defaultValue: true);

--- a/test/models/dynamics/up_test.dart
+++ b/test/models/dynamics/up_test.dart
@@ -1,60 +1,166 @@
+import 'package:PiliPlus/models/common/dynamic/dynamic_up_list_mode.dart';
 import 'package:PiliPlus/models/dynamics/up.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-/// 验证动态更新解析、分页收集和红点排序的核心业务规则。
+/// 验证动态更新解析、基线截断和红点排序的核心业务规则。
+///
+/// 夹具刻意沿用真实接口的字段形态，避免再次出现“测试通过但线上失效”：
+///   * `module_author.following` 实测为整数 `1`（不是布尔 `true`）
+///   * `update_num` 实测为字符串 `'0'`，且与基线深浅无关，不能用于截取条数
 void main() {
-  test('动态更新页保留条目位置并只解析已关注 UP', () {
+  /// 构造一条动态流记录，字段层级与 `/feed/all` 返回一致。
+  Map<String, dynamic> dynItem({
+    required String idStr,
+    required int mid,
+    Object? following = 1,
+    int pubTs = 100,
+    String type = 'DYNAMIC_TYPE_AV',
+    String name = 'UP',
+  }) => {
+    'id_str': idStr,
+    'type': type,
+    'modules': {
+      'module_author': {
+        'mid': mid,
+        'name': name,
+        'face': 'face-$mid',
+        'following': following,
+        'pub_ts': pubTs,
+      },
+    },
+  };
+
+  test('关注状态兼容整数 1 与布尔 true，两种形态都要识别', () {
+    // 真实接口下发整数 1；早期写成 following == true 会导致整条动态被过滤。
+    expect(UpItem.isFollowingAuthor(1), isTrue);
+    expect(UpItem.isFollowingAuthor(true), isTrue);
+    expect(UpItem.isFollowingAuthor(0), isFalse);
+    expect(UpItem.isFollowingAuthor(false), isFalse);
+    expect(UpItem.isFollowingAuthor(null), isFalse);
+  });
+
+  test('解析单页：保留动态 id，只收录关注中的作者', () {
     final page = DynamicUpUpdatePage.fromJson({
-      'update_baseline': '300',
-      'update_num': 3,
-      'offset': '100',
+      'update_baseline': '1247174239795019776',
+      'update_num': '0',
+      'offset': '1247140481416036368',
       'has_more': true,
       'items': [
-        {
-          'id_str': '300',
-          'modules': {
-            'module_author': {
-              'mid': 1,
-              'name': '已关注作者',
-              'face': 'face-1',
-              'following': true,
-              'pub_ts': 300,
-            },
-          },
-        },
-        {
-          'modules': {
-            'module_author': {
-              'mid': 2,
-              'name': '番剧等非关注作者',
-              'following': false,
-              'pub_ts': 200,
-            },
-          },
-        },
+        dynItem(idStr: '300', mid: 1, pubTs: 300),
+        // 番剧、直播推荐等非关注作者必须被排除，但位置仍要保留供基线比较。
+        dynItem(idStr: '200', mid: 2, following: 0, pubTs: 200),
+        // 缺少 id 的异常记录按 0 处理，视为早于任何基线。
         <String, dynamic>{},
       ],
     });
 
-    expect(page.updateBaseline, '300');
-    expect(page.updateNum, 3);
-    expect(page.offset, '100');
+    expect(page.updateBaseline, '1247174239795019776');
+    expect(page.offset, '1247140481416036368');
     expect(page.hasMore, isTrue);
     expect(page.itemCount, 3);
-    expect(page.items[0]?.mid, 1);
-    expect(page.items[0]?.latestUpdateAt, 300);
-    expect(page.items[1], isNull);
-    expect(page.items[2], isNull);
+    expect(page.entries[0].dynamicId, 300);
+    expect(page.entries[0].up?.mid, 1);
+    expect(page.entries[0].up?.latestUpdateAt, 300);
+    // 非关注作者：条目保留、作者为空
+    expect(page.entries[1].dynamicId, 200);
+    expect(page.entries[1].up, isNull);
+    expect(page.entries[2].dynamicId, 0);
+    expect(page.entries[2].up, isNull);
+    expect(page.lastId, 0);
   });
 
-  test('接口省略更新基线时回退到首条动态 ID', () {
+  test('服务端未下发基线时用本页最大 id 兜底，不被置顶动态拉低', () {
     final page = DynamicUpUpdatePage.fromJson({
       'items': [
-        {'id_str': 'fallback-baseline'},
+        // 置顶动态会以较早的 id 排在最前面
+        dynItem(idStr: '100', mid: 9, pubTs: 100),
+        dynItem(idStr: '900', mid: 8, pubTs: 900),
       ],
     });
 
-    expect(page.updateBaseline, 'fallback-baseline');
+    expect(page.updateBaseline, isNull);
+    expect(page.maxId, 900);
+    expect(page.lastId, 900);
+  });
+
+  test('只收集动态 id 严格大于基线的作者，基线为 0 时视为首次回补全收', () {
+    final page = DynamicUpUpdatePage.fromJson({
+      'items': [
+        dynItem(idStr: '500', mid: 1, pubTs: 500),
+        dynItem(idStr: '300', mid: 2, pubTs: 300),
+        dynItem(idStr: '100', mid: 3, pubTs: 100),
+      ],
+    });
+
+    // 基线 300：500 算新，300 与 100 都不算（边界取严格大于）
+    final incremental = <int, UpItem>{};
+    DynamicUpUpdateResult.collectPage(incremental, page, 300);
+    expect(incremental.keys, [1]);
+
+    // 基线 0：首次回补，全部已关注作者都计入
+    final backfill = <int, UpItem>{};
+    DynamicUpUpdateResult.collectPage(backfill, page, 0);
+    expect(backfill.keys, [1, 2, 3]);
+  });
+
+  test('同一 UP 多条新动态只保留发布时间最新的一条', () {
+    final page = DynamicUpUpdatePage.fromJson({
+      'items': [
+        dynItem(idStr: '500', mid: 1, pubTs: 500),
+        dynItem(idStr: '400', mid: 1, pubTs: 400),
+        dynItem(idStr: '300', mid: 1, pubTs: 300),
+      ],
+    });
+
+    final ups = <int, UpItem>{};
+    DynamicUpUpdateResult.collectPage(ups, page, 0);
+
+    expect(ups.length, 1);
+    expect(ups[1]?.latestUpdateAt, 500);
+  });
+
+  test('跨页收集：基线之上的作者全部收集，越过基线即停止', () {
+    final firstPage = DynamicUpUpdatePage.fromJson({
+      'items': [
+        dynItem(idStr: '900', mid: 1, pubTs: 900),
+        dynItem(idStr: '800', mid: 2, pubTs: 800),
+      ],
+    });
+    final secondPage = DynamicUpUpdatePage.fromJson({
+      'items': [
+        dynItem(idStr: '300', mid: 3, pubTs: 300),
+        dynItem(idStr: '200', mid: 4, pubTs: 200),
+      ],
+    });
+
+    final ups = <int, UpItem>{};
+    DynamicUpUpdateResult.collectPage(ups, firstPage, 100);
+    expect(DynamicUpUpdateResult.passedBaseline(firstPage, 100), isFalse);
+
+    DynamicUpUpdateResult.collectPage(ups, secondPage, 100);
+    // 300/200 仍大于基线 100，继续收集；末条 200 也未越过基线。
+    expect(ups.keys, [1, 2, 3, 4]);
+    expect(DynamicUpUpdateResult.passedBaseline(secondPage, 100), isFalse);
+
+    // 基线抬到 250 后，第二页只剩 300 算新，且末条 200 已越过基线。
+    final ups2 = <int, UpItem>{};
+    DynamicUpUpdateResult.collectPage(ups2, secondPage, 250);
+    expect(ups2.keys, [3]);
+    expect(DynamicUpUpdateResult.passedBaseline(secondPage, 250), isTrue);
+  });
+
+  test('红点展示范围：仅视频模式只认确知是视频的更新', () {
+    // 「所有动态」不筛类型；「常看」走官方红点，同样不筛。
+    expect(DynamicUpListMode.all.showsBadge(true), isTrue);
+    expect(DynamicUpListMode.all.showsBadge(false), isTrue);
+    expect(DynamicUpListMode.all.showsBadge(null), isTrue);
+    expect(DynamicUpListMode.frequent.showsBadge(null), isTrue);
+
+    // 「仅视频」只展示确知是视频的更新；官方带入的无类型红点（null）必须排除，
+    // 否则只发了图文的 UP 也会被标红。
+    expect(DynamicUpListMode.video.showsBadge(true), isTrue);
+    expect(DynamicUpListMode.video.showsBadge(false), isFalse);
+    expect(DynamicUpListMode.video.showsBadge(null), isFalse);
   });
 
   test('更新 UP 按发布时间置顶且未更新组保持原顺序', () {
@@ -69,43 +175,5 @@ void main() {
     DynamicUpUpdateResult.sortUnreadFirst(items);
 
     expect(items.map((item) => item.mid), [4, 2, 5, 1, 3]);
-  });
-
-  test('跨页仅收集更新数量内的作者并保留每位 UP 最新时间', () {
-    // 构造最小动态作者模块，保持测试数据与真实接口层级一致。
-    Map<String, dynamic> item(int mid, int pubTs) => {
-      'modules': {
-        'module_author': {
-          'mid': mid,
-          'name': 'UP$mid',
-          'following': true,
-          'pub_ts': pubTs,
-        },
-      },
-    };
-
-    final firstPage = DynamicUpUpdatePage.fromJson({
-      'items': [item(1, 300), item(1, 200)],
-    });
-    final secondPage = DynamicUpUpdatePage.fromJson({
-      'items': [item(2, 100), item(3, 50)],
-    });
-    final updatedUps = <int, UpItem>{};
-
-    int remaining = DynamicUpUpdateResult.collectPage(
-      updatedUps,
-      firstPage,
-      3,
-    );
-    remaining = DynamicUpUpdateResult.collectPage(
-      updatedUps,
-      secondPage,
-      remaining,
-    );
-
-    expect(remaining, -1);
-    expect(updatedUps.keys, [1, 2]);
-    expect(updatedUps[1]?.latestUpdateAt, 300);
-    expect(updatedUps.containsKey(3), isFalse);
   });
 }

--- a/test/models/dynamics/up_test.dart
+++ b/test/models/dynamics/up_test.dart
@@ -1,0 +1,111 @@
+import 'package:PiliPlus/models/dynamics/up.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// 验证动态更新解析、分页收集和红点排序的核心业务规则。
+void main() {
+  test('动态更新页保留条目位置并只解析已关注 UP', () {
+    final page = DynamicUpUpdatePage.fromJson({
+      'update_baseline': '300',
+      'update_num': 3,
+      'offset': '100',
+      'has_more': true,
+      'items': [
+        {
+          'id_str': '300',
+          'modules': {
+            'module_author': {
+              'mid': 1,
+              'name': '已关注作者',
+              'face': 'face-1',
+              'following': true,
+              'pub_ts': 300,
+            },
+          },
+        },
+        {
+          'modules': {
+            'module_author': {
+              'mid': 2,
+              'name': '番剧等非关注作者',
+              'following': false,
+              'pub_ts': 200,
+            },
+          },
+        },
+        <String, dynamic>{},
+      ],
+    });
+
+    expect(page.updateBaseline, '300');
+    expect(page.updateNum, 3);
+    expect(page.offset, '100');
+    expect(page.hasMore, isTrue);
+    expect(page.itemCount, 3);
+    expect(page.items[0]?.mid, 1);
+    expect(page.items[0]?.latestUpdateAt, 300);
+    expect(page.items[1], isNull);
+    expect(page.items[2], isNull);
+  });
+
+  test('接口省略更新基线时回退到首条动态 ID', () {
+    final page = DynamicUpUpdatePage.fromJson({
+      'items': [
+        {'id_str': 'fallback-baseline'},
+      ],
+    });
+
+    expect(page.updateBaseline, 'fallback-baseline');
+  });
+
+  test('更新 UP 按发布时间置顶且未更新组保持原顺序', () {
+    final items = [
+      UpItem(mid: 1, uname: '未更新一'),
+      UpItem(mid: 2, uname: '较早更新', hasUpdate: true, latestUpdateAt: 100),
+      UpItem(mid: 3, uname: '未更新二'),
+      UpItem(mid: 4, uname: '最新更新', hasUpdate: true, latestUpdateAt: 200),
+      UpItem(mid: 5, uname: '同时间更新', hasUpdate: true, latestUpdateAt: 100),
+    ];
+
+    DynamicUpUpdateResult.sortUnreadFirst(items);
+
+    expect(items.map((item) => item.mid), [4, 2, 5, 1, 3]);
+  });
+
+  test('跨页仅收集更新数量内的作者并保留每位 UP 最新时间', () {
+    // 构造最小动态作者模块，保持测试数据与真实接口层级一致。
+    Map<String, dynamic> item(int mid, int pubTs) => {
+      'modules': {
+        'module_author': {
+          'mid': mid,
+          'name': 'UP$mid',
+          'following': true,
+          'pub_ts': pubTs,
+        },
+      },
+    };
+
+    final firstPage = DynamicUpUpdatePage.fromJson({
+      'items': [item(1, 300), item(1, 200)],
+    });
+    final secondPage = DynamicUpUpdatePage.fromJson({
+      'items': [item(2, 100), item(3, 50)],
+    });
+    final updatedUps = <int, UpItem>{};
+
+    int remaining = DynamicUpUpdateResult.collectPage(
+      updatedUps,
+      firstPage,
+      3,
+    );
+    remaining = DynamicUpUpdateResult.collectPage(
+      updatedUps,
+      secondPage,
+      remaining,
+    );
+
+    expect(remaining, -1);
+    expect(updatedUps.keys, [1, 2]);
+    expect(updatedUps[1]?.latestUpdateAt, 300);
+    expect(updatedUps.containsKey(3), isFalse);
+  });
+}

--- a/test/utils/storage/settings_sync_test.dart
+++ b/test/utils/storage/settings_sync_test.dart
@@ -1,0 +1,52 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:PiliPlus/models/common/dynamic/dynamic_up_list_mode.dart';
+import 'package:PiliPlus/utils/settings_sync.dart';
+import 'package:PiliPlus/utils/storage_key.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+
+/// 验证新模式沿用现有设置导出/导入链路，而设备阅读状态不会混入同步数据。
+void main() {
+  late Directory tempDir;
+  late Box<dynamic> settingBox;
+  late Box<dynamic> videoBox;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp(
+      'piliplus-dynamic-setting-test-',
+    );
+    Hive.init(tempDir.path);
+    settingBox = await Hive.openBox<dynamic>('setting');
+    videoBox = await Hive.openBox<dynamic>('video');
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    await tempDir.delete(recursive: true);
+  });
+
+  test('动态 UP 模式随 WebDAV 设置载荷同步', () async {
+    await settingBox.put(
+      SettingBoxKey.dynamicUpListMode,
+      DynamicUpListMode.video.index,
+    );
+
+    final payload = SettingsSync.export(settingBox, videoBox);
+    final json = jsonDecode(payload) as Map<String, dynamic>;
+    final setting = json['setting'] as Map<String, dynamic>;
+    expect(
+      setting[SettingBoxKey.dynamicUpListMode],
+      DynamicUpListMode.video.index,
+    );
+    expect(payload, isNot(contains(LocalCacheKey.dynamicUpUnread)));
+
+    await settingBox.clear();
+    await SettingsSync.import(payload, settingBox, videoBox);
+    expect(
+      settingBox.get(SettingBoxKey.dynamicUpListMode),
+      DynamicUpListMode.video.index,
+    );
+  });
+}


### PR DESCRIPTION
## 功能

- 外观设置中的「动态页 UP 主与更新红点」可选三种：**常看（官方红点）**、**全部关注（所有动态）**、**全部关注（仅视频，含动态小视频）**
- 官方 `portal` / `uplist` 返回的是同一批「常看」UP，不在其中的已关注 UP 永远不会被标红（实测某账号关注 244 人，官方只覆盖 50 人）。本 PR 改为客户端自行判定更新，只要关注了就会显示红点
- 「仅视频」只标记更新了视频投稿的 UP，是「所有动态」的子集
- 点开某个 UP 只清除它的红点，**不立即重排列表**，位置留到下次刷新时统一调整

## 过程中确认的两个接口事实

1. `module_author.following` 下发的是**整数 `1`**，不是布尔 `true`。按 `following == true` 判断会全部落空，导致每条动态都被当成番剧、直播推荐等非关注作者过滤掉
2. `feed/all` 的 `update_num` 一旦带上 `update_baseline` 就**恒为字符串 `'0'`**，与基线深浅无关，无法用来截取新增条数

所以新增判定改为客户端完成：动态 id 是单调递增的雪花号，`id > 本地基线` 即「新动态」，基线取接口返回的 `update_baseline`。

另外实测同一时间窗内，综合流里 `DYNAMIC_TYPE_AV` 的集合与 `type=video` 流返回的集合完全一致，因此一次 `type=all` 请求即可同时支撑两种模式，不需要为「仅视频」再发一次请求。

## 其它实现说明

- 首次启用回补 2 页并继承官方已有红点，避免刚开启时红点比官方还少
- 模式设置沿用现有 `setting` Box，可随 WebDAV 备份/恢复；更新的基线与未读状态按账号缓存在本地
- 翻页与截断规则抽到 `DynamicUpUpdateResult.scan`，取页函数可注入，便于用抓包数据离线回归

## 测试

- `flutter test test/models/dynamics/up_test.dart test/utils/storage/settings_sync_test.dart`（全部通过）
- `flutter analyze` 相关实现与测试文件（No issues found）
- 用真实账号抓包的响应驱动 `scan` 做离线回归：首次回补 2 页得到 32 个更新作者（官方仅 14 个），增量扫描结果与手工计算逐条一致
