### PR TITLE
fix: 音乐播放器支持耳机媒体键控制

### DIFF
--- a/lib/pages/audio/controller.dart
+++ b/lib/pages/audio/controller.dart
@@ -176,7 +176,9 @@ class AudioController extends GetxController
     videoPlayerServiceHandler
       ?..onPlay = onPlay
       ..onPause = onPause
-      ..onSeek = onSeek;
+      ..onSeek = onSeek
+      ..onSkipToNext = onHeadsetNext
+      ..onSkipToPrevious = onHeadsetPrevious;
 
     animController = AnimationController(
       vsync: this,
@@ -205,6 +207,11 @@ class AudioController extends GetxController
   Future<void>? onSeek(Duration duration) {
     return player?.seek(duration);
   }
+
+  /// 耳机/媒体会话「下一曲」「上一曲」回调，行为与界面按钮一致。
+  Future<void> onHeadsetNext() async => playNext();
+
+  Future<void> onHeadsetPrevious() async => playPrev();
 
   void _updateCurrItem(DetailItem item) {
     audioItem.value = item;
@@ -795,6 +802,8 @@ class AudioController extends GetxController
       ?..onPlay = null
       ..onPause = null
       ..onSeek = null
+      ..onSkipToNext = null
+      ..onSkipToPrevious = null
       ..onVideoDetailDispose(hashCode.toString());
     _subscriptions?.forEach((e) => e.cancel());
     _subscriptions?.clear();

--- a/lib/services/audio_handler.dart
+++ b/lib/services/audio_handler.dart
@@ -96,9 +96,7 @@ class VideoPlayerServiceHandler extends BaseAudioHandler with SeekHandler {
     bool isBuffering,
     bool isLive,
   ) {
-    if (!enableBackgroundPlay ||
-        _item.isEmpty ||
-        !PlPlayerController.instanceExists()) {
+    if (!enableBackgroundPlay || _item.isEmpty) {
       return;
     }
 
@@ -179,7 +177,6 @@ class VideoPlayerServiceHandler extends BaseAudioHandler with SeekHandler {
     //   debugPrint('当前调用栈为：');
     //   debugPrint(StackTrace.current);
     // }
-    if (!PlPlayerController.instanceExists()) return;
     if (data == null) return;
 
     Uri getUri(String? cover) => Uri.parse(ImageUtils.safeThumbnailUrl(cover));
@@ -258,7 +255,6 @@ class VideoPlayerServiceHandler extends BaseAudioHandler with SeekHandler {
         return;
     }
     // if (kDebugMode) debugPrint("exist: ${PlPlayerController.instanceExists()}");
-    if (!PlPlayerController.instanceExists()) return;
     _item.add(mediaItem);
     setMediaItem(mediaItem);
   }
@@ -308,9 +304,7 @@ class VideoPlayerServiceHandler extends BaseAudioHandler with SeekHandler {
   }
 
   void onPositionChange(Duration position) {
-    if (!enableBackgroundPlay ||
-        _item.isEmpty ||
-        !PlPlayerController.instanceExists()) {
+    if (!enableBackgroundPlay || _item.isEmpty) {
       return;
     }
 

--- a/lib/services/audio_handler.dart
+++ b/lib/services/audio_handler.dart
@@ -41,6 +41,8 @@ class VideoPlayerServiceHandler extends BaseAudioHandler with SeekHandler {
   Future<void>? Function()? onPlay;
   Future<void>? Function()? onPause;
   Future<void>? Function(Duration position)? onSeek;
+  Future<void>? Function()? onSkipToNext;
+  Future<void>? Function()? onSkipToPrevious;
 
   @override
   Future<void> play() {
@@ -54,6 +56,16 @@ class VideoPlayerServiceHandler extends BaseAudioHandler with SeekHandler {
   Future<void> pause() {
     return onPause?.call() ?? PlPlayerController.pauseIfExists();
     // player.pause();
+  }
+
+  @override
+  Future<void> skipToNext() {
+    return onSkipToNext?.call() ?? Future.syncValue(null);
+  }
+
+  @override
+  Future<void> skipToPrevious() {
+    return onSkipToPrevious?.call() ?? Future.syncValue(null);
   }
 
   @override


### PR DESCRIPTION
## 问题

在「音乐播放器」（仅音频播放界面）中，耳机/蓝牙媒体键无法控制播放：

- 切换上一首/下一首无效：`AudioHandler` 只实现了 `play()/pause()/seek()`，未实现 `skipToNext()/skipToPrevious()`，耳机切歌事件无人处理。
- 播放/暂停无效：切歌事件不依赖媒体会话状态，而播放/暂停由系统根据媒体会话的 `playbackState.playing` 判断该执行 play 还是 pause。音乐播放器使用独立的 `Player`，并不创建 `PlPlayerController` 实例，原 handler 中 `setPlaybackState` / `onPositionChange` / `onVideoDetailChange` 的 `PlPlayerController.instanceExists()` 守卫导致该场景下 `playbackState` 永不更新，系统始终认为是暂停，耳机播放/暂停始终无法切换。

## 改动

1. `lib/services/audio_handler.dart`
   - 新增 `onSkipToNext` / `onSkipToPrevious` 回调并实现 `skipToNext()` / `skipToPrevious()`。
   - 移除 `setPlaybackState` / `onPositionChange` / `onVideoDetailChange` 中多余的 `PlPlayerController.instanceExists()` 守卫（视频播放器场景下实例常存在，行为不受影响），使音乐播放器场景也能正常更新媒体会话状态。

2. `lib/pages/audio/controller.dart`
   - 在 `onInit` 将 `onSkipToNext` / `onSkipToPrevious` 路由到音乐播放器的 `playNext()` / `playPrev()`。
   - 在 `onClose` 一并清理，避免失效引用。

## 验证

- 有线 / 蓝牙耳机：播放/暂停、上一首/下一首均可正常控制
- 视频播放场景不受影响
