### PR TITLE
fix(mine): 侧边栏模式下保留「我的」页设置入口

### DIFF
--- a/lib/pages/mine/view.dart
+++ b/lib/pages/mine/view.dart
@@ -26,6 +26,11 @@ import 'package:get/get.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
 import 'package:material_ui/material_ui.dart' hide ListTile;
 
+bool shouldShowMineHeaderGlobalActions({
+  required bool hasHome,
+  required bool useBottomNav,
+}) => !hasHome && useBottomNav;
+
 class MinePage extends StatefulWidget {
   const MinePage({super.key, this.showBackBtn = false});
 
@@ -140,83 +145,103 @@ class _MediaPageState extends CommonPageState<MinePage>
     const padding = EdgeInsets.all(8);
     const style = ButtonStyle(tapTargetSize: .shrinkWrap);
     return Row(
-      spacing: 5,
-      mainAxisAlignment: .end,
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (widget.showBackBtn)
-          const Expanded(
-            child: Align(
-              alignment: Alignment.centerLeft,
-              child: Padding(
-                padding: EdgeInsets.only(left: 8),
-                child: BackButton(),
+          const Padding(
+            padding: EdgeInsets.only(left: 8),
+            child: BackButton(),
+          ),
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.only(right: 16),
+            child: LayoutBuilder(
+              builder: (context, constraints) => SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                reverse: true,
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(minWidth: constraints.maxWidth),
+                  child: Row(
+                    spacing: 5,
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      if (shouldShowMineHeaderGlobalActions(
+                        hasHome: _mainController.hasHome,
+                        useBottomNav: _mainController.useBottomNav,
+                      )) ...[
+                        IconButton(
+                          iconSize: iconSize,
+                          padding: padding,
+                          style: style,
+                          tooltip: '搜索',
+                          onPressed: () => Get.toNamed('/search'),
+                          icon: const Icon(Icons.search),
+                        ),
+                        msgBadge(_mainController),
+                      ],
+                      if (GStorage.reply != null)
+                        IconButton(
+                          iconSize: iconSize,
+                          padding: padding,
+                          style: style,
+                          tooltip: '评论记录',
+                          onPressed: () => Get.toNamed('/myReply'),
+                          icon: const Icon(Icons.message_outlined),
+                        ),
+                      Obx(
+                        () {
+                          final anonymity = MineController.anonymity.value;
+                          return IconButton(
+                            iconSize: iconSize,
+                            padding: padding,
+                            style: style,
+                            tooltip: "${anonymity ? '退出' : '进入'}无痕模式",
+                            onPressed: MineController.onChangeAnonymity,
+                            icon: anonymity
+                                ? const Icon(MdiIcons.incognito)
+                                : const Icon(MdiIcons.incognitoOff),
+                          );
+                        },
+                      ),
+                      IconButton(
+                        iconSize: iconSize,
+                        padding: padding,
+                        style: style,
+                        tooltip: '切换账号',
+                        onPressed: () =>
+                            LoginPageController.switchAccountDialog(context),
+                        icon: const Icon(Icons.switch_account_outlined),
+                      ),
+                      Obx(
+                        () {
+                          return IconButton(
+                            iconSize: iconSize,
+                            padding: padding,
+                            style: style,
+                            tooltip: '切换至${controller.nextThemeType.label}主题',
+                            onPressed: controller.onChangeTheme,
+                            icon: controller.themeType.value.icon,
+                          );
+                        },
+                      ),
+                      IconButton(
+                        iconSize: iconSize,
+                        padding: padding,
+                        style: style,
+                        tooltip: '设置',
+                        onPressed: () => Get.toNamed(
+                          '/setting',
+                          preventDuplicates: false,
+                        ),
+                        icon: const Icon(Icons.settings_outlined),
+                      ),
+                    ],
+                  ),
+                ),
               ),
             ),
           ),
-        if (!_mainController.hasHome) ...[
-          IconButton(
-            iconSize: iconSize,
-            padding: padding,
-            style: style,
-            tooltip: '搜索',
-            onPressed: () => Get.toNamed('/search'),
-            icon: const Icon(Icons.search),
-          ),
-          msgBadge(_mainController),
-        ],
-        if (GStorage.reply != null)
-          IconButton(
-            iconSize: iconSize,
-            padding: padding,
-            style: style,
-            tooltip: '评论记录',
-            onPressed: () => Get.toNamed('/myReply'),
-            icon: const Icon(Icons.message_outlined),
-          ),
-        Obx(
-          () {
-            final anonymity = MineController.anonymity.value;
-            return IconButton(
-              iconSize: iconSize,
-              padding: padding,
-              style: style,
-              tooltip: "${anonymity ? '退出' : '进入'}无痕模式",
-              onPressed: MineController.onChangeAnonymity,
-              icon: anonymity
-                  ? const Icon(MdiIcons.incognito)
-                  : const Icon(MdiIcons.incognitoOff),
-            );
-          },
         ),
-        IconButton(
-          iconSize: iconSize,
-          padding: padding,
-          style: style,
-          tooltip: '切换账号',
-          onPressed: () => LoginPageController.switchAccountDialog(context),
-          icon: const Icon(Icons.switch_account_outlined),
-        ),
-        Obx(
-          () {
-            return IconButton(
-              iconSize: iconSize,
-              padding: padding,
-              style: style,
-              tooltip: '切换至${controller.nextThemeType.label}主题',
-              onPressed: controller.onChangeTheme,
-              icon: controller.themeType.value.icon,
-            );
-          },
-        ),
-        IconButton(
-          iconSize: iconSize,
-          padding: padding,
-          style: style,
-          tooltip: '设置',
-          onPressed: () => Get.toNamed('/setting', preventDuplicates: false),
-          icon: const Icon(Icons.settings_outlined),
-        ),
-        const SizedBox(width: 16),
       ],
     );
   }

