### PR TITLE
feat: 缓存视频支持「仅下载音频」与「播放缓存音频自动进入音乐播放器」

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -28,7 +28,7 @@ android {
     }
 
     defaultConfig {
-        applicationId = "test.piliplus.com"
+        applicationId = "com.example.piliplus"
         minSdk = flutter.minSdkVersion
         targetSdk = 37
         versionCode = flutter.versionCode

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -28,7 +28,7 @@ android {
     }
 
     defaultConfig {
-        applicationId = "com.example.piliplus"
+        applicationId = "test.piliplus.com"
         minSdk = flutter.minSdkVersion
         targetSdk = 37
         versionCode = flutter.versionCode

--- a/lib/http/download.dart
+++ b/lib/http/download.dart
@@ -95,7 +95,9 @@ abstract final class DownloadHttp {
         List<Type2File>? audioFileList;
         final List<AudioItem>? audioDashList = dash.audio;
         if (audioDashList != null && audioDashList.isNotEmpty) {
-          final preferAudioQa = Pref.defaultAudioQa;
+          final preferAudioQa = entry.audioOnly && entry.audioQuality != null
+              ? entry.audioQuality!
+              : Pref.defaultAudioQa;
           final List<int> audioIds = audioDashList
               .map((map) => map.id)
               .toList();

--- a/lib/models_new/download/bili_download_entry_info.dart
+++ b/lib/models_new/download/bili_download_entry_info.dart
@@ -13,6 +13,7 @@ import 'package:material_ui/material_ui.dart';
 class BiliDownloadEntryInfo with MultiSelectData {
   int mediaType;
   bool hasDashAudio;
+  bool audioOnly;
   bool isCompleted;
   int totalBytes;
   int downloadedBytes;
@@ -144,6 +145,7 @@ class BiliDownloadEntryInfo with MultiSelectData {
   BiliDownloadEntryInfo({
     this.mediaType = 1,
     this.hasDashAudio = false,
+    this.audioOnly = false,
     required this.isCompleted,
     required this.totalBytes,
     required this.downloadedBytes,
@@ -175,6 +177,7 @@ class BiliDownloadEntryInfo with MultiSelectData {
       BiliDownloadEntryInfo(
         mediaType: json['media_type'] as int,
         hasDashAudio: json['has_dash_audio'] as bool,
+        audioOnly: json['audio_only'] as bool? ?? false,
         isCompleted: json['is_completed'] as bool,
         totalBytes: json['total_bytes'] as int,
         downloadedBytes: json['downloaded_bytes'] as int,
@@ -212,6 +215,7 @@ class BiliDownloadEntryInfo with MultiSelectData {
   Map<String, dynamic> toJson() => <String, dynamic>{
     'media_type': mediaType,
     'has_dash_audio': hasDashAudio,
+    'audio_only': audioOnly,
     'is_completed': isCompleted,
     'total_bytes': totalBytes,
     'downloaded_bytes': downloadedBytes,

--- a/lib/models_new/download/bili_download_entry_info.dart
+++ b/lib/models_new/download/bili_download_entry_info.dart
@@ -14,6 +14,7 @@ class BiliDownloadEntryInfo with MultiSelectData {
   int mediaType;
   bool hasDashAudio;
   bool audioOnly;
+  int? audioQuality;
   bool isCompleted;
   int totalBytes;
   int downloadedBytes;
@@ -146,6 +147,7 @@ class BiliDownloadEntryInfo with MultiSelectData {
     this.mediaType = 1,
     this.hasDashAudio = false,
     this.audioOnly = false,
+    this.audioQuality,
     required this.isCompleted,
     required this.totalBytes,
     required this.downloadedBytes,
@@ -178,6 +180,7 @@ class BiliDownloadEntryInfo with MultiSelectData {
         mediaType: json['media_type'] as int,
         hasDashAudio: json['has_dash_audio'] as bool,
         audioOnly: json['audio_only'] as bool? ?? false,
+        audioQuality: json['audio_quality'] as int?,
         isCompleted: json['is_completed'] as bool,
         totalBytes: json['total_bytes'] as int,
         downloadedBytes: json['downloaded_bytes'] as int,
@@ -216,6 +219,7 @@ class BiliDownloadEntryInfo with MultiSelectData {
     'media_type': mediaType,
     'has_dash_audio': hasDashAudio,
     'audio_only': audioOnly,
+    'audio_quality': ?audioQuality,
     'is_completed': isCompleted,
     'total_bytes': totalBytes,
     'downloaded_bytes': downloadedBytes,

--- a/lib/pages/audio/controller.dart
+++ b/lib/pages/audio/controller.dart
@@ -881,8 +881,22 @@ class AudioController extends GetxController
   void onChangeOrder(ListOrder value) {
     if (order != value) {
       order = value;
-      _queryPlayList(isInit: true);
+      if (isLocal && _localEntries != null) {
+        _reverseLocalPlaylist();
+      } else {
+        _queryPlayList(isInit: true);
+      }
     }
+  }
+
+  /// 本地模式下正序/倒序切换：直接反转本地播放列表及其对应的条目/文件。
+  void _reverseLocalPlaylist() {
+    final curIndex = index ?? 0;
+    final curCid = _localEntries![curIndex].cid;
+    _localEntries = _localEntries!.reversed.toList();
+    _localFileUrls = _localFileUrls!.reversed.toList();
+    playlist = playlist!.reversed.toList();
+    index = _localEntries!.indexWhere((e) => e.cid == curCid);
   }
 
   @override

--- a/lib/pages/audio/controller.dart
+++ b/lib/pages/audio/controller.dart
@@ -21,6 +21,8 @@ import 'package:PiliPlus/http/browser_ua.dart';
 import 'package:PiliPlus/http/constants.dart';
 import 'package:PiliPlus/http/loading_state.dart';
 import 'package:PiliPlus/models/common/audio_normalization.dart';
+import 'package:PiliPlus/models_new/download/bili_download_entry_info.dart'
+    show BiliDownloadEntryInfo;
 import 'package:PiliPlus/models/video/play/url.dart' as http_model show Volume;
 import 'package:PiliPlus/pages/common/common_intro_controller.dart'
     show FavMixin;
@@ -34,6 +36,8 @@ import 'package:PiliPlus/pages/video/introduction/ugc/widgets/triple_mixin.dart'
 import 'package:PiliPlus/plugin/pl_player/controller.dart';
 import 'package:PiliPlus/plugin/pl_player/models/play_repeat.dart';
 import 'package:PiliPlus/plugin/pl_player/models/play_status.dart';
+import 'package:PiliPlus/services/download/download_service.dart'
+    show DownloadService;
 import 'package:PiliPlus/services/service_locator.dart';
 import 'package:PiliPlus/services/shutdown_timer_service.dart';
 import 'package:PiliPlus/utils/accounts.dart';
@@ -44,6 +48,7 @@ import 'package:PiliPlus/utils/extension/num_ext.dart';
 import 'package:PiliPlus/utils/global_data.dart';
 import 'package:PiliPlus/utils/id_utils.dart';
 import 'package:PiliPlus/utils/page_utils.dart';
+import 'package:PiliPlus/utils/path_utils.dart';
 import 'package:PiliPlus/utils/platform_utils.dart';
 import 'package:PiliPlus/utils/share_utils.dart';
 import 'package:PiliPlus/utils/storage.dart';
@@ -56,6 +61,7 @@ import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:get/get.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:media_kit/media_kit.dart';
+import 'package:path/path.dart' as path;
 
 class AudioController extends GetxController
     with
@@ -78,6 +84,10 @@ class AudioController extends GetxController
 
   /// 本地缓存音频播放模式（离线缓存进入，不联网）。
   bool isLocal = false;
+
+  /// 本地播放列表对应的下载条目与本地音频 URL（与 [playlist] 一一对应）。
+  List<BiliDownloadEntryInfo>? _localEntries;
+  List<String>? _localFileUrls;
 
   bool _hasInit = false;
   @override
@@ -164,7 +174,7 @@ class AudioController extends GetxController
     final String? audioUrl = args['audioUrl'];
     final hasAudioUrl = audioUrl != null;
     if (isLocal) {
-      _initLocalItem(args);
+      _initLocalPlaylist(args);
       _onOpenMedia(audioUrl!, volume: _videoDetailController?.volume);
     } else {
       _queryPlayList(isInit: true);
@@ -226,6 +236,73 @@ class AudioController extends GetxController
       item,
       (subId.firstOrNull ?? oid).toInt(),
       hashCode.toString(),
+    );
+  }
+
+  /// 本地缓存模式：把所有已完成的「仅音频」缓存项组成播放列表，
+  /// 使播放列表、切换上一首/下一首可用；若无其它仅音频缓存则退化为单曲。
+  void _initLocalPlaylist(Map args) {
+    List<BiliDownloadEntryInfo> entries;
+    try {
+      entries = Get
+              .find<DownloadService>()
+              .downloadList
+              .where((e) => e.audioOnly && e.isCompleted)
+              .toList();
+    } catch (_) {
+      entries = [];
+    }
+    if (entries.isEmpty) {
+      _initLocalItem(args);
+      return;
+    }
+    playlist = <DetailItem>[];
+    _localEntries = <BiliDownloadEntryInfo>[];
+    _localFileUrls = <String>[];
+    for (final e in entries) {
+      _localEntries!.add(e);
+      _localFileUrls!.add(
+        Uri.file(
+          path.join(e.entryDirPath, e.typeTag!, PathUtils.audioNameType2),
+        ).toString(),
+      );
+      playlist!.add(_buildLocalItem(e));
+    }
+    final Object? localCid = args['localCid'];
+    int start = 0;
+    if (localCid is int) {
+      final i = entries.indexWhere((e) => e.cid == localCid);
+      if (i != -1) {
+        start = i;
+      }
+    }
+    index = start;
+    final Object? localOid = args['localOid'];
+    if (localOid is int) {
+      oid = Int64(localOid);
+    }
+    subId = [Int64(entries[start].cid)];
+    _updateCurrItem(playlist![start]);
+    // 本地播放列表无远程分页
+    _prev = null;
+    _next = null;
+  }
+
+  DetailItem _buildLocalItem(BiliDownloadEntryInfo e) {
+    final oid = Int64(e.avid);
+    return DetailItem(
+      arc: BKArchive(
+        oid: oid,
+        title: e.showTitle,
+        cover: e.cover,
+        duration: e.totalTimeMilli > 0 ? Int64(e.totalTimeMilli) : null,
+        displayedOid: oid.toString(),
+      ),
+      owner: Author(
+        name: e.ownerName,
+        mid: e.ownerId != null ? Int64(e.ownerId!) : null,
+      ),
+      stat: BKStat(),
     );
   }
 
@@ -741,6 +818,14 @@ class AudioController extends GetxController
     if (index == this.index && subId == null) return;
     this.index = index;
     final audioItem = playlist![index];
+    if (isLocal && _localFileUrls != null) {
+      final entry = _localEntries![index];
+      oid = Int64(entry.avid);
+      this.subId = [Int64(entry.cid)];
+      _updateCurrItem(audioItem);
+      _onOpenMedia(_localFileUrls![index]);
+      return;
+    }
     final item = audioItem.item;
     oid = item.oid;
     this.subId =

--- a/lib/pages/audio/controller.dart
+++ b/lib/pages/audio/controller.dart
@@ -240,15 +240,29 @@ class AudioController extends GetxController
   }
 
   /// 本地缓存模式：把所有已完成的「仅音频」缓存项组成播放列表，
+  /// 排序与缓存列表一致：按 pageId 分组（保持下载顺序），组内按 sortKey 升序。
   /// 使播放列表、切换上一首/下一首可用；若无其它仅音频缓存则退化为单曲。
   void _initLocalPlaylist(Map args) {
     List<BiliDownloadEntryInfo> entries;
     try {
-      entries = Get
-              .find<DownloadService>()
-              .downloadList
-              .where((e) => e.audioOnly && e.isCompleted)
-              .toList();
+      final downloadService = Get.find<DownloadService>();
+      final pageOrder = <String>[];
+      final pageMap = <String, List<BiliDownloadEntryInfo>>{};
+      for (final e in downloadService.downloadList) {
+        if (!e.audioOnly || !e.isCompleted) continue;
+        final pid = e.pageId;
+        final bucket = pageMap.putIfAbsent(pid, () {
+          pageOrder.add(pid);
+          return <BiliDownloadEntryInfo>[];
+        });
+        bucket.add(e);
+      }
+      entries = <BiliDownloadEntryInfo>[];
+      for (final pid in pageOrder) {
+        final bucket = List.of(pageMap[pid]!);
+        bucket.sort((a, b) => a.sortKey.compareTo(b.sortKey));
+        entries.addAll(bucket);
+      }
     } catch (_) {
       entries = [];
     }

--- a/lib/pages/audio/controller.dart
+++ b/lib/pages/audio/controller.dart
@@ -13,7 +13,10 @@ import 'package:PiliPlus/grpc/bilibili/app/listener/v1.pb.dart'
         ThumbUpReq_ThumbType,
         ListOrder,
         DashItem,
-        ResponseUrl;
+        ResponseUrl,
+        BKArchive,
+        Author,
+        BKStat;
 import 'package:PiliPlus/http/browser_ua.dart';
 import 'package:PiliPlus/http/constants.dart';
 import 'package:PiliPlus/http/loading_state.dart';
@@ -72,6 +75,9 @@ class AudioController extends GetxController
   late final bool isUgc = itemType == 1;
 
   final audioItem = Rxn<DetailItem>();
+
+  /// 本地缓存音频播放模式（离线缓存进入，不联网）。
+  bool isLocal = false;
 
   bool _hasInit = false;
   @override
@@ -154,25 +160,30 @@ class AudioController extends GetxController
       } catch (_) {}
     }
 
-    _queryPlayList(isInit: true);
-
+    isLocal = args['isLocal'] == true;
     final String? audioUrl = args['audioUrl'];
     final hasAudioUrl = audioUrl != null;
-    if (hasAudioUrl) {
-      _querySponsorBlock();
-      _onOpenMedia(
-        audioUrl,
-        ua: BrowserUa.pc,
-        referer: HttpString.baseUrl,
-        volume: _videoDetailController?.volume,
-      );
-    }
-    ConnectivityUtils.isWiFi.then((isWiFi) {
-      cacheAudioQa = isWiFi ? Pref.defaultAudioQa : Pref.defaultAudioQaCellular;
-      if (!hasAudioUrl) {
-        _queryPlayUrl();
+    if (isLocal) {
+      _initLocalItem(args);
+      _onOpenMedia(audioUrl!, volume: _videoDetailController?.volume);
+    } else {
+      _queryPlayList(isInit: true);
+      if (hasAudioUrl) {
+        _querySponsorBlock();
+        _onOpenMedia(
+          audioUrl,
+          ua: BrowserUa.pc,
+          referer: HttpString.baseUrl,
+          volume: _videoDetailController?.volume,
+        );
       }
-    });
+      ConnectivityUtils.isWiFi.then((isWiFi) {
+        cacheAudioQa = isWiFi ? Pref.defaultAudioQa : Pref.defaultAudioQaCellular;
+        if (!hasAudioUrl) {
+          _queryPlayUrl();
+        }
+      });
+    }
     videoPlayerServiceHandler
       ?..onPlay = onPlay
       ..onPause = onPause
@@ -215,6 +226,29 @@ class AudioController extends GetxController
       item,
       (subId.firstOrNull ?? oid).toInt(),
       hashCode.toString(),
+    );
+  }
+
+  /// 本地缓存模式：根据 arguments 构造最小 DetailItem 并填充界面，不联网。
+  void _initLocalItem(Map args) {
+    final Object? localOid = args['localOid'];
+    if (localOid is int) {
+      oid = Int64(localOid);
+    }
+    final Object? localDuration = args['localDuration'];
+    audioItem.value = DetailItem(
+      arc: BKArchive(
+        oid: oid,
+        title: (args['localTitle'] as String? ?? ''),
+        cover: (args['localCover'] as String? ?? ''),
+        duration: localDuration is int ? Int64(localDuration) : null,
+        displayedOid: oid.toString(),
+      ),
+      owner: Author(
+        name: args['localOwnerName'] as String?,
+        mid: localOid is int ? oid : null,
+      ),
+      stat: BKStat(),
     );
   }
 

--- a/lib/pages/audio/controller.dart
+++ b/lib/pages/audio/controller.dart
@@ -263,6 +263,22 @@ class AudioController extends GetxController
         bucket.sort((a, b) => a.sortKey.compareTo(b.sortKey));
         entries.addAll(bucket);
       }
+      // 从缓存视频点击耳机进入时，当前视频是完整缓存（非「仅音频」），
+      // 不在上方列表中；把它也加入播放列表首位，保证标题/封面与播放的音频一致。
+      final Object? localCid = args['localCid'];
+      if (localCid is int &&
+          entries.indexWhere((e) => e.cid == localCid) == -1) {
+        BiliDownloadEntryInfo? cur;
+        for (final e in downloadService.downloadList) {
+          if (e.isCompleted && e.cid == localCid) {
+            cur = e;
+            break;
+          }
+        }
+        if (cur != null) {
+          entries.insert(0, cur);
+        }
+      }
     } catch (_) {
       entries = [];
     }

--- a/lib/pages/audio/view.dart
+++ b/lib/pages/audio/view.dart
@@ -126,18 +126,20 @@ class _AudioPageState extends State<AudioPage> {
               }
               return const SizedBox.shrink();
             }),
-          if (!_controller.isLocal)
-            Builder(
-              builder: (context) {
-                return PopupMenuButton<ListOrder>(
-                  tooltip: '排序',
-                  icon: const Icon(Icons.sort, size: 22),
+          Builder(
+            builder: (context) {
+              final orders = _controller.isLocal
+                  ? const [ListOrder.ORDER_NORMAL, ListOrder.ORDER_REVERSE]
+                  : ListOrder.values;
+              return PopupMenuButton<ListOrder>(
+                tooltip: '排序',
+                icon: const Icon(Icons.sort, size: 22),
                 initialValue: _controller.order,
                 onSelected: (value) {
                   _controller.onChangeOrder(value);
                   (context as Element).markNeedsBuild();
                 },
-                itemBuilder: (context) => ListOrder.values
+                itemBuilder: (context) => orders
                     .map((e) => PopupMenuItem(value: e, child: Text(e.title)))
                     .toList(),
               );

--- a/lib/pages/audio/view.dart
+++ b/lib/pages/audio/view.dart
@@ -1,3 +1,4 @@
+import 'dart:io' show File;
 import 'dart:math' show min;
 
 import 'package:PiliPlus/common/assets.dart';
@@ -60,6 +61,13 @@ class AudioPage extends StatefulWidget {
     Duration? start,
     String? audioUrl,
     int? extraId,
+    bool isLocal = false,
+    String? localTitle,
+    String? localCover,
+    int? localOid,
+    int? localCid,
+    int? localDuration,
+    String? localOwnerName,
   }) => Get.toNamed(
     '/audio',
     arguments: {
@@ -72,6 +80,13 @@ class AudioPage extends StatefulWidget {
       'start': ?start,
       'audioUrl': ?audioUrl,
       'extraId': ?extraId,
+      'isLocal': isLocal,
+      'localTitle': ?localTitle,
+      'localCover': ?localCover,
+      'localOid': ?localOid,
+      'localCid': ?localCid,
+      'localDuration': ?localDuration,
+      'localOwnerName': ?localOwnerName,
     },
   );
 }
@@ -111,11 +126,12 @@ class _AudioPageState extends State<AudioPage> {
               }
               return const SizedBox.shrink();
             }),
-          Builder(
-            builder: (context) {
-              return PopupMenuButton<ListOrder>(
-                tooltip: '排序',
-                icon: const Icon(Icons.sort, size: 22),
+          if (!_controller.isLocal)
+            Builder(
+              builder: (context) {
+                return PopupMenuButton<ListOrder>(
+                  tooltip: '排序',
+                  icon: const Icon(Icons.sort, size: 22),
                 initialValue: _controller.order,
                 onSelected: (value) {
                   _controller.onChangeOrder(value);
@@ -138,7 +154,7 @@ class _AudioPageState extends State<AudioPage> {
               ),
             icon: const Icon(Icons.schedule, size: 22),
           ),
-          if (_controller.isUgc)
+          if (_controller.isUgc && !_controller.isLocal)
             IconButton(
               tooltip: '更多',
               onPressed: _showMore,
@@ -177,7 +193,7 @@ class _AudioPageState extends State<AudioPage> {
                       children: [
                         Obx(() {
                           final audioItem = _controller.audioItem.value;
-                          if (audioItem != null) {
+                          if (audioItem != null && !_controller.isLocal) {
                             return _buildActions(audioItem);
                           }
                           return const SizedBox.shrink();
@@ -907,7 +923,31 @@ class _AudioPageState extends State<AudioPage> {
     return Obx(() {
       final audioItem = _controller.audioItem.value;
       if (audioItem != null) {
+        final isLocal = _controller.isLocal;
         final cover = audioItem.arc.cover.http2https;
+        final coverWidget = isLocal && cover.startsWith('http')
+            ? NetworkImgLayer(
+                src: cover,
+                width: 170,
+                height: 170,
+                cacheWidth: false,
+              )
+            : isLocal
+            ? Image.file(
+                File(cover),
+                width: 170,
+                height: 170,
+                fit: BoxFit.cover,
+              )
+            : fromHero(
+                tag: cover,
+                child: NetworkImgLayer(
+                  src: cover,
+                  width: 170,
+                  height: 170,
+                  cacheWidth: false,
+                ),
+              );
         return Column(
           children: [
             Expanded(
@@ -923,15 +963,7 @@ class _AudioPageState extends State<AudioPage> {
                         onTap: () => PageUtils.imageView(
                           imgList: [SourceModel(url: cover)],
                         ),
-                        child: fromHero(
-                          tag: cover,
-                          child: NetworkImgLayer(
-                            src: cover,
-                            width: 170,
-                            height: 170,
-                            cacheWidth: false,
-                          ),
-                        ),
+                        child: coverWidget,
                       ),
                     ),
                     const SizedBox(height: 12),
@@ -940,7 +972,33 @@ class _AudioPageState extends State<AudioPage> {
                       style: const TextStyle(height: 1.7, fontSize: 16),
                     ),
                     const SizedBox(height: 12),
-                    if (audioItem.owner.hasName()) ...[
+                    if (isLocal) ...[
+                      if (audioItem.owner.hasName())
+                        Text(
+                          audioItem.owner.name,
+                          style: TextStyle(
+                            fontSize: 13,
+                            color: colorScheme.outline,
+                          ),
+                        ),
+                      if (audioItem.arc.hasDuration())
+                        Row(
+                          children: [
+                            Icon(
+                              size: 14,
+                              Icons.headphones_outlined,
+                              color: colorScheme.outline,
+                            ),
+                            Text(
+                              ' ${DurationUtils.formatDuration(audioItem.arc.duration.toInt() ~/ 1000)}',
+                              style: TextStyle(
+                                fontSize: 13,
+                                color: colorScheme.outline,
+                              ),
+                            ),
+                          ],
+                        ),
+                    ] else if (audioItem.owner.hasName()) ...[
                       GestureDetector(
                         behavior: HitTestBehavior.opaque,
                         onTap: () {
@@ -966,39 +1024,42 @@ class _AudioPageState extends State<AudioPage> {
                       ),
                       const SizedBox(height: 10),
                     ],
-                    Row(
-                      children: [
-                        Icon(
-                          size: 14,
-                          Icons.headphones_outlined,
-                          color: colorScheme.outline,
-                        ),
-                        Text.rich(
-                          TextSpan(
-                            children: [
-                              TextSpan(
-                                text:
-                                    ' ${NumUtils.numFormat(audioItem.stat.view)}   '
-                                    '${DateFormatUtils.dateFormat(audioItem.arc.publish.toInt(), long: DateFormatUtils.longFormatD)}   ',
-                              ),
-                              TextSpan(
-                                text: audioItem.arc.displayedOid,
-                                style: TextStyle(color: colorScheme.secondary),
-                                recognizer: NoDeadlineTapGestureRecognizer()
-                                  ..onTap = () => Utils.copyText(
-                                    audioItem.arc.displayedOid,
-                                  ),
-                              ),
-                            ],
-                          ),
-                          style: TextStyle(
-                            fontSize: 13,
+                    if (!isLocal)
+                      Row(
+                        children: [
+                          Icon(
+                            size: 14,
+                            Icons.headphones_outlined,
                             color: colorScheme.outline,
                           ),
-                        ),
-                      ],
-                    ),
-                    if (audioItem.arc.hasDesc()) ...[
+                          Text.rich(
+                            TextSpan(
+                              children: [
+                                TextSpan(
+                                  text:
+                                      ' ${NumUtils.numFormat(audioItem.stat.view)}   '
+                                      '${DateFormatUtils.dateFormat(audioItem.arc.publish.toInt(), long: DateFormatUtils.longFormatD)}   ',
+                                ),
+                                TextSpan(
+                                  text: audioItem.arc.displayedOid,
+                                  style: TextStyle(
+                                    color: colorScheme.secondary,
+                                  ),
+                                  recognizer: NoDeadlineTapGestureRecognizer()
+                                    ..onTap = () => Utils.copyText(
+                                      audioItem.arc.displayedOid,
+                                    ),
+                                ),
+                              ],
+                            ),
+                            style: TextStyle(
+                              fontSize: 13,
+                              color: colorScheme.outline,
+                            ),
+                          ),
+                        ],
+                      ),
+                    if (!isLocal && audioItem.arc.hasDesc()) ...[
                       const SizedBox(height: 10),
                       SelectionText(audioItem.arc.desc),
                     ],
@@ -1006,7 +1067,7 @@ class _AudioPageState extends State<AudioPage> {
                 ),
               ),
             ),
-            if (isPortrait) ...[
+            if (isPortrait && !isLocal) ...[
               const SizedBox(height: 10),
               _buildActions(audioItem),
             ],

--- a/lib/pages/download/detail/widgets/item.dart
+++ b/lib/pages/download/detail/widgets/item.dart
@@ -10,6 +10,7 @@ import 'package:PiliPlus/common/widgets/select_mask.dart';
 import 'package:PiliPlus/grpc/bilibili/app/listener/v1.pb.dart'
     show PlaylistSource;
 import 'package:PiliPlus/models/common/badge_type.dart';
+import 'package:PiliPlus/models/common/video/audio_quality.dart';
 import 'package:PiliPlus/models/common/video/source_type.dart';
 import 'package:PiliPlus/models/common/video/video_quality.dart';
 import 'package:PiliPlus/models_new/download/bili_download_entry_info.dart';
@@ -60,6 +61,17 @@ class DetailItem extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final outline = theme.colorScheme.outline;
+    String audioQualityLabel(int? code) {
+      if (code != null) {
+        for (final e in AudioQuality.values) {
+          if (e.code == code) {
+            return e.desc;
+          }
+        }
+      }
+      return '音频';
+    }
+
     final cid = entry.source?.cid ?? entry.pageData?.cid;
     final canDel = onDelete != null;
     final enableMultiSelect = controller.enableMultiSelect.value;
@@ -230,7 +242,14 @@ class DetailItem extends StatelessWidget {
                       },
                     ),
                   ),
-                  if (entry.videoQuality case final videoQuality?)
+                  if (entry.audioOnly)
+                    PBadge(
+                      text: audioQualityLabel(entry.audioQuality),
+                      right: 6.0,
+                      top: 6.0,
+                      type: PBadgeType.gray,
+                    )
+                  else if (entry.videoQuality case final videoQuality?)
                     PBadge(
                       text: VideoQuality.fromCode(videoQuality).shortDesc,
                       right: 6.0,

--- a/lib/pages/download/detail/widgets/item.dart
+++ b/lib/pages/download/detail/widgets/item.dart
@@ -7,10 +7,13 @@ import 'package:PiliPlus/common/widgets/dialog/simple_dialog_option.dart';
 import 'package:PiliPlus/common/widgets/image/network_img_layer.dart';
 import 'package:PiliPlus/common/widgets/progress_bar/video_progress_indicator.dart';
 import 'package:PiliPlus/common/widgets/select_mask.dart';
+import 'package:PiliPlus/grpc/bilibili/app/listener/v1.pb.dart'
+    show PlaylistSource;
 import 'package:PiliPlus/models/common/badge_type.dart';
 import 'package:PiliPlus/models/common/video/source_type.dart';
 import 'package:PiliPlus/models/common/video/video_quality.dart';
 import 'package:PiliPlus/models_new/download/bili_download_entry_info.dart';
+import 'package:PiliPlus/pages/audio/view.dart';
 import 'package:PiliPlus/pages/common/multi_select/base.dart';
 import 'package:PiliPlus/pages/download/downloading/view.dart';
 import 'package:PiliPlus/services/download/download_service.dart';
@@ -21,6 +24,7 @@ import 'package:PiliPlus/utils/page_utils.dart';
 import 'package:PiliPlus/utils/path_utils.dart';
 import 'package:PiliPlus/utils/platform_utils.dart';
 import 'package:PiliPlus/utils/storage.dart';
+import 'package:PiliPlus/utils/storage_key.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:get/get.dart';
 import 'package:material_ui/material_ui.dart';
@@ -110,25 +114,52 @@ class DetailItem extends StatelessWidget {
             return;
           }
           if (entry.isCompleted) {
-            await PageUtils.toVideoPage(
-              aid: entry.avid,
-              cid: cid!,
-              cover: entry.cover,
-              title: entry.showTitle,
-              isVertical: entry.pageData?.isVertical ?? false,
-              extraArguments: {
-                'sourceType': SourceType.file,
-                'entry': entry,
-                'dirPath': entry.entryDirPath,
-              },
-            );
-            if (context.mounted) {
-              Future.delayed(const Duration(milliseconds: 400), () {
-                if (context.mounted) {
-                  // ignore: invalid_use_of_protected_member, invalid_use_of_visible_for_testing_member
-                  progress?.notifyListeners();
-                }
-              });
+            final inAudioPlayer = entry.audioOnly &&
+                GStorage.setting.get(
+                  SettingBoxKey.cacheAudioEnterAudioPlayer,
+                  defaultValue: false,
+                );
+            if (inAudioPlayer) {
+              final audioFile = path.join(
+                entry.entryDirPath,
+                entry.typeTag!,
+                PathUtils.audioNameType2,
+              );
+              AudioPage.toAudioPage(
+                isLocal: true,
+                itemType: 1,
+                oid: entry.avid,
+                subId: [cid!],
+                from: PlaylistSource.UP_ARCHIVE,
+                audioUrl: Uri.file(audioFile).toString(),
+                localTitle: entry.showTitle,
+                localCover: entry.cover,
+                localOid: entry.avid,
+                localCid: cid!,
+                localDuration: entry.totalTimeMilli,
+                localOwnerName: entry.ownerName,
+              );
+            } else {
+              await PageUtils.toVideoPage(
+                aid: entry.avid,
+                cid: cid!,
+                cover: entry.cover,
+                title: entry.showTitle,
+                isVertical: entry.pageData?.isVertical ?? false,
+                extraArguments: {
+                  'sourceType': SourceType.file,
+                  'entry': entry,
+                  'dirPath': entry.entryDirPath,
+                },
+              );
+              if (context.mounted) {
+                Future.delayed(const Duration(milliseconds: 400), () {
+                  if (context.mounted) {
+                    // ignore: invalid_use_of_protected_member, invalid_use_of_visible_for_testing_member
+                    progress?.notifyListeners();
+                  }
+                });
+              }
             }
           } else {
             final curDownload = downloadService.curDownload.value;

--- a/lib/pages/setting/models/play_settings.dart
+++ b/lib/pages/setting/models/play_settings.dart
@@ -296,6 +296,13 @@ List<SettingsModel> get playSettings => [
     setKey: SettingBoxKey.tempPlayerConf,
     defaultVal: false,
   ),
+  const SwitchModel(
+    title: '缓存音频点击进入音乐播放器',
+    subtitle: '离线缓存的音频文件点击后直接进入音乐播放器播放',
+    leading: Icon(Icons.headphones_outlined),
+    setKey: SettingBoxKey.cacheAudioEnterAudioPlayer,
+    defaultVal: false,
+  ),
 ];
 
 Future<void> _showSubtitleDialog(

--- a/lib/pages/video/controller.dart
+++ b/lib/pages/video/controller.dart
@@ -60,7 +60,9 @@ import 'package:PiliPlus/utils/extension/nested_scroll_ext.dart';
 import 'package:PiliPlus/utils/extension/num_ext.dart';
 import 'package:PiliPlus/utils/extension/size_ext.dart';
 import 'package:PiliPlus/utils/page_utils.dart';
+import 'package:PiliPlus/utils/path_utils.dart';
 import 'package:PiliPlus/utils/platform_utils.dart';
+import 'package:path/path.dart' as path;
 import 'package:PiliPlus/utils/storage.dart';
 import 'package:PiliPlus/utils/storage_pref.dart';
 import 'package:PiliPlus/utils/theme_utils.dart';
@@ -729,6 +731,7 @@ class VideoDetailController extends GetxController
               typeTag: entry.typeTag!,
               isMp4: entry.mediaType == 1,
               hasDashAudio: entry.hasDashAudio,
+              audioOnly: entry.audioOnly,
             )
           : NetworkSource(
               videoSource: videoUrl!,
@@ -1402,6 +1405,28 @@ class VideoDetailController extends GetxController
     int? id;
     int? extraId;
     PlaylistSource from = PlaylistSource.UP_ARCHIVE;
+    if (isFileSource) {
+      final audioFile = path.join(
+        entry.entryDirPath,
+        entry.typeTag!,
+        PathUtils.audioNameType2,
+      );
+      AudioPage.toAudioPage(
+        isLocal: true,
+        itemType: 1,
+        oid: aid,
+        subId: [cid.value],
+        from: from,
+        audioUrl: Uri.file(audioFile).toString(),
+        localTitle: entry.showTitle,
+        localCover: entry.cover,
+        localOid: aid,
+        localCid: cid.value,
+        localDuration: entry.totalTimeMilli,
+        localOwnerName: entry.ownerName,
+      );
+      return;
+    }
     if (isPlayAll) {
       id = args['mediaId'];
       extraId = sourceType.extraId;

--- a/lib/pages/video/download_panel/view.dart
+++ b/lib/pages/video/download_panel/view.dart
@@ -67,6 +67,7 @@ class _DownloadPanelState extends State<DownloadPanel> {
 
   late final cidSet = widget.cidSet;
   VideoQuality _quality = VideoQuality.fromCode(Pref.defaultVideoQa);
+  bool _audioOnly = false;
 
   @override
   void initState() {
@@ -146,6 +147,30 @@ class _DownloadPanelState extends State<DownloadPanel> {
                     ),
                   ],
                 ),
+              ),
+            ),
+          ),
+          TextButton.icon(
+            style: TextButton.styleFrom(
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              minimumSize: Size.zero,
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+            onPressed: () => setState(() => _audioOnly = !_audioOnly),
+            icon: Icon(
+              _audioOnly ? Icons.check_box : Icons.check_box_outline_blank,
+              size: 16,
+              color: _audioOnly
+                  ? theme.colorScheme.primary
+                  : theme.colorScheme.onSurfaceVariant,
+            ),
+            label: Text(
+              '仅下载音频',
+              style: TextStyle(
+                fontSize: 13,
+                color: _audioOnly
+                    ? theme.colorScheme.primary
+                    : theme.colorScheme.onSurfaceVariant,
               ),
             ),
           ),
@@ -292,6 +317,7 @@ class _DownloadPanelState extends State<DownloadPanel> {
             parent == null ? widget.videoDetail : null,
             parent,
             _quality,
+            audioOnly: _audioOnly,
           );
           break;
         case ugc.EpisodeItem episode:
@@ -300,6 +326,7 @@ class _DownloadPanelState extends State<DownloadPanel> {
             null,
             episode,
             _quality,
+            audioOnly: _audioOnly,
           );
           break;
         case pgc.EpisodeItem episode:
@@ -308,6 +335,7 @@ class _DownloadPanelState extends State<DownloadPanel> {
             widget.pgcItem!,
             episode,
             _quality,
+            audioOnly: _audioOnly,
           );
           break;
       }

--- a/lib/pages/video/download_panel/view.dart
+++ b/lib/pages/video/download_panel/view.dart
@@ -6,6 +6,7 @@ import 'package:PiliPlus/common/widgets/image/network_img_layer.dart';
 import 'package:PiliPlus/common/widgets/stat/stat.dart';
 import 'package:PiliPlus/models/common/badge_type.dart';
 import 'package:PiliPlus/models/common/stat_type.dart';
+import 'package:PiliPlus/models/common/video/audio_quality.dart';
 import 'package:PiliPlus/models/common/video/video_quality.dart';
 import 'package:PiliPlus/models_new/pgc/pgc_info_model/episode.dart' as pgc;
 import 'package:PiliPlus/models_new/pgc/pgc_info_model/result.dart';
@@ -68,6 +69,10 @@ class _DownloadPanelState extends State<DownloadPanel> {
   late final cidSet = widget.cidSet;
   VideoQuality _quality = VideoQuality.fromCode(Pref.defaultVideoQa);
   bool _audioOnly = false;
+  AudioQuality _audioQuality = AudioQuality.values.firstWhere(
+    (e) => e.code == Pref.defaultAudioQa,
+    orElse: () => AudioQuality.k132,
+  );
 
   @override
   void initState() {
@@ -112,31 +117,18 @@ class _DownloadPanelState extends State<DownloadPanel> {
         spacing: 16,
         children: [
           Text(
-            '最高画质',
+            _audioOnly ? '音质' : '最高画质',
             style: textStyle,
           ),
           Builder(
-            builder: (context) => PopupMenuButton<VideoQuality>(
-              initialValue: _quality,
-              onSelected: (value) {
-                _quality = value;
-                (context as Element).markNeedsBuild();
-              },
-              itemBuilder: (context) => VideoQuality.values
-                  .map(
-                    (e) => PopupMenuItem(
-                      value: e,
-                      child: Text(e.desc),
-                    ),
-                  )
-                  .toList(),
-              child: Padding(
+            builder: (context) {
+              final Widget child = Padding(
                 padding: const EdgeInsets.symmetric(vertical: 3),
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     Text(
-                      _quality.desc,
+                      _audioOnly ? _audioQuality.desc : _quality.desc,
                       style: const TextStyle(height: 1),
                       strutStyle: const StrutStyle(height: 1, leading: 0),
                     ),
@@ -147,8 +139,42 @@ class _DownloadPanelState extends State<DownloadPanel> {
                     ),
                   ],
                 ),
-              ),
-            ),
+              );
+              if (_audioOnly) {
+                return PopupMenuButton<AudioQuality>(
+                  initialValue: _audioQuality,
+                  onSelected: (value) {
+                    _audioQuality = value;
+                    (context as Element).markNeedsBuild();
+                  },
+                  itemBuilder: (context) => AudioQuality.values
+                      .map(
+                        (e) => PopupMenuItem(
+                          value: e,
+                          child: Text(e.desc),
+                        ),
+                      )
+                      .toList(),
+                  child: child,
+                );
+              }
+              return PopupMenuButton<VideoQuality>(
+                initialValue: _quality,
+                onSelected: (value) {
+                  _quality = value;
+                  (context as Element).markNeedsBuild();
+                },
+                itemBuilder: (context) => VideoQuality.values
+                    .map(
+                      (e) => PopupMenuItem(
+                        value: e,
+                        child: Text(e.desc),
+                      ),
+                    )
+                    .toList(),
+                child: child,
+              );
+            },
           ),
           TextButton.icon(
             style: TextButton.styleFrom(
@@ -318,6 +344,7 @@ class _DownloadPanelState extends State<DownloadPanel> {
             parent,
             _quality,
             audioOnly: _audioOnly,
+            audioQuality: _audioQuality,
           );
           break;
         case ugc.EpisodeItem episode:
@@ -327,6 +354,7 @@ class _DownloadPanelState extends State<DownloadPanel> {
             episode,
             _quality,
             audioOnly: _audioOnly,
+            audioQuality: _audioQuality,
           );
           break;
         case pgc.EpisodeItem episode:
@@ -336,6 +364,7 @@ class _DownloadPanelState extends State<DownloadPanel> {
             episode,
             _quality,
             audioOnly: _audioOnly,
+            audioQuality: _audioQuality,
           );
           break;
       }

--- a/lib/pages/video/widgets/header_control.dart
+++ b/lib/pages/video/widgets/header_control.dart
@@ -1858,6 +1858,22 @@ class HeaderControlState extends State<HeaderControl>
                       : const SizedBox.shrink(),
                 ),
               ],
+              if (isFileSource && !isFSOrPip) ...[
+                SizedBox(
+                  width: btnWidth,
+                  height: btnHeight,
+                  child: IconButton(
+                    tooltip: '听音频',
+                    style: btnStyle,
+                    onPressed: videoDetailCtr.toAudioPage,
+                    icon: const Icon(
+                      Icons.headphones_outlined,
+                      size: 19,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+              ],
               if (!isPortrait || isFullScreen || PlatformUtils.isDesktop) ...[
                 SizedBox(
                   width: btnWidth,

--- a/lib/plugin/pl_player/models/data_source.dart
+++ b/lib/plugin/pl_player/models/data_source.dart
@@ -26,14 +26,17 @@ class FileSource extends DataSource {
     required this.dir,
     required this.isMp4,
     required bool hasDashAudio,
+    required bool audioOnly,
     required String typeTag,
   }) : super(
-         videoSource: path.join(
-           dir,
-           typeTag,
-           isMp4 ? PathUtils.videoNameType1 : PathUtils.videoNameType2,
-         ),
-         audioSource: isMp4 || !hasDashAudio
+         videoSource: audioOnly
+             ? path.join(dir, typeTag, PathUtils.audioNameType2)
+             : path.join(
+                 dir,
+                 typeTag,
+                 isMp4 ? PathUtils.videoNameType1 : PathUtils.videoNameType2,
+               ),
+         audioSource: audioOnly || isMp4 || !hasDashAudio
              ? null
              : path.join(dir, typeTag, PathUtils.audioNameType2),
        );

--- a/lib/services/download/download_service.dart
+++ b/lib/services/download/download_service.dart
@@ -112,8 +112,9 @@ class DownloadService extends GetxService {
     Part page,
     VideoDetailData? videoDetail,
     ugc.EpisodeItem? videoArc,
-    VideoQuality videoQuality,
-  ) {
+    VideoQuality videoQuality, {
+    bool audioOnly = false,
+  }) {
     final cid = page.cid!;
     if (downloadList.indexWhere((e) => e.cid == cid) != -1) {
       return;
@@ -139,6 +140,7 @@ class DownloadService extends GetxService {
     final entry = BiliDownloadEntryInfo(
       mediaType: 2,
       hasDashAudio: false,
+      audioOnly: audioOnly,
       isCompleted: false,
       totalBytes: 0,
       downloadedBytes: 0,
@@ -172,8 +174,9 @@ class DownloadService extends GetxService {
     int index,
     PgcInfoModel pgcItem,
     pgc.EpisodeItem episode,
-    VideoQuality quality,
-  ) {
+    VideoQuality quality, {
+    bool audioOnly = false,
+  }) {
     final cid = episode.cid!;
     if (downloadList.indexWhere((e) => e.cid == cid) != -1) {
       return;
@@ -207,6 +210,7 @@ class DownloadService extends GetxService {
     final entry = BiliDownloadEntryInfo(
       mediaType: 2,
       hasDashAudio: false,
+      audioOnly: audioOnly,
       isCompleted: false,
       totalBytes: 0,
       downloadedBytes: 0,
@@ -401,6 +405,11 @@ class DownloadService extends GetxService {
 
       switch (mediaFileInfo) {
         case Type1 mediaFileInfo:
+          // 单文件格式无法单独抽取音频，忽略仅音频选项
+          if (entry.audioOnly) {
+            entry.audioOnly = false;
+            await _updateBiliDownloadEntryJson(entry);
+          }
           final first = mediaFileInfo.segmentList.first;
           _downloadManager = DownloadManager(
             url: first.url,
@@ -410,20 +419,33 @@ class DownloadService extends GetxService {
           );
           break;
         case Type2 mediaFileInfo:
-          _downloadManager = DownloadManager(
-            url: mediaFileInfo.video.first.baseUrl,
-            path: path.join(videoDir.path, PathUtils.videoNameType2),
-            onReceiveProgress: _onReceive,
-            onDone: _onDone,
-          );
           final audio = mediaFileInfo.audio;
-          if (audio != null && audio.isNotEmpty) {
-            _audioDownloadManager = DownloadManager(
+          if (entry.audioOnly) {
+            if (audio == null || audio.isEmpty) {
+              throw StateError('没有可用的音频流');
+            }
+            // 仅下载音频：把音频流交给主下载管理器，复用进度/完成逻辑
+            _downloadManager = DownloadManager(
               url: audio.first.baseUrl,
               path: path.join(videoDir.path, PathUtils.audioNameType2),
-              onReceiveProgress: null,
-              onDone: _onAudioDone,
+              onReceiveProgress: _onReceive,
+              onDone: _onDone,
             );
+          } else {
+            _downloadManager = DownloadManager(
+              url: mediaFileInfo.video.first.baseUrl,
+              path: path.join(videoDir.path, PathUtils.videoNameType2),
+              onReceiveProgress: _onReceive,
+              onDone: _onDone,
+            );
+            if (audio != null && audio.isNotEmpty) {
+              _audioDownloadManager = DownloadManager(
+                url: audio.first.baseUrl,
+                path: path.join(videoDir.path, PathUtils.audioNameType2),
+                onReceiveProgress: null,
+                onDone: _onAudioDone,
+              );
+            }
           }
           late final first = mediaFileInfo.video.first;
           entry.pageData

--- a/lib/services/download/download_service.dart
+++ b/lib/services/download/download_service.dart
@@ -5,6 +5,7 @@ import 'dart:io' show Directory, File;
 import 'package:PiliPlus/grpc/dm.dart';
 import 'package:PiliPlus/http/download.dart';
 import 'package:PiliPlus/http/init.dart';
+import 'package:PiliPlus/models/common/video/audio_quality.dart';
 import 'package:PiliPlus/models/common/video/video_quality.dart';
 import 'package:PiliPlus/models_new/download/bili_download_entry_info.dart';
 import 'package:PiliPlus/models_new/download/bili_download_media_file_info.dart';
@@ -114,6 +115,7 @@ class DownloadService extends GetxService {
     ugc.EpisodeItem? videoArc,
     VideoQuality videoQuality, {
     bool audioOnly = false,
+    AudioQuality? audioQuality,
   }) {
     final cid = page.cid!;
     if (downloadList.indexWhere((e) => e.cid == cid) != -1) {
@@ -141,6 +143,7 @@ class DownloadService extends GetxService {
       mediaType: 2,
       hasDashAudio: false,
       audioOnly: audioOnly,
+      audioQuality: audioOnly ? audioQuality?.code : null,
       isCompleted: false,
       totalBytes: 0,
       downloadedBytes: 0,
@@ -176,6 +179,7 @@ class DownloadService extends GetxService {
     pgc.EpisodeItem episode,
     VideoQuality quality, {
     bool audioOnly = false,
+    AudioQuality? audioQuality,
   }) {
     final cid = episode.cid!;
     if (downloadList.indexWhere((e) => e.cid == cid) != -1) {
@@ -211,6 +215,7 @@ class DownloadService extends GetxService {
       mediaType: 2,
       hasDashAudio: false,
       audioOnly: audioOnly,
+      audioQuality: audioOnly ? audioQuality?.code : null,
       isCompleted: false,
       totalBytes: 0,
       downloadedBytes: 0,

--- a/lib/utils/storage_key.dart
+++ b/lib/utils/storage_key.dart
@@ -31,7 +31,8 @@ abstract final class SettingBoxKey {
       audioPlayMode = 'audioPlayMode',
       showBatteryLevel = 'showBatteryLevel',
       playerVolume = 'playerVolume',
-      maxVolume = 'maxVolume';
+      maxVolume = 'maxVolume',
+      cacheAudioEnterAudioPlayer = 'cacheAudioEnterAudioPlayer';
 
   static const String enableVerticalExpand = 'enableVerticalExpand',
       feedBackEnable = 'feedBackEnable',


### PR DESCRIPTION
## 功能

为离线缓存新增两个相关能力：

1. **仅下载音频**：缓存视频时勾选「仅下载音频」，只下载 DASH 音频流，不下载视频流。
2. **缓存音频进入音乐播放器**：缓存列表里点开「仅音频」的缓存项，自动进入音乐播放器界面播放；并新增设置开关「缓存音频点击进入音乐播放器」（默认关闭）。

## 改动文件（11 个，均为纯功能改动）

- 下载数据模型 & 下载服务：`audioOnly` 字段 + 仅下载音频逻辑（DASH 流跳过视频下载）
- 下载面板：新增「仅下载音频」勾选项
- 播放器 dataSource：仅音频缓存走音频源
- 视频播放控制栏：缓存视频同样支持「听音频 / 听视频」
- 音频播放器：本地缓存文件播放模式（离线、不联网）
- 缓存列表项 + 设置开关：点击仅音频缓存自动进入音乐播放器

## 说明

 仅 DASH 音频缓存支持该能力；MP4 缓存无独立音频流
