### PR TITLE
feat: upgrade media-kit

### DIFF
--- a/lib/pages/video/introduction/pgc/controller.dart
+++ b/lib/pages/video/introduction/pgc/controller.dart
@@ -369,8 +369,6 @@ class PgcIntroController extends CommonIntroController {
       if (nextIndex >= episodes.length) {
         if (playRepeat == PlayRepeat.listCycle) {
           nextIndex = 0;
-        } else if (playRepeat == PlayRepeat.autoPlayRelated) {
-          return false;
         } else {
           return false;
         }

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -17,8 +17,6 @@ import 'package:PiliPlus/models/user/danmaku_rule.dart';
 import 'package:PiliPlus/models/video/play/url.dart';
 import 'package:PiliPlus/models_new/video/video_shot/data.dart';
 import 'package:PiliPlus/pages/danmaku/danmaku_model.dart';
-import 'package:PiliPlus/pages/setting/models/play_settings.dart'
-    show kMaxVolume;
 import 'package:PiliPlus/pages/sponsor_block/block_mixin.dart';
 import 'package:PiliPlus/plugin/pl_player/models/data_source.dart';
 import 'package:PiliPlus/plugin/pl_player/models/data_status.dart';
@@ -727,7 +725,7 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
       'volume':
           (PlatformUtils.isMobile ? Pref.playerVolume : volume.value * 100)
               .toString(),
-      'volume-max': kMaxVolume.toString(),
+      'stream-lavf-o': 'reconnect=1,reconnect_max_retries=${Pref.retryCount}',
     };
     final autosync = Pref.autosync;
     if (autosync != '0') {

--- a/lib/plugin/pl_player/controller.dart
+++ b/lib/plugin/pl_player/controller.dart
@@ -871,6 +871,8 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
   final Set<ValueChanged<Duration>> _positionListeners = {};
   final Set<ValueChanged<PlayerStatus>> _statusListeners = {};
 
+  Timer? _wakeLockTimer;
+
   /// 播放事件监听
   void _startListeners(NativePlayer player) {
     assert(_subscriptions == null);
@@ -878,8 +880,11 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
     _subscriptions = [
       /// playing
       stream.playing.listen((bool playing) {
-        WakelockPlus.toggle(enable: playing);
         if (playing) {
+          _wakeLockTimer?.cancel();
+          _wakeLockTimer = null;
+          WakelockPlus.enable();
+
           if (_isAutoEnterPip) {
             if (_isCurrVideoPage) {
               enterPip(autoEnter: true);
@@ -889,6 +894,12 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
           }
           playerStatus.value = .playing;
         } else {
+          _wakeLockTimer?.cancel();
+          _wakeLockTimer = Timer(
+            const Duration(milliseconds: 500),
+            WakelockPlus.disable,
+          );
+
           _disableAutoEnterPip();
           playerStatus.value = .paused;
         }
@@ -1545,6 +1556,7 @@ class PlPlayerController with BlockConfigMixin, AudioNormalizationMixin {
       AndroidHelper$ToDart.onUserLeaveHint = null;
     }
     _timer?.cancel();
+    _wakeLockTimer?.cancel();
     // _position.close();
     // _playerEventSubs?.cancel();
     // _sliderPosition.close();

--- a/lib/plugin/pl_player/view/view.dart
+++ b/lib/plugin/pl_player/view/view.dart
@@ -1846,9 +1846,8 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
                             size: 20,
                             color: Colors.white,
                           ),
-                          onLongPress:
-                              (Platform.isAndroid || kDebugMode) && !isLive
-                              ? screenshotWebp
+                          onLongPress: !PlatformUtils.isDarwin && !isLive
+                              ? _screenshotWebp
                               : null,
                           onTap: plPlayerController.takeScreenshot,
                         ),
@@ -2044,7 +2043,7 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
     );
   }
 
-  Future<void> screenshotWebp() async {
+  Future<void> _screenshotWebp() async {
     final videoInfo = videoDetailController.data;
     final ids = videoInfo.dash!.video!.availableVideoQualities;
     final video = videoDetailController.findVideoByQa(ids.min);

--- a/lib/plugin/pl_player/widgets/mpv_convert_webp.dart
+++ b/lib/plugin/pl_player/widgets/mpv_convert_webp.dart
@@ -41,7 +41,6 @@ class MpvConvertWebp {
   Future<void> _init() async {
     final enableHA = Pref.enableHA;
     _ctx = await Initializer.create(
-      _mpv,
       _onEvent,
       options: {
         'idle': 'once',
@@ -51,8 +50,8 @@ class MpvConvertWebp {
         'of': 'webp',
         'ovc': 'libwebp_anim',
         'ofopts': 'loop=0',
-        'ovcopts': 'preset=${preset.flag}',
-        if (enableHA) 'vo': 'gpu',
+        'ovcopts': 'preset=${preset.flag},compression_level=6',
+        'vf': 'fps=12',
         if (enableHA) 'hwdec': '${Pref.hardwareDecoding},auto-copy', // transcode only support copy
       },
     );
@@ -61,12 +60,7 @@ class MpvConvertWebp {
       generated.mpv_event_id.MPV_EVENT_VIDEO_RECONFIG,
       0,
     );
-    NativePlayer.setHeader(
-      _mpv,
-      _ctx,
-      userAgent: BrowserUa.pc,
-      referer: HttpString.baseUrl,
-    );
+    _mpv.setHeader(_ctx, userAgent: BrowserUa.pc, referer: HttpString.baseUrl);
     if (progress != null) {
       _observeProperty('time-pos');
     }

--- a/lib/services/audio_handler.dart
+++ b/lib/services/audio_handler.dart
@@ -79,11 +79,7 @@ class VideoPlayerServiceHandler extends BaseAudioHandler with SeekHandler {
     if (!mediaItem.isClosed) mediaItem.add(newMediaItem);
   }
 
-  void setPlaybackState(
-    PlayerStatus status,
-    bool isBuffering,
-    bool isLive,
-  ) {
+  void setPlaybackState(PlayerStatus status, bool isBuffering, bool isLive) {
     if (!enableBackgroundPlay ||
         _item.isEmpty ||
         !PlPlayerController.instanceExists()) {
@@ -132,14 +128,12 @@ class VideoPlayerServiceHandler extends BaseAudioHandler with SeekHandler {
             ),
         ],
         playing: playing,
-        systemActions: const {
-          MediaAction.seek,
-        },
+        systemActions: const {MediaAction.seek},
       ),
     );
     if (Platform.isAndroid &&
         (AndroidHelper.isPipMode ||
-            PlPlayerController.instance?.isAutoEnterPip == true)) {
+            PlPlayerController.instance!.isAutoEnterPip)) {
       AndroidHelper.updatePipActions(
         PlatformDispatcher.instance.engineId!,
         isLive,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1169,29 +1169,29 @@ packages:
     dependency: "direct main"
     description:
       path: media_kit
-      ref: native
-      resolved-ref: "73771ec38176be2d984a3049c28177bce23b54a0"
+      ref: upstream
+      resolved-ref: b0187daeb076cbe29c3d332f0626cca5a34f1624
       url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
-    version: "1.1.11"
+    version: "1.2.6"
   media_kit_libs_android_video:
     dependency: "direct overridden"
     description:
       path: "libs/android/media_kit_libs_android_video"
-      ref: native
-      resolved-ref: "73771ec38176be2d984a3049c28177bce23b54a0"
+      ref: upstream
+      resolved-ref: b0187daeb076cbe29c3d332f0626cca5a34f1624
       url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
-    version: "1.3.7"
+    version: "1.3.8"
   media_kit_libs_ios_video:
     dependency: "direct overridden"
     description:
       path: "libs/ios/media_kit_libs_ios_video"
-      ref: native
-      resolved-ref: "73771ec38176be2d984a3049c28177bce23b54a0"
+      ref: upstream
+      resolved-ref: b0187daeb076cbe29c3d332f0626cca5a34f1624
       url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
-    version: "1.1.4"
+    version: "1.1.5"
   media_kit_libs_linux:
     dependency: transitive
     description:
@@ -1212,38 +1212,38 @@ packages:
     dependency: "direct main"
     description:
       path: "libs/universal/media_kit_libs_video"
-      ref: native
-      resolved-ref: "73771ec38176be2d984a3049c28177bce23b54a0"
+      ref: upstream
+      resolved-ref: b0187daeb076cbe29c3d332f0626cca5a34f1624
       url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
-    version: "1.0.5"
+    version: "1.0.8"
   media_kit_libs_windows_video:
     dependency: "direct overridden"
     description:
       path: "libs/windows/media_kit_libs_windows_video"
-      ref: native
-      resolved-ref: "73771ec38176be2d984a3049c28177bce23b54a0"
+      ref: upstream
+      resolved-ref: b0187daeb076cbe29c3d332f0626cca5a34f1624
       url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
-    version: "1.0.10"
+    version: "1.0.12"
   media_kit_native_event_loop:
     dependency: "direct overridden"
     description:
       path: media_kit_native_event_loop
-      ref: native
-      resolved-ref: "73771ec38176be2d984a3049c28177bce23b54a0"
+      ref: upstream
+      resolved-ref: b0187daeb076cbe29c3d332f0626cca5a34f1624
       url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
-    version: "1.0.9"
+    version: "1.1.0"
   media_kit_video:
     dependency: "direct main"
     description:
       path: media_kit_video
-      ref: native
-      resolved-ref: "73771ec38176be2d984a3049c28177bce23b54a0"
+      ref: upstream
+      resolved-ref: b0187daeb076cbe29c3d332f0626cca5a34f1624
       url: "https://github.com/My-Responsitories/media-kit.git"
     source: git
-    version: "1.2.5"
+    version: "2.0.1"
   menu_base:
     dependency: transitive
     description:
@@ -1534,7 +1534,7 @@ packages:
     source: hosted
     version: "5.1.0"
   screen_brightness_android:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: screen_brightness_android
       sha256: "2008ad8e9527cc968f7a4de1ec58b476d495b3c612a149dbd6550c4f046da147"
@@ -1542,7 +1542,7 @@ packages:
     source: hosted
     version: "2.1.6"
   screen_brightness_ios:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: screen_brightness_ios
       sha256: "352d355e8523a186ba1e494b74218e5ca96e51975a0630b8ed89fbb7ff609762"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1310,7 +1310,7 @@ packages:
     source: hosted
     version: "3.0.0"
   package_info_plus:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: package_info_plus
       sha256: "127e1751e37ffb2ff4658beeaca77bad0c27bf5f932bd3a501c2296926d4b481"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -148,6 +148,8 @@ dependencies:
   protobuf: ^6.0.0
   re_highlight: ^0.0.3
   saver_gallery: ^5.0.2
+  screen_brightness_android: ^2.1.6
+  screen_brightness_ios: ^2.1.4
   screen_brightness_platform_interface: ^2.1.0
   screen_retriever: ^0.2.0
   share_plus: ^13.1.0
@@ -190,37 +192,37 @@ dependency_overrides:
     git:
       url: https://github.com/My-Responsitories/media-kit.git
       path: media_kit
-      ref: native
+      ref: upstream
   media_kit_libs_android_video:
     git:
       url: https://github.com/My-Responsitories/media-kit.git
       path: libs/android/media_kit_libs_android_video
-      ref: native
+      ref: upstream
   media_kit_libs_ios_video:
     git:
       url: https://github.com/My-Responsitories/media-kit.git
       path: libs/ios/media_kit_libs_ios_video
-      ref: native
+      ref: upstream
   media_kit_libs_video:
     git:
       url: https://github.com/My-Responsitories/media-kit.git
       path: libs/universal/media_kit_libs_video
-      ref: native
+      ref: upstream
   media_kit_libs_windows_video:
     git:
       url: https://github.com/My-Responsitories/media-kit.git
       path: libs/windows/media_kit_libs_windows_video
-      ref: native
+      ref: upstream
   media_kit_native_event_loop:
     git:
       url: https://github.com/My-Responsitories/media-kit.git
       path: media_kit_native_event_loop
-      ref: native
+      ref: upstream
   media_kit_video:
     git:
       url: https://github.com/My-Responsitories/media-kit.git
       path: media_kit_video
-      ref: native
+      ref: upstream
   cached_network_image_ce:
     git:
       url: https://github.com/My-Responsitories/flutter_cached_network_image_ce.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -138,7 +138,6 @@ dependencies:
     git:
       url: https://github.com/bggRGjQaUbCoE/flutter_native_device_orientation.git
       ref: master
-  package_info_plus: ^10.1.0
   path: ^1.9.1
   path_provider: ^2.1.5
   permission_handler_android: ^14.0.0


### PR DESCRIPTION
close #2890
1. media-kit与上游同步, 并合入https://github.com/Predidit/media-kit/commit/9c94fabdb5a2e7cea5b06a8f55c90db9fef3e16c 更改, 允许Windows端截动图
2. `WakeLock`防抖
3. 尝试开启`lavf`的`reconnect`