--- a/test/utils/mine_header_actions_test.dart
+++ b/test/utils/mine_header_actions_test.dart
@@ -1,0 +1,38 @@
+import 'package:PiliPlus/pages/mine/view.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('mine header global actions', () {
+    test('are hidden when the sidebar already provides them', () {
+      expect(
+        shouldShowMineHeaderGlobalActions(
+          hasHome: false,
+          useBottomNav: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('remain available when bottom navigation has no home page', () {
+      expect(
+        shouldShowMineHeaderGlobalActions(
+          hasHome: false,
+          useBottomNav: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('are hidden when home already provides them', () {
+      for (final useBottomNav in [false, true]) {
+        expect(
+          shouldShowMineHeaderGlobalActions(
+            hasHome: true,
+            useBottomNav: useBottomNav,
+          ),
+          isFalse,
+        );
+      }
+    });
+  });
+}


### PR DESCRIPTION
Fixes #2956

## 问题与复现

在「Navbar 编辑」中删除首页，开启「改用侧边栏」并重启后，进入「我的」。此时侧边栏已有搜索和消息入口，但「我的」页原本只根据 `!hasHome` 判断是否补这两个按钮，于是顶部重复出现搜索、消息。窄屏下顶部不可滚动的 `Row` 超出可用宽度，位于最右侧的「设置」被挤出屏幕；issue 中有复现截图。

## 这次如何修复

- 把补充搜索、消息的条件改为 `!hasHome && useBottomNav`：底栏没有首页时仍能从「我的」进入搜索和消息；侧边栏模式则使用侧边栏已有的入口。
- 将顶部按钮区域放入横向 `SingleChildScrollView`。`reverse: true` 让右侧的「设置」优先出现在初始可见区域，宽度不足时可向左滑动访问前面的按钮。`ConstrainedBox(minWidth: viewportWidth)` 保持按钮未溢出时原本的右对齐。
- 使用 Flutter 现有布局组件，没有引入第三方依赖或需要单独维护的新工具栏组件；原有按钮回调不变。

| 导航状态 | 「我的」顶部搜索 / 消息 |
| --- | --- |
| 侧边栏、无首页 | 隐藏（侧边栏已有） |
| 底栏、无首页 | 保留 |
| 有首页 | 隐藏（首页已有） |

## Review 范围

- `lib/pages/mine/view.dart`：仅调整顶部操作区布局与搜索 / 消息显示条件。按钮列表因嵌入滚动容器而产生较大的缩进 diff，动作本身没有删改。
- `test/utils/mine_header_actions_test.dart`：覆盖上述三类导航状态；没有包含 fork 的收藏夹首页、包名或应用名称改动。

## 验证

- `flutter test --no-pub`：全部 5 个测试通过。
- 对两个改动文件执行 `dart analyze`：无问题；全项目 `flutter analyze` 仍有 37 条位于未改动文件的既有 info 提示。
- `flutter build apk --debug --no-pub`：通过。
- 用户此前也在当时最新官方安装包按 issue 步骤复现；原修复曾在 Android 13、720 × 1600 设备上检查设置入口。此次基于上游最新 `main` 移植后的提交完成上述测试和构建